### PR TITLE
Rdm 3178 + RDM 3179 + bug fix to cancel on CYA page of create case event with S&R: Release new version

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,5 @@
 ## RELEASE NOTES
-### Version 1.2.17 - October 18 2018
+### Version 1.2.18 - October 18 2018
 **RDM-3178** + **RDM-3179** + bug fix to cancel on CYA page of create case event with S&R
 
 ### Version 1.2.16 - October 15 2018

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,7 @@
 ## RELEASE NOTES
+### Version 1.2.17 - October 18 2018
+**RDM-3178** + **RDM-3179** + bug fix to cancel on CYA page of create case event with S&R
+
 ### Version 1.2.16 - October 15 2018
 **RDM-3063** - Case Progression: Extract case progression with existing contract part 2
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "description": "Case UI Toolkit",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "1.2.17",
+  "version": "1.2.18",
   "description": "Case UI Toolkit",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.js",

--- a/src/shared/case-editor/case-edit-page.component.spec.ts
+++ b/src/shared/case-editor/case-edit-page.component.spec.ts
@@ -46,240 +46,338 @@ describe('CaseEditPageComponent', () => {
   let caseEditComponentStub: any;
   let cancelled: any;
 
-  beforeEach(async(() => {
-    firstPage.id = 'first page';
-    cancelled = createSpyObj('cancelled', ['emit'])
-    caseEditComponentStub = {
-      'form': FORM_GROUP,
-      'data': '',
-      'eventTrigger': {'case_fields': [], 'name': 'Test event trigger name', 'can_save_draft': false },
-      'hasPrevious': () => true,
-      'getPage': () => firstPage,
-      'first': () => true,
-      'next': () => true,
-      'previous': () => true,
-      'cancel': () => undefined,
-      'cancelled': cancelled,
-      'validate': (caseEventData: CaseEventData) => of(caseEventData),
-      'saveDraft': (caseEventData: CaseEventData) => of(someObservable),
-      'caseDetails': { 'case_id': '1234567812345678' },
-    };
-    snapshot = {
-      queryParamMap: createSpyObj('queryParamMap', ['get']),
-    };
-    route = {
-      params: of({id: 123}),
-      snapshot: snapshot
-    };
+  describe('Save and Resume enabled', () => {
+    beforeEach(async(() => {
+      firstPage.id = 'first page';
+      cancelled = createSpyObj('cancelled', ['emit'])
+      caseEditComponentStub = {
+        'form': FORM_GROUP,
+        'data': '',
+        'eventTrigger': {'case_fields': [], 'name': 'Test event trigger name', 'can_save_draft': true },
+        'hasPrevious': () => true,
+        'getPage': () => firstPage,
+        'first': () => true,
+        'next': () => true,
+        'previous': () => true,
+        'cancel': () => undefined,
+        'cancelled': cancelled,
+        'validate': (caseEventData: CaseEventData) => of(caseEventData),
+        'saveDraft': (caseEventData: CaseEventData) => of(someObservable),
+        'caseDetails': { 'case_id': '1234567812345678' },
+      };
+      snapshot = {
+        queryParamMap: createSpyObj('queryParamMap', ['get']),
+      };
+      route = {
+        params: of({id: 123}),
+        snapshot: snapshot
+      };
 
-    matDialogRef = createSpyObj<MatDialogRef<SaveOrDiscardDialogComponent>>('MatDialogRef', ['afterClosed', 'close']);
-    dialog = createSpyObj<MatDialog>('dialog', ['open']);
-    dialog.open.and.returnValue(matDialogRef);
+      matDialogRef = createSpyObj<MatDialogRef<SaveOrDiscardDialogComponent>>('MatDialogRef', ['afterClosed', 'close']);
+      dialog = createSpyObj<MatDialog>('dialog', ['open']);
+      dialog.open.and.returnValue(matDialogRef);
 
-    spyOn(caseEditComponentStub, 'first');
-    spyOn(caseEditComponentStub, 'next');
-    spyOn(caseEditComponentStub, 'previous');
-    TestBed.configureTestingModule({
-      declarations: [CaseEditPageComponent,
-        CaseReferencePipe],
-      schemas: [NO_ERRORS_SCHEMA],
-      providers: [
-        {provide: FormValueService, useValue: formValueService},
-        {provide: FormErrorService, useValue: formErrorService},
-        {provide: CaseEditComponent, useValue: caseEditComponentStub},
-        {provide: PageValidationService, useValue: pageValidationService},
-        {provide: ActivatedRoute, useValue: route},
-        {provide: MatDialog, useValue: dialog }
-      ]
-    }).compileComponents();
-  }));
+      spyOn(caseEditComponentStub, 'first');
+      spyOn(caseEditComponentStub, 'next');
+      spyOn(caseEditComponentStub, 'previous');
+      TestBed.configureTestingModule({
+        declarations: [CaseEditPageComponent,
+          CaseReferencePipe],
+        schemas: [NO_ERRORS_SCHEMA],
+        providers: [
+          {provide: FormValueService, useValue: formValueService},
+          {provide: FormErrorService, useValue: formErrorService},
+          {provide: CaseEditComponent, useValue: caseEditComponentStub},
+          {provide: PageValidationService, useValue: pageValidationService},
+          {provide: ActivatedRoute, useValue: route},
+          {provide: MatDialog, useValue: dialog }
+        ]
+      }).compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(CaseEditPageComponent);
-    comp = fixture.componentInstance;
-    readOnly.display_context = 'READONLY';
-    const FIELDS: CaseField[] = [readOnly];
-    wizardPage = new WizardPage();
-    wizardPage.case_fields = FIELDS;
-    wizardPage.label = 'Test Label';
-    wizardPage.getCol1Fields = () => FIELDS;
-    wizardPage.getCol2Fields = () => FIELDS;
-  });
-
-  it('should display a page with two columns when wizard page is multicolumn', () => {
-    wizardPage.isMultiColumn = () => true;
-    comp.currentPage = wizardPage;
-    fixture.detectChanges();
-
-    de = fixture.debugElement.query(By.css('#caseEditForm'));
-    expect(de).toBeNull();
-    de = fixture.debugElement.query(By.css('#caseEditForm1'));
-    expect(de.nativeElement.textContent).toBeDefined();
-    de = fixture.debugElement.query(By.css('#caseEditForm2'));
-    expect(de.nativeElement.textContent).toBeDefined();
-  });
-
-  it('should display a page label in the header', () => {
-    wizardPage.isMultiColumn = () => false;
-    comp.currentPage = wizardPage;
-    fixture.detectChanges();
-
-    de = fixture.debugElement.query(By.css('#page-header'));
-    expect(de).toBeNull(); // Header is removed
-  });
-
-  it('should display an event trigger in the header', () => {
-    wizardPage.isMultiColumn = () => false;
-    comp.currentPage = wizardPage;
-    fixture.detectChanges();
-
-    de = fixture.debugElement.query(By.css('#page-header'));
-    expect(de).toBeNull(); // Header is removed
-  });
-
-  it('should display a page with one column when wizard page is not multicolumn', () => {
-    wizardPage.isMultiColumn = () => false;
-    comp.currentPage = wizardPage;
-    fixture.detectChanges();
-
-    de = fixture.debugElement.query(By.css('#caseEditForm'));
-    expect(de.nativeElement.textContent).toBeDefined();
-    de = fixture.debugElement.query(By.css('#caseEditForm1'));
-    expect(de).toBeNull();
-    de = fixture.debugElement.query(By.css('#caseEditForm2'));
-    expect(de).toBeNull();
-  });
-
-  it('should init to the provided first page in event trigger', () => {
-    comp.ngOnInit();
-    expect(comp.currentPage).toEqual(firstPage);
-  });
-
-  it('should return true on hasPrevious check', () => {
-    let errorContext = {
-      'ignore_warning': true,
-      'trigger_text': 'Some error!'
-    };
-    comp.callbackErrorsNotify(errorContext);
-    expect(comp.ignoreWarning).toBeTruthy();
-    expect(comp.triggerText).toEqual('Some error!');
-  });
-
-  it('should emit RESUMED_FORM_DISCARD on create event if discard triggered with no value changed', () => {
-    wizardPage.isMultiColumn = () => false;
-    comp.currentPage = wizardPage;
-    comp.formValuesChanged = false;
-    snapshot.queryParamMap.get.and.callFake(key => {
-      switch (key) {
-        case CaseEditComponent.ORIGIN_QUERY_PARAM:
-          return 'viewDraft';
-      }
+    beforeEach(() => {
+      fixture = TestBed.createComponent(CaseEditPageComponent);
+      comp = fixture.componentInstance;
+      readOnly.display_context = 'READONLY';
+      const FIELDS: CaseField[] = [readOnly];
+      wizardPage = new WizardPage();
+      wizardPage.case_fields = FIELDS;
+      wizardPage.label = 'Test Label';
+      wizardPage.getCol1Fields = () => FIELDS;
+      wizardPage.getCol2Fields = () => FIELDS;
     });
-    fixture.detectChanges();
 
-    comp.cancel();
+    it('should display a page with two columns when wizard page is multicolumn', () => {
+      wizardPage.isMultiColumn = () => true;
+      comp.currentPage = wizardPage;
+      fixture.detectChanges();
 
-    expect(cancelled.emit).toHaveBeenCalledWith({status: CaseEditPageComponent.RESUMED_FORM_DISCARD});
-  });
-
-  it('should emit NEW_FORM_DISCARD on create case if discard triggered with no value changed', () => {
-    wizardPage.isMultiColumn = () => false;
-    comp.currentPage = wizardPage;
-    comp.formValuesChanged = false;
-    fixture.detectChanges();
-
-    comp.cancel();
-
-    expect(cancelled.emit).toHaveBeenCalledWith({status: CaseEditPageComponent.NEW_FORM_DISCARD});
-  });
-
-  it('should emit RESUMED_FORM_DISCARD on create event if discard triggered with value changed', () => {
-    wizardPage.isMultiColumn = () => false;
-    comp.currentPage = wizardPage;
-    comp.formValuesChanged = true;
-    snapshot.queryParamMap.get.and.callFake(key => {
-      switch (key) {
-        case CaseEditComponent.ORIGIN_QUERY_PARAM:
-          return 'viewDraft';
-      }
+      de = fixture.debugElement.query(By.css('#caseEditForm'));
+      expect(de).toBeNull();
+      de = fixture.debugElement.query(By.css('#caseEditForm1'));
+      expect(de.nativeElement.textContent).toBeDefined();
+      de = fixture.debugElement.query(By.css('#caseEditForm2'));
+      expect(de.nativeElement.textContent).toBeDefined();
     });
-    matDialogRef.afterClosed.and.returnValue(of('Discard'));
-    fixture.detectChanges();
 
-    comp.cancel();
+    it('should display a page label in the header', () => {
+      wizardPage.isMultiColumn = () => false;
+      comp.currentPage = wizardPage;
+      fixture.detectChanges();
 
-    expect(cancelled.emit).toHaveBeenCalledWith({status: CaseEditPageComponent.RESUMED_FORM_DISCARD});
-  });
-
-  it('should emit NEW_FORM_DISCARD on create case if discard triggered with no value changed', () => {
-    wizardPage.isMultiColumn = () => false;
-    comp.currentPage = wizardPage;
-    comp.formValuesChanged = true;
-    fixture.detectChanges();
-    matDialogRef.afterClosed.and.returnValue(of('Discard'));
-
-    comp.cancel();
-
-    expect(cancelled.emit).toHaveBeenCalledWith({status: CaseEditPageComponent.NEW_FORM_DISCARD});
-  });
-
-  it('should emit RESUMED_FORM_SAVE on create case if discard triggered with no value changed', () => {
-    wizardPage.isMultiColumn = () => false;
-    comp.currentPage = wizardPage;
-    comp.formValuesChanged = true;
-    snapshot.queryParamMap.get.and.callFake(key => {
-      switch (key) {
-        case CaseEditComponent.ORIGIN_QUERY_PARAM:
-          return 'viewDraft';
-      }
+      de = fixture.debugElement.query(By.css('#page-header'));
+      expect(de).toBeNull(); // Header is removed
     });
-    matDialogRef.afterClosed.and.returnValue(of('Save'));
-    fixture.detectChanges();
 
-    comp.cancel();
-    expect(cancelled.emit).toHaveBeenCalledWith({status: CaseEditPageComponent.RESUMED_FORM_SAVE, data: { data: {'field1': 'SOME_VALUE'}}});
+    it('should display an event trigger in the header', () => {
+      wizardPage.isMultiColumn = () => false;
+      comp.currentPage = wizardPage;
+      fixture.detectChanges();
+
+      de = fixture.debugElement.query(By.css('#page-header'));
+      expect(de).toBeNull(); // Header is removed
+    });
+
+    it('should display a page with one column when wizard page is not multicolumn', () => {
+      wizardPage.isMultiColumn = () => false;
+      comp.currentPage = wizardPage;
+      fixture.detectChanges();
+
+      de = fixture.debugElement.query(By.css('#caseEditForm'));
+      expect(de.nativeElement.textContent).toBeDefined();
+      de = fixture.debugElement.query(By.css('#caseEditForm1'));
+      expect(de).toBeNull();
+      de = fixture.debugElement.query(By.css('#caseEditForm2'));
+      expect(de).toBeNull();
+    });
+
+    it('should init to the provided first page in event trigger', () => {
+      comp.ngOnInit();
+      expect(comp.currentPage).toEqual(firstPage);
+    });
+
+    it('should return true on hasPrevious check', () => {
+      let errorContext = {
+        'ignore_warning': true,
+        'trigger_text': 'Some error!'
+      };
+      comp.callbackErrorsNotify(errorContext);
+      expect(comp.ignoreWarning).toBeTruthy();
+      expect(comp.triggerText).toEqual('Some error!');
+    });
+
+    it('should emit RESUMED_FORM_DISCARD on create event if discard triggered with no value changed', () => {
+      wizardPage.isMultiColumn = () => false;
+      comp.currentPage = wizardPage;
+      comp.formValuesChanged = false;
+      snapshot.queryParamMap.get.and.callFake(key => {
+        switch (key) {
+          case CaseEditComponent.ORIGIN_QUERY_PARAM:
+            return 'viewDraft';
+        }
+      });
+      fixture.detectChanges();
+
+      comp.cancel();
+
+      expect(cancelled.emit).toHaveBeenCalledWith({status: CaseEditPageComponent.RESUMED_FORM_DISCARD});
+    });
+
+    it('should emit NEW_FORM_DISCARD on create case if discard triggered with no value changed', () => {
+      wizardPage.isMultiColumn = () => false;
+      comp.currentPage = wizardPage;
+      comp.formValuesChanged = false;
+      fixture.detectChanges();
+
+      comp.cancel();
+
+      expect(cancelled.emit).toHaveBeenCalledWith({status: CaseEditPageComponent.NEW_FORM_DISCARD});
+    });
+
+    it('should emit RESUMED_FORM_DISCARD on create event if discard triggered with value changed', () => {
+      wizardPage.isMultiColumn = () => false;
+      comp.currentPage = wizardPage;
+      comp.formValuesChanged = true;
+      snapshot.queryParamMap.get.and.callFake(key => {
+        switch (key) {
+          case CaseEditComponent.ORIGIN_QUERY_PARAM:
+            return 'viewDraft';
+        }
+      });
+      matDialogRef.afterClosed.and.returnValue(of('Discard'));
+      fixture.detectChanges();
+
+      comp.cancel();
+
+      expect(cancelled.emit).toHaveBeenCalledWith({status: CaseEditPageComponent.RESUMED_FORM_DISCARD});
+    });
+
+    it('should emit NEW_FORM_DISCARD on create case if discard triggered with no value changed', () => {
+      wizardPage.isMultiColumn = () => false;
+      comp.currentPage = wizardPage;
+      comp.formValuesChanged = true;
+      fixture.detectChanges();
+      matDialogRef.afterClosed.and.returnValue(of('Discard'));
+
+      comp.cancel();
+
+      expect(cancelled.emit).toHaveBeenCalledWith({status: CaseEditPageComponent.NEW_FORM_DISCARD});
+    });
+
+    it('should emit RESUMED_FORM_SAVE on create case if discard triggered with no value changed', () => {
+      wizardPage.isMultiColumn = () => false;
+      comp.currentPage = wizardPage;
+      comp.formValuesChanged = true;
+      snapshot.queryParamMap.get.and.callFake(key => {
+        switch (key) {
+          case CaseEditComponent.ORIGIN_QUERY_PARAM:
+            return 'viewDraft';
+        }
+      });
+      matDialogRef.afterClosed.and.returnValue(of('Save'));
+      fixture.detectChanges();
+
+      comp.cancel();
+      expect(cancelled.emit)
+        .toHaveBeenCalledWith({status: CaseEditPageComponent.RESUMED_FORM_SAVE, data: { data: {'field1': 'SOME_VALUE'}}});
+    });
+
+    it('should emit RESUMED_FORM_SAVE on create case if discard triggered with no value changed', () => {
+      wizardPage.isMultiColumn = () => false;
+      comp.currentPage = wizardPage;
+      comp.formValuesChanged = true;
+      matDialogRef.afterClosed.and.returnValue(of('Save'));
+      fixture.detectChanges();
+
+      comp.cancel();
+      expect(cancelled.emit).toHaveBeenCalledWith({status: CaseEditPageComponent.NEW_FORM_SAVE, data: { data: {'field1': 'SOME_VALUE'}}});
+    });
+
+    it('should delegate first calls to caseEditComponent', () => {
+      wizardPage.isMultiColumn = () => false;
+      comp.currentPage = wizardPage;
+      fixture.detectChanges();
+      comp.first();
+      expect(caseEditComponentStub.first).toHaveBeenCalled();
+    });
+
+    it('should delegate next calls to caseEditComponent', () => {
+      wizardPage.isMultiColumn = () => false;
+      comp.currentPage = wizardPage;
+      fixture.detectChanges();
+      comp.next();
+      expect(caseEditComponentStub.next).toHaveBeenCalled();
+    });
+
+    it('should delegate prev calls to caseEditComponent', () => {
+      wizardPage.isMultiColumn = () => false;
+      comp.currentPage = wizardPage;
+      fixture.detectChanges();
+      comp.previous();
+      expect(caseEditComponentStub.previous).toHaveBeenCalled();
+    });
+
+    it('should allow empty values when field is OPTIONAL', () => {
+      wizardPage.case_fields.push(aCaseField('fieldX', 'fieldX', 'Text', 'OPTIONAL', null));
+      wizardPage.isMultiColumn = () => false;
+      comp.currentPage = wizardPage;
+      fixture.detectChanges();
+      expect(comp.currentPageIsNotValid()).toBeFalsy();
+    });
+
+    it('should return "Cancel and return" as cancel button text if save and resume enabled for event', () => {
+      wizardPage.isMultiColumn = () => true;
+      comp.currentPage = wizardPage;
+      fixture.detectChanges();
+
+      let cancelText = comp.getCancelText();
+
+      expect(cancelText).toEqual('Cancel and return');
+    });
   });
 
-  it('should emit RESUMED_FORM_SAVE on create case if discard triggered with no value changed', () => {
-    wizardPage.isMultiColumn = () => false;
-    comp.currentPage = wizardPage;
-    comp.formValuesChanged = true;
-    matDialogRef.afterClosed.and.returnValue(of('Save'));
-    fixture.detectChanges();
+  describe('Save and Resume disabled', () => {
+    beforeEach(async(() => {
+      firstPage.id = 'first page';
+      cancelled = createSpyObj('cancelled', ['emit'])
+      caseEditComponentStub = {
+        'form': FORM_GROUP,
+        'data': '',
+        'eventTrigger': {'case_fields': [], 'name': 'Test event trigger name', 'can_save_draft': false },
+        'hasPrevious': () => true,
+        'getPage': () => firstPage,
+        'first': () => true,
+        'next': () => true,
+        'previous': () => true,
+        'cancel': () => undefined,
+        'cancelled': cancelled,
+        'validate': (caseEventData: CaseEventData) => of(caseEventData),
+        'saveDraft': (caseEventData: CaseEventData) => of(someObservable),
+        'caseDetails': { 'case_id': '1234567812345678' },
+      };
+      snapshot = {
+        queryParamMap: createSpyObj('queryParamMap', ['get']),
+      };
+      route = {
+        params: of({id: 123}),
+        snapshot: snapshot
+      };
 
-    comp.cancel();
-    expect(cancelled.emit).toHaveBeenCalledWith({status: CaseEditPageComponent.NEW_FORM_SAVE, data: { data: {'field1': 'SOME_VALUE'}}});
+      matDialogRef = createSpyObj<MatDialogRef<SaveOrDiscardDialogComponent>>('MatDialogRef', ['afterClosed', 'close']);
+      dialog = createSpyObj<MatDialog>('dialog', ['open']);
+      dialog.open.and.returnValue(matDialogRef);
+
+      spyOn(caseEditComponentStub, 'first');
+      spyOn(caseEditComponentStub, 'next');
+      spyOn(caseEditComponentStub, 'previous');
+      TestBed.configureTestingModule({
+        declarations: [CaseEditPageComponent,
+          CaseReferencePipe],
+        schemas: [NO_ERRORS_SCHEMA],
+        providers: [
+          {provide: FormValueService, useValue: formValueService},
+          {provide: FormErrorService, useValue: formErrorService},
+          {provide: CaseEditComponent, useValue: caseEditComponentStub},
+          {provide: PageValidationService, useValue: pageValidationService},
+          {provide: ActivatedRoute, useValue: route},
+          {provide: MatDialog, useValue: dialog }
+        ]
+      }).compileComponents();
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(CaseEditPageComponent);
+      comp = fixture.componentInstance;
+      readOnly.display_context = 'READONLY';
+      const FIELDS: CaseField[] = [readOnly];
+      wizardPage = new WizardPage();
+      wizardPage.case_fields = FIELDS;
+      wizardPage.label = 'Test Label';
+      wizardPage.getCol1Fields = () => FIELDS;
+      wizardPage.getCol2Fields = () => FIELDS;
+      wizardPage.isMultiColumn = () => true;
+      comp.currentPage = wizardPage;
+    });
+
+    it('should return "Cancel" as cancel button text if save and resume not enabled for event', () => {
+      fixture.detectChanges();
+
+      let cancelText = comp.getCancelText();
+
+      expect(cancelText).toEqual('Cancel');
+    });
+
+    it('should emit cancelled with no event if save and resume not enabled', () => {
+      fixture.detectChanges();
+
+      comp.cancel();
+
+      expect(cancelled.emit).toHaveBeenCalled();
+      expect(cancelled.emit).not.toHaveBeenCalledWith({status: CaseEditPageComponent.RESUMED_FORM_DISCARD});
+      expect(cancelled.emit).not.toHaveBeenCalledWith({status: CaseEditPageComponent.NEW_FORM_DISCARD});
+      expect(cancelled.emit).not.toHaveBeenCalledWith({status: CaseEditPageComponent.RESUMED_FORM_SAVE});
+      expect(cancelled.emit).not.toHaveBeenCalledWith({status: CaseEditPageComponent.NEW_FORM_SAVE});
+    });
   });
 
-  it('should delegate first calls to caseEditComponent', () => {
-    wizardPage.isMultiColumn = () => false;
-    comp.currentPage = wizardPage;
-    fixture.detectChanges();
-    comp.first();
-    expect(caseEditComponentStub.first).toHaveBeenCalled();
-  });
-
-  it('should delegate next calls to caseEditComponent', () => {
-    wizardPage.isMultiColumn = () => false;
-    comp.currentPage = wizardPage;
-    fixture.detectChanges();
-    comp.next();
-    expect(caseEditComponentStub.next).toHaveBeenCalled();
-  });
-
-  it('should delegate prev calls to caseEditComponent', () => {
-    wizardPage.isMultiColumn = () => false;
-    comp.currentPage = wizardPage;
-    fixture.detectChanges();
-    comp.previous();
-    expect(caseEditComponentStub.previous).toHaveBeenCalled();
-  });
-
-  it('should allow empty values when field is OPTIONAL', () => {
-    wizardPage.case_fields.push(aCaseField('fieldX', 'fieldX', 'Text', 'OPTIONAL', null));
-    wizardPage.isMultiColumn = () => false;
-    comp.currentPage = wizardPage;
-    fixture.detectChanges();
-    expect(comp.currentPageIsNotValid()).toBeFalsy();
-  });
 });

--- a/src/shared/case-editor/case-edit-page.component.ts
+++ b/src/shared/case-editor/case-edit-page.component.ts
@@ -146,22 +146,26 @@ export class CaseEditPageComponent implements OnInit, AfterViewChecked {
   }
 
   cancel(): void {
-    if (this.formValuesChanged) {
-      const dialogRef = this.dialog.open(SaveOrDiscardDialogComponent, this.dialogConfig);
-      dialogRef.afterClosed().subscribe(result => {
-        if (result === 'Discard') {
-          this.discard();
-        } else if (result === 'Save') {
-          const draftCaseEventData: CaseEventData = this.formValueService.sanitise(this.editForm.value) as CaseEventData;
-          if (this.route.snapshot.queryParamMap.get(CaseEditComponent.ORIGIN_QUERY_PARAM) === 'viewDraft') {
-            this.caseEdit.cancelled.emit({status: CaseEditPageComponent.RESUMED_FORM_SAVE, data: draftCaseEventData});
-          } else {
-            this.caseEdit.cancelled.emit({status: CaseEditPageComponent.NEW_FORM_SAVE, data: draftCaseEventData});
+    if (this.eventTrigger.can_save_draft) {
+      if (this.formValuesChanged) {
+        const dialogRef = this.dialog.open(SaveOrDiscardDialogComponent, this.dialogConfig);
+        dialogRef.afterClosed().subscribe(result => {
+          if (result === 'Discard') {
+            this.discard();
+          } else if (result === 'Save') {
+            const draftCaseEventData: CaseEventData = this.formValueService.sanitise(this.editForm.value) as CaseEventData;
+            if (this.route.snapshot.queryParamMap.get(CaseEditComponent.ORIGIN_QUERY_PARAM) === 'viewDraft') {
+              this.caseEdit.cancelled.emit({status: CaseEditPageComponent.RESUMED_FORM_SAVE, data: draftCaseEventData});
+            } else {
+              this.caseEdit.cancelled.emit({status: CaseEditPageComponent.NEW_FORM_SAVE, data: draftCaseEventData});
+            }
           }
-        }
-      });
+        });
+      } else {
+        this.discard();
+      }
     } else {
-      this.discard();
+      this.caseEdit.cancelled.emit();
     }
   }
 
@@ -203,6 +207,14 @@ export class CaseEditPageComponent implements OnInit, AfterViewChecked {
       this.caseEdit.saveDraft(draftCaseEventData).subscribe(
         (draft) => this.eventTrigger.case_id = DRAFT_PREFIX + draft.id, error => this.handleError(error)
       );
+    }
+  }
+
+  getCancelText(): String {
+    if (this.eventTrigger.can_save_draft) {
+      return 'Cancel and return';
+    } else {
+      return 'Cancel';
     }
   }
 }

--- a/src/shared/case-editor/case-edit-page.html
+++ b/src/shared/case-editor/case-edit-page.html
@@ -37,7 +37,7 @@
     <button class="button" type="submit" [disabled]="currentPageIsNotValid() || submitting()">Continue</button>
   </div>
 
-  <p class="cancel"><a (click)="cancel()" href="javascript:void(0)">Cancel and return</a></p>
+  <p class="cancel"><a (click)="cancel()" href="javascript:void(0)">{{getCancelText()}}</a></p>
 
 </form>
 </div>

--- a/src/shared/case-editor/case-edit-submit.component.spec.ts
+++ b/src/shared/case-editor/case-edit-submit.component.spec.ts
@@ -19,9 +19,10 @@ import { FormErrorService } from '../form/form-error.service';
 import { FormValueService } from '../form/form-value.service';
 import { CaseEditSubmitComponent } from './case-edit-submit.component';
 import { CaseEditComponent } from './case-edit.component';
-import { CaseEventTrigger } from '../domain/case-view/case-event-trigger.model';
+import { CaseEditPageComponent } from './case-edit-page.component';
 
 describe('CaseEditSubmitComponent', () => {
+
   let comp: CaseEditSubmitComponent;
   let fixture: ComponentFixture<CaseEditSubmitComponent>;
   let de: DebugElement;
@@ -35,20 +36,16 @@ describe('CaseEditSubmitComponent', () => {
     'data': new FormGroup({ 'PersonLastName': new FormControl('Khaleesi') })
   });
   let caseEditComponent: any;
-  let pages: WizardPage[] = [
-    aWizardPage('page1', 'Page 1', 1),
-    aWizardPage('page2', 'Page 2', 2),
-    aWizardPage('page3', 'Page 3', 3)
-  ];
-  let firstPage = pages[0];
-  let wizard: Wizard = new Wizard(pages);
+  let pages: WizardPage[];
+  let wizard: Wizard;
   let orderService;
   let casesReferencePipe: any;
-  let eventTrigger: CaseEventTrigger = new CaseEventTrigger();
   let caseField1: CaseField = aCaseField('field1', 'field1', 'Text', 'OPTIONAL', 3);
   let caseField2: CaseField = aCaseField('field2', 'field2', 'Text', 'OPTIONAL', 2);
   let caseField3: CaseField = aCaseField('field3', 'field3', 'Text', 'OPTIONAL', 1);
   const $EVENT_NOTES = By.css('#fieldset-event');
+  let cancelled: any;
+  let snapshot: any;
 
   let mockRoute: any = {
     snapshot: {
@@ -77,242 +74,239 @@ describe('CaseEditSubmitComponent', () => {
     params: of({})
   };
 
-  beforeEach(async(() => {
-    orderService = new OrderService();
-    spyOn(orderService, 'sort').and.callThrough();
+  describe('Save and Resume disabled', () => {
+    pages  = [
+      aWizardPage('page1', 'Page 1', 1),
+      aWizardPage('page2', 'Page 2', 2),
+      aWizardPage('page3', 'Page 3', 3)
+    ];
+    let firstPage = pages[0];
+    wizard = new Wizard(pages);
+    beforeEach(async(() => {
+      orderService = new OrderService();
+      spyOn(orderService, 'sort').and.callThrough();
 
-    casesReferencePipe = createSpyObj<CaseReferencePipe>('caseReference', ['transform']);
+      casesReferencePipe = createSpyObj<CaseReferencePipe>('caseReference', ['transform']);
+      cancelled = createSpyObj('cancelled', ['emit'])
+      caseEditComponent = {
+        'form': FORM_GROUP,
+        'data': '',
+        'eventTrigger':
+          {'case_fields': [caseField1, caseField2, caseField3], 'end_button_label': END_BUTTON_LABEL, 'can_save_draft': false},
+        'wizard': wizard,
+        'hasPrevious': () => true,
+        'getPage': () => firstPage,
+        'navigateToPage': () => undefined,
+        'cancel': () => undefined,
+        'cancelled': cancelled,
+      };
+      formErrorService = createSpyObj<FormErrorService>('formErrorService', ['mapFieldErrors']);
+      formValueService = createSpyObj<FormValueService>('formValueService', ['sanitise']);
 
-    caseEditComponent = {
-      'form': FORM_GROUP,
-      'data': '',
-      'eventTrigger': {'case_fields': [caseField1, caseField2, caseField3], 'end_button_label': END_BUTTON_LABEL},
-      'wizard': wizard,
-      'hasPrevious': () => true,
-      'getPage': () => firstPage,
-      'navigateToPage': () => undefined,
-      'cancel': () => undefined
-    };
-    formErrorService = createSpyObj<FormErrorService>('formErrorService', ['mapFieldErrors']);
-    formValueService = createSpyObj<FormValueService>('formValueService', ['sanitise']);
+      spyOn(caseEditComponent, 'navigateToPage');
+      spyOn(caseEditComponent, 'cancel');
 
-    spyOn(caseEditComponent, 'navigateToPage');
-    spyOn(caseEditComponent, 'cancel');
+      TestBed.configureTestingModule({
+        declarations: [
+          CaseEditSubmitComponent,
+          IsCompoundPipe,
+          CaseReferencePipe
+        ],
+        schemas: [NO_ERRORS_SCHEMA],
+        providers: [
+          {provide: CaseEditComponent, useValue: caseEditComponent},
+          {provide: FormValueService, useValue: formValueService},
+          {provide: FormErrorService, useValue: formErrorService},
+          {provide: CaseFieldService, useValue: caseFieldService},
+          {provide: FieldsUtils, useValue: fieldsUtils},
+          {provide: CaseReferencePipe, useValue: casesReferencePipe},
+          {provide: ActivatedRoute, useValue: mockRoute},
+          {provide: OrderService, useValue: orderService}
+        ]
+      }).compileComponents();
 
-    TestBed.configureTestingModule({
-      declarations: [
-        CaseEditSubmitComponent,
-        IsCompoundPipe,
-        CaseReferencePipe
-      ],
-      schemas: [NO_ERRORS_SCHEMA],
-      providers: [
-        {provide: CaseEditComponent, useValue: caseEditComponent},
-        {provide: FormValueService, useValue: formValueService},
-        {provide: FormErrorService, useValue: formErrorService},
-        {provide: CaseFieldService, useValue: caseFieldService},
-        {provide: FieldsUtils, useValue: fieldsUtils},
-        {provide: CaseReferencePipe, useValue: casesReferencePipe},
-        {provide: ActivatedRoute, useValue: mockRoute},
-        {provide: OrderService, useValue: orderService}
-      ]
-    }).compileComponents();
+    }));
 
-  }));
+    beforeEach(() => {
+      fixture = TestBed.createComponent(CaseEditSubmitComponent);
+      comp = fixture.componentInstance;
+      de = fixture.debugElement;
+      fixture.detectChanges();
+    });
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(CaseEditSubmitComponent);
-    comp = fixture.componentInstance;
-    de = fixture.debugElement;
-    fixture.detectChanges();
+    it('must render correct button label', () => {
+      let buttons = de.queryAll(By.css('div>button'));
+      expect(buttons[1].nativeElement.textContent.trim()).toEqual(END_BUTTON_LABEL);
+    });
+
+    it('should delegate navigateToPage calls to caseEditComponent', () => {
+      comp.navigateToPage('somePage');
+      expect(caseEditComponent.navigateToPage).toHaveBeenCalled();
+    });
+
+    it('should delegate cancel calls to caseEditComponent if save and resume disabled', () => {
+      comp.cancel();
+      expect(cancelled.emit).toHaveBeenCalled();
+    });
+
+    it('should not allow changes for READONLY fields', () => {
+      let changeAllowed = comp.isChangeAllowed(aCaseField('field1', 'field1', 'Text', 'READONLY', null));
+      expect(changeAllowed).toBeFalsy();
+    });
+
+    it('should allow changes for non READONLY fields', () => {
+      let changeAllowed = comp.isChangeAllowed(aCaseField('field1', 'field1', 'Text', 'OPTIONAL', null));
+      expect(changeAllowed).toBeTruthy();
+    });
+
+    it('should return TRUE for canShowFieldInCYA when caseField show_summary_change_option is TRUE', () => {
+      let caseField: CaseField = aCaseField('field1', 'field1', 'Text', 'OPTIONAL', null);
+      caseField.show_summary_change_option = true;
+      let canShow = comp.canShowFieldInCYA(caseField);
+      expect(canShow).toBeTruthy();
+    });
+
+    it('should return FALSE for canShowFieldInCYA when caseField show_summary_change_option is FALSE', () => {
+      let caseField: CaseField = aCaseField('field1', 'field1', 'Text', 'OPTIONAL', null);
+      caseField.show_summary_change_option = false;
+      let canShow = comp.canShowFieldInCYA(caseField);
+      expect(canShow).toBeFalsy();
+    });
+
+    it('should return lastPageShown', () => {
+      spyOn(comp, 'navigateToPage').and.callThrough();
+
+      comp.previous();
+
+      expect(comp.navigateToPage).toHaveBeenCalled();
+      expect(caseEditComponent.navigateToPage).toHaveBeenCalled();
+    });
+
+    it('should return false when no field exists and checkYourAnswerFieldsToDisplayExists is called', () => {
+      let result = comp.checkYourAnswerFieldsToDisplayExists();
+
+      expect(result).toBeFalsy();
+    });
+
+    it('should return true when no Fields to Display exists and checkYourAnswerFieldsToDisplayExists is called', () => {
+      let caseField: CaseField = aCaseField('field1', 'field1', 'Text', 'OPTIONAL', null);
+      caseField.show_summary_change_option = true;
+      comp.wizard.pages[0].case_fields = [caseField];
+      comp.eventTrigger.show_summary = true;
+
+      let result = comp.checkYourAnswerFieldsToDisplayExists();
+      expect(result).toBeTruthy();
+    });
+
+    it('should return false when no field exists and readOnlySummaryFieldsToDisplayExists is called', () => {
+      comp.eventTrigger.case_fields = [];
+      fixture.detectChanges();
+
+      let result = comp.readOnlySummaryFieldsToDisplayExists();
+
+      expect(result).toBeFalsy();
+    });
+
+    it('should return true when no Fields to Display exists and readOnlySummaryFieldsToDisplayExists is called', () => {
+      let caseField: CaseField = aCaseField('field1', 'field1', 'Text', 'OPTIONAL', null);
+      caseField.show_summary_content_option = 3;
+      comp.eventTrigger.case_fields = [caseField];
+
+      let result = comp.readOnlySummaryFieldsToDisplayExists();
+
+      expect(result).toBeTruthy();
+    });
+
+    it('should show event notes when set in event trigger and showEventNotes is called', () => {
+      comp.eventTrigger.show_event_notes = true;
+      fixture.detectChanges();
+      let eventNotes = de.query($EVENT_NOTES);
+
+      let result = comp.showEventNotes();
+
+      expect(result).toBeTruthy();
+      expect(eventNotes).not.toBeNull();
+    });
+
+    it('should show event notes when not set in event trigger and showEventNotes is called', () => {
+      comp.eventTrigger.show_event_notes = null;
+      fixture.detectChanges();
+      let eventNotes = de.query($EVENT_NOTES);
+
+      let result = comp.showEventNotes();
+
+      expect(result).toBeTruthy();
+      expect(eventNotes).not.toBeNull();
+    });
+
+    it('should show event notes when not defined in event trigger and showEventNotes is called', () => {
+      comp.eventTrigger.show_event_notes = undefined;
+      fixture.detectChanges();
+      let eventNotes = de.query($EVENT_NOTES);
+
+      let result = comp.showEventNotes();
+
+      expect(result).toBeTruthy();
+      expect(eventNotes).not.toBeNull();
+    });
+
+    it('should not show event notes when set to false in event trigger and showEventNotes is called', () => {
+      comp.eventTrigger.show_event_notes = false;
+      fixture.detectChanges();
+      let eventNotes = de.query($EVENT_NOTES);
+
+      let result = comp.showEventNotes();
+
+      expect(result).toBeFalsy();
+      expect(eventNotes).toBeNull();
+    });
+
+    it('should return false when no field exists and readOnlySummaryFieldsToDisplayExists is called', () => {
+      comp.eventTrigger.case_fields = [];
+      fixture.detectChanges();
+
+      let result = comp.readOnlySummaryFieldsToDisplayExists();
+
+      expect(result).toBeFalsy();
+    });
+
+    it('should return true when no Fields to Display exists and readOnlySummaryFieldsToDisplayExists is called', () => {
+      let caseField: CaseField = aCaseField('field1', 'field1', 'Text', 'OPTIONAL', null);
+      caseField.show_summary_content_option = 3;
+      comp.eventTrigger.case_fields = [caseField];
+
+      let result = comp.readOnlySummaryFieldsToDisplayExists();
+
+      expect(result).toBeTruthy();
+    });
+
+    it('should sort case fields with show_summary_content_option', () => {
+      expect(comp.eventTrigger.case_fields[0].show_summary_content_option).toBe(3);
+      expect(comp.eventTrigger.case_fields[1].show_summary_content_option).toBe(2);
+      expect(comp.eventTrigger.case_fields[2].show_summary_content_option).toBe(1);
+      expect(orderService.sort).toHaveBeenCalledWith(
+        comp.eventTrigger.case_fields,
+        CaseEditSubmitComponent.SHOW_SUMMARY_CONTENT_COMPARE_FUNCTION);
+      expect(comp.showSummaryFields.length).toBe(3);
+      expect(comp.showSummaryFields[0].show_summary_content_option).toBe(1);
+      expect(comp.showSummaryFields[1].show_summary_content_option).toBe(2);
+      expect(comp.showSummaryFields[2].show_summary_content_option).toBe(3);
+    });
+
+    it('should return "Cancel" text label for cancel button when save and resume disabled', () => {
+      let result = comp.getCancelText();
+      expect(result).toBe('Cancel');
+    });
   });
 
-  it('must render correct button label', () => {
-    let buttons = de.queryAll(By.css('div>button'));
-    expect(buttons[1].nativeElement.textContent.trim()).toEqual(END_BUTTON_LABEL);
-  });
-
-  it('should delegate navigateToPage calls to caseEditComponent', () => {
-    comp.navigateToPage('somePage');
-    expect(caseEditComponent.navigateToPage).toHaveBeenCalled();
-  });
-
-  it('should delegate cancel calls to caseEditComponent', () => {
-    comp.cancel();
-    expect(caseEditComponent.cancel).toHaveBeenCalled();
-  });
-
-  it('should not allow changes for READONLY fields', () => {
-    let changeAllowed = comp.isChangeAllowed(aCaseField('field1', 'field1', 'Text', 'READONLY', null));
-    expect(changeAllowed).toBeFalsy();
-  });
-
-  it('should allow changes for non READONLY fields', () => {
-    let changeAllowed = comp.isChangeAllowed(aCaseField('field1', 'field1', 'Text', 'OPTIONAL', null));
-    expect(changeAllowed).toBeTruthy();
-  });
-
-  it('should return TRUE for canShowFieldInCYA when caseField show_summary_change_option is TRUE', () => {
-    let caseField: CaseField = aCaseField('field1', 'field1', 'Text', 'OPTIONAL', null);
-    caseField.show_summary_change_option = true;
-    let canShow = comp.canShowFieldInCYA(caseField);
-    expect(canShow).toBeTruthy();
-  });
-
-  it('should return FALSE for canShowFieldInCYA when caseField show_summary_change_option is FALSE', () => {
-    let caseField: CaseField = aCaseField('field1', 'field1', 'Text', 'OPTIONAL', null);
-    caseField.show_summary_change_option = false;
-    let canShow = comp.canShowFieldInCYA(caseField);
-    expect(canShow).toBeFalsy();
-  });
-
-  it('should return lastPageShown', () => {
-    spyOn(comp, 'navigateToPage').and.callThrough();
-
-    comp.previous();
-
-    expect(comp.navigateToPage).toHaveBeenCalled();
-    expect(caseEditComponent.navigateToPage).toHaveBeenCalled();
-  });
-
-  it('should return false when no field exists and checkYourAnswerFieldsToDisplayExists is called', () => {
-    let result = comp.checkYourAnswerFieldsToDisplayExists();
-
-    expect(result).toBeFalsy();
-  });
-
-  it('should return true when no Fields to Display exists and checkYourAnswerFieldsToDisplayExists is called', () => {
-    let caseField: CaseField = aCaseField('field1', 'field1', 'Text', 'OPTIONAL', null);
-    caseField.show_summary_change_option = true;
-    comp.wizard.pages[0].case_fields = [caseField];
-    comp.eventTrigger.show_summary = true;
-
-    let result = comp.checkYourAnswerFieldsToDisplayExists();
-    expect(result).toBeTruthy();
-  });
-
-  it('should return false when no field exists and readOnlySummaryFieldsToDisplayExists is called', () => {
-    comp.eventTrigger.case_fields = [];
-    fixture.detectChanges();
-
-    let result = comp.readOnlySummaryFieldsToDisplayExists();
-
-    expect(result).toBeFalsy();
-  });
-
-  it('should return true when no Fields to Display exists and readOnlySummaryFieldsToDisplayExists is called', () => {
-    let caseField: CaseField = aCaseField('field1', 'field1', 'Text', 'OPTIONAL', null);
-    caseField.show_summary_content_option = 3;
-    comp.eventTrigger.case_fields = [caseField];
-
-    let result = comp.readOnlySummaryFieldsToDisplayExists();
-
-    expect(result).toBeTruthy();
-  });
-
-  it('should show event notes when set in event trigger and showEventNotes is called', () => {
-    comp.eventTrigger.show_event_notes = true;
-    fixture.detectChanges();
-    let eventNotes = de.query($EVENT_NOTES);
-
-    let result = comp.showEventNotes();
-
-    expect(result).toBeTruthy();
-    expect(eventNotes).not.toBeNull();
-  });
-
-  it('should show event notes when not set in event trigger and showEventNotes is called', () => {
-    comp.eventTrigger.show_event_notes = null;
-    fixture.detectChanges();
-    let eventNotes = de.query($EVENT_NOTES);
-
-    let result = comp.showEventNotes();
-
-    expect(result).toBeTruthy();
-    expect(eventNotes).not.toBeNull();
-  });
-
-  it('should show event notes when not defined in event trigger and showEventNotes is called', () => {
-    comp.eventTrigger.show_event_notes = undefined;
-    fixture.detectChanges();
-    let eventNotes = de.query($EVENT_NOTES);
-
-    let result = comp.showEventNotes();
-
-    expect(result).toBeTruthy();
-    expect(eventNotes).not.toBeNull();
-  });
-
-  it('should not show event notes when set to false in event trigger and showEventNotes is called', () => {
-    comp.eventTrigger.show_event_notes = false;
-    fixture.detectChanges();
-    let eventNotes = de.query($EVENT_NOTES);
-
-    let result = comp.showEventNotes();
-
-    expect(result).toBeFalsy();
-    expect(eventNotes).toBeNull();
-  });
-
-  it('should return false when no field exists and readOnlySummaryFieldsToDisplayExists is called', () => {
-    comp.eventTrigger.case_fields = [];
-    fixture.detectChanges();
-
-    let result = comp.readOnlySummaryFieldsToDisplayExists();
-
-    expect(result).toBeFalsy();
-  });
-
-  it('should return true when no Fields to Display exists and readOnlySummaryFieldsToDisplayExists is called', () => {
-    let caseField: CaseField = aCaseField('field1', 'field1', 'Text', 'OPTIONAL', null);
-    caseField.show_summary_content_option = 3;
-    comp.eventTrigger.case_fields = [caseField];
-
-    let result = comp.readOnlySummaryFieldsToDisplayExists();
-
-    expect(result).toBeTruthy();
-  });
-
-  it('should sort case fields with show_summary_content_option', () => {
-    expect(comp.eventTrigger.case_fields[0].show_summary_content_option).toBe(3);
-    expect(comp.eventTrigger.case_fields[1].show_summary_content_option).toBe(2);
-    expect(comp.eventTrigger.case_fields[2].show_summary_content_option).toBe(1);
-    expect(orderService.sort).toHaveBeenCalledWith(
-      comp.eventTrigger.case_fields,
-      CaseEditSubmitComponent.SHOW_SUMMARY_CONTENT_COMPARE_FUNCTION);
-    expect(comp.showSummaryFields.length).toBe(3);
-    expect(comp.showSummaryFields[0].show_summary_content_option).toBe(1);
-    expect(comp.showSummaryFields[1].show_summary_content_option).toBe(2);
-    expect(comp.showSummaryFields[2].show_summary_content_option).toBe(3);
-  });
-});
-
-describe('CaseEditSubmitComponent without custom end button label', () => {
-  let comp: CaseEditSubmitComponent;
-  let fixture: ComponentFixture<CaseEditSubmitComponent>;
-  let de: DebugElement;
-
-  let formValueService: any;
-  let formErrorService: any;
-  let casesReferencePipe: any;
-  let caseFieldService = new CaseFieldService();
-  let fieldsUtils: FieldsUtils = new FieldsUtils();
-
-  const FORM_GROUP = new FormGroup({
-    'data': new FormGroup({ 'PersonLastName': new FormControl('Khaleesi') })
-  });
-  let caseEditComponent: any;
-  let pages: WizardPage[] = [
-    aWizardPage('page1', 'Page 1', 1),
-  ];
-  let firstPage = pages[0];
-  let wizard: Wizard = new Wizard(pages);
-  let orderService;
-
-  let mockRoute: any = {
-    snapshot: {
-      data: {},
-      params: {},
+  describe('CaseEditSubmitComponent without custom end button label and with Save and Resume enabled', () => {
+    pages = [
+      aWizardPage('page1', 'Page 1', 1),
+    ];
+    let firstPage = pages[0];
+    wizard = new Wizard(pages);
+    let queryParamMap = createSpyObj('queryParamMap', ['get']);
+    snapshot = {
       pathFromRoot: [
         {},
         {
@@ -331,61 +325,99 @@ describe('CaseEditSubmitComponent without custom end button label', () => {
             }
           }
         }
-      ]
-    },
-    params: of({})
-  };
-
-  beforeEach(async(() => {
-    orderService = new OrderService();
-    spyOn(orderService, 'sort').and.callThrough();
-    casesReferencePipe = createSpyObj<CaseReferencePipe>('caseReference', ['transform']);
-    caseEditComponent = {
-      'form': FORM_GROUP,
-      'data': '',
-      'eventTrigger': { 'case_fields': [] },
-      'wizard': wizard,
-      'hasPrevious': () => true,
-      'getPage': () => firstPage,
-      'navigateToPage': () => undefined,
-      'cancel': () => undefined
-    };
-    formErrorService = createSpyObj<FormErrorService>('formErrorService', ['mapFieldErrors']);
-    formValueService = createSpyObj<FormValueService>('formValueService', ['sanitise']);
-
-    spyOn(caseEditComponent, 'navigateToPage');
-    spyOn(caseEditComponent, 'cancel');
-
-    TestBed.configureTestingModule({
-      declarations: [
-        CaseEditSubmitComponent,
-        IsCompoundPipe,
-        CaseReferencePipe
       ],
-      schemas: [NO_ERRORS_SCHEMA],
-      providers: [
-        { provide: CaseEditComponent, useValue: caseEditComponent },
-        { provide: FormValueService, useValue: formValueService },
-        { provide: FormErrorService, useValue: formErrorService },
-        { provide: CaseFieldService, useValue: caseFieldService },
-        { provide: FieldsUtils, useValue: fieldsUtils },
-        { provide: CaseReferencePipe, useValue: casesReferencePipe },
-        { provide: ActivatedRoute, useValue: mockRoute },
-        { provide: OrderService, useValue: orderService }
-      ]
-    }).compileComponents();
+      queryParamMap: queryParamMap,
+    };
+    mockRoute = {
+      params: of({id: 123}),
+      snapshot: snapshot
+    };
+    beforeEach(async(() => {
+      orderService = new OrderService();
+      spyOn(orderService, 'sort').and.callThrough();
+      casesReferencePipe = createSpyObj<CaseReferencePipe>('caseReference', ['transform']);
+      cancelled = createSpyObj('cancelled', ['emit'])
+      caseEditComponent = {
+        'form': FORM_GROUP,
+        'data': '',
+        'eventTrigger': { 'case_fields': [], 'can_save_draft': true },
+        'wizard': wizard,
+        'hasPrevious': () => true,
+        'getPage': () => firstPage,
+        'navigateToPage': () => undefined,
+        'cancel': () => undefined,
+        'cancelled': cancelled,
+      };
+      formErrorService = createSpyObj<FormErrorService>('formErrorService', ['mapFieldErrors']);
+      formValueService = createSpyObj<FormValueService>('formValueService', ['sanitise']);
 
-  }));
+      spyOn(caseEditComponent, 'navigateToPage');
+      spyOn(caseEditComponent, 'cancel');
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(CaseEditSubmitComponent);
-    comp = fixture.componentInstance;
-    de = fixture.debugElement;
-    fixture.detectChanges();
-  });
+      TestBed.configureTestingModule({
+        declarations: [
+          CaseEditSubmitComponent,
+          IsCompoundPipe,
+          CaseReferencePipe
+        ],
+        schemas: [NO_ERRORS_SCHEMA],
+        providers: [
+          { provide: CaseEditComponent, useValue: caseEditComponent },
+          { provide: FormValueService, useValue: formValueService },
+          { provide: FormErrorService, useValue: formErrorService },
+          { provide: CaseFieldService, useValue: caseFieldService },
+          { provide: FieldsUtils, useValue: fieldsUtils },
+          { provide: CaseReferencePipe, useValue: casesReferencePipe },
+          { provide: ActivatedRoute, useValue: mockRoute },
+          { provide: OrderService, useValue: orderService }
+        ]
+      }).compileComponents();
 
-  it('must render default button label when custom one is not supplied', () => {
-    let buttons = de.queryAll(By.css('div>button'));
-    expect(buttons[1].nativeElement.textContent.trim()).toEqual('Submit');
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(CaseEditSubmitComponent);
+      comp = fixture.componentInstance;
+      de = fixture.debugElement;
+      fixture.detectChanges();
+    });
+
+    it('must render default button label when custom one is not supplied', () => {
+      let buttons = de.queryAll(By.css('div>button'));
+      expect(buttons[1].nativeElement.textContent.trim()).toEqual('Submit');
+    });
+
+    it('should emit RESUMED_FORM_DISCARD on create event if cancel triggered and originated from view case', () => {
+      queryParamMap.get.and.callFake(key => {
+        switch (key) {
+          case CaseEditComponent.ORIGIN_QUERY_PARAM:
+            return 'viewDraft';
+        }
+      });
+      fixture.detectChanges();
+
+      comp.cancel();
+      expect(cancelled.emit).toHaveBeenCalledWith({status: CaseEditPageComponent.RESUMED_FORM_DISCARD});
+      expect(cancelled.emit).not.toHaveBeenCalledWith({status: CaseEditPageComponent.NEW_FORM_DISCARD});
+    });
+
+    it('should emit NEW_FORM_DISCARD on create event if cancel triggered and originated from create case', () => {
+      queryParamMap.get.and.callFake(key => {
+        switch (key) {
+          case CaseEditComponent.ORIGIN_QUERY_PARAM:
+            return '';
+        }
+      });
+      fixture.detectChanges();
+
+      comp.cancel();
+      expect(cancelled.emit).toHaveBeenCalledWith({status: CaseEditPageComponent.NEW_FORM_DISCARD});
+      expect(cancelled.emit).not.toHaveBeenCalledWith({status: CaseEditPageComponent.RESUMED_FORM_DISCARD});
+    });
+
+    it('should return "Cancel and return" text label for cancel button when save and resume enabled', () => {
+      let result = comp.getCancelText();
+      expect(result).toBe('Cancel and return');
+    });
   });
 });

--- a/src/shared/case-editor/case-edit-submit.component.ts
+++ b/src/shared/case-editor/case-edit-submit.component.ts
@@ -19,6 +19,7 @@ import { OrderService } from '../domain/order/order.service';
 import { CaseEventData } from '../domain/case-event-data';
 import { Confirmation } from '../domain/case-edit/confirmation.model';
 import { WizardPage } from '../domain/wizard-page.model';
+import { CaseEditPageComponent } from './case-edit-page.component';
 
 // @dynamic
 @Component({
@@ -138,7 +139,15 @@ export class CaseEditSubmitComponent implements OnInit {
   }
 
   cancel(): void {
-    this.caseEdit.cancel();
+    if (this.eventTrigger.can_save_draft) {
+      if (this.route.snapshot.queryParamMap.get(CaseEditComponent.ORIGIN_QUERY_PARAM) === 'viewDraft') {
+        this.caseEdit.cancelled.emit({status: CaseEditPageComponent.RESUMED_FORM_DISCARD});
+      } else {
+        this.caseEdit.cancelled.emit({status: CaseEditPageComponent.NEW_FORM_DISCARD});
+      }
+    } else {
+      this.caseEdit.cancelled.emit();
+    }
   }
 
   isChangeAllowed(field: CaseField): boolean {
@@ -234,5 +243,13 @@ export class CaseEditSubmitComponent implements OnInit {
 
   getCaseId(): String {
     return (this.caseEdit.caseDetails ? this.caseEdit.caseDetails.case_id : '');
+  }
+
+  getCancelText(): String {
+    if (this.eventTrigger.can_save_draft) {
+      return 'Cancel and return';
+    } else {
+      return 'Cancel';
+    }
   }
 }

--- a/src/shared/case-editor/case-edit-submit.html
+++ b/src/shared/case-editor/case-edit-submit.html
@@ -93,5 +93,5 @@
     <button class="button button-secondary" type="button" [disabled]="!hasPrevious()" (click)="previous()">Previous</button>
     <button type="submit" [disabled]="isDisabled()" class="button">{{triggerText}}</button>
   </div>
-  <p class="cancel"><a (click)="cancel()" href="javascript:void(0)">Cancel and return</a></p>
+  <p class="cancel"><a (click)="cancel()" href="javascript:void(0)">{{getCancelText()}}</a></p>
 </form>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-3178
https://tools.hmcts.net/jira/browse/RDM-3179

### Change description ###
'Cancel and Return' functionality is enabled when Save and Resume is not configured	
As a user I want to 'Cancel and Return' only on a create event
bug fix to cancel on CYA page of create case event with S&R: Release new version


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
