### PR TITLE
Drop NodeJS 8.9.4 as 8.11.1 is the new default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "8.9.4"   # Likely set Azure webapp minimum
   - "8.11.1"  # Highest 8.* in Azure
   - "lts/*"   # Latest Node LTS
   - "10.6.0"  # Highest Azure 10.*


### PR DESCRIPTION
RDM-3092




https://tools.hmcts.net/jira/browse/RDM-3093






**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```