### PR TITLE
RDM-3391 - BugFix- Selecting radio label will select radio button now

### DIFF
--- a/src/shared/components/palette/fixed-radio-list/write-fixed-radio-list-field.html
+++ b/src/shared/components/palette/fixed-radio-list/write-fixed-radio-list-field.html
@@ -11,7 +11,7 @@
     <ng-container>
       <div class="multiple-choice" *ngFor="let radioButton of caseField.field_type.fixed_list_items" [ngClass]="{selected: fixedRadioListControl.value === radioButton.code}">
           <input [id]="id()+'-'+radioButton.code" [name]="id()" type="radio" [formControl]="fixedRadioListControl" [value]="radioButton.code">
-          <label class="form-label" [for]="id()+'-'+value">{{radioButton.label}}</label>
+          <label class="form-label" [for]="id()+'-'+radioButton.code">{{radioButton.label}}</label>
       </div>
     </ng-container>
   </fieldset>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-3391

Steps:
Load definition file with FixeRadioList component for Create Case page
Login into the Web app
Go to Create case page to view the component
Click on Radio label text to select the radio option (not on the circle button)
Expected:
Radio list option should be selectable on label text click (Ref. https://design-system.service.gov.uk/components/radios/)
Actual:
Radio list option is not selected when clicked on a label text

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
