### PR TITLE
Rdm 2323 based on latest master

### DIFF
--- a/src/shared/components/palette/label/label-field.component.spec.ts
+++ b/src/shared/components/palette/label/label-field.component.spec.ts
@@ -17,7 +17,12 @@ describe('LabelFieldComponent', () => {
     id: 'Label',
     type: 'Label'
   };
-
+  const CASE_FIELD_WITH_NO_VALUE: CaseField = {
+    id: 'label',
+    label: 'Label Field Label',
+    display_context: 'OPTIONAL',
+    field_type: FIELD_TYPE,
+  };
   const CASE_FIELD: CaseField = {
     id: 'label',
     label: 'Label Field Label',
@@ -39,8 +44,8 @@ describe('LabelFieldComponent', () => {
   ];
 
   let MarkdownComponent: any = MockComponent({ selector: 'ccd-markdown', inputs: [
-    'content'
-  ]});
+      'content'
+    ]});
   let fixture: ComponentFixture<LabelFieldComponent>;
   let component: LabelFieldComponent;
   let de: DebugElement;
@@ -67,14 +72,14 @@ describe('LabelFieldComponent', () => {
   describe('LabelFieldComponent without label substitution', () => {
     beforeEach(() => {
       component = fixture.componentInstance;
-      component.caseField = CASE_FIELD;
+      component.caseField = CASE_FIELD_WITH_NO_VALUE;
 
       de = fixture.debugElement;
       fixture.detectChanges();
     });
 
     it('Should render a table with the field label in the markdown tag in the header', () => {
-      expect(de.query($CONTENT).nativeElement.getAttribute('ng-reflect-content')).toBe(CASE_FIELD.label);
+      expect(de.query($CONTENT).nativeElement.getAttribute('ng-reflect-content')).toBe(CASE_FIELD_WITH_NO_VALUE.label);
     });
   });
 

--- a/src/shared/components/palette/label/label-field.html
+++ b/src/shared/components/palette/label/label-field.html
@@ -1,6 +1,6 @@
-<dl class="case-field" ccdLabelSubstitutor [caseField]="caseField" [eventFields]="eventFields">
+  <dl class="case-field" ccdLabelSubstitutor [caseField]="caseField" [eventFields]="eventFields">
   <dt>
-    <ccd-markdown [content]="caseField.label"></ccd-markdown>
+    <ccd-markdown [content]="caseField.value || caseField.label"></ccd-markdown>
   </dt>
   <dd></dd>
 </dl>

--- a/src/shared/directives/substitutor/label-substitutor.directive.spec.ts
+++ b/src/shared/directives/substitutor/label-substitutor.directive.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { By }              from '@angular/platform-browser';
-import { DebugElement, Component, Input }    from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { DebugElement, Component, Input } from '@angular/core';
 import { LabelSubstitutorDirective } from './label-substitutor.directive';
 import { CaseField } from '../../domain/definition/case-field.model';
 import { async } from '@angular/core/testing';
@@ -8,6 +8,7 @@ import { FormGroup, FormControl } from '@angular/forms';
 import { FieldsUtils } from '../../services/fields/fields.utils';
 import { LabelSubstitutionService } from './services/label-substitution.service';
 import createSpyObj = jasmine.createSpyObj;
+import { flattenStyles } from '@angular/platform-browser/src/dom/dom_renderer';
 
 @Component({
   template: `
@@ -18,812 +19,825 @@ import createSpyObj = jasmine.createSpyObj;
 })
 class TestHostComponent {
 
-    @Input() caseField: CaseField;
-    @Input() eventFields: CaseField[];
-    @Input() formGroup: FormGroup;
+  @Input() caseField: CaseField;
+  @Input() eventFields: CaseField[];
+  @Input() formGroup: FormGroup = new FormGroup({});
+  @Input() isEmptyIfPlaceholderMissing: Boolean = false;
 }
 
 let field = (id, value, fieldType, label?, hintText?) => {
-    let caseField = new CaseField();
-    caseField.id = id;
-    caseField.value = value;
-    caseField.field_type = fieldType;
-    caseField.label = label;
-    caseField.hint_text = hintText;
-    return caseField;
+  let caseField = new CaseField();
+  caseField.id = id;
+  caseField.value = value;
+  caseField.field_type = fieldType;
+  caseField.label = label;
+  caseField.hint_text = hintText;
+  return caseField;
 };
 
 describe('LabelSubstitutorDirective', () => {
 
-    let comp:    TestHostComponent;
-    let fixture: ComponentFixture<TestHostComponent>;
-    let de:      DebugElement;
-    let labelEl: HTMLElement;
-    let hintEl: HTMLElement;
-    let labelSubstitutionService: any;
+  let comp: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
+  let de: DebugElement;
+  let labelEl: HTMLElement;
+  let hintEl: HTMLElement;
+  let labelSubstitutionService: any;
 
-    beforeEach( async(() => {
-        labelSubstitutionService = createSpyObj<LabelSubstitutionService>('labelSubstitutionService', ['substituteLabel']);
+  beforeEach(async(() => {
+    labelSubstitutionService = createSpyObj<LabelSubstitutionService>('labelSubstitutionService', ['substituteLabel']);
 
-        TestBed.configureTestingModule({
-            declarations: [ LabelSubstitutorDirective, TestHostComponent ],
-            providers:    [ FieldsUtils ,
-                            {provide: LabelSubstitutionService, useValue: labelSubstitutionService}]
-        }).compileComponents();
+    TestBed.configureTestingModule({
+      declarations: [LabelSubstitutorDirective, TestHostComponent],
+      providers: [FieldsUtils,
+        { provide: LabelSubstitutionService, useValue: labelSubstitutionService }]
+    }).compileComponents();
 
-        fixture = TestBed.createComponent(TestHostComponent);
-        comp = fixture.componentInstance;
-        de = fixture.debugElement;
-        labelEl = de.query(By.css('tr> td:nth-child(1)')).nativeElement;
-        hintEl = de.query(By.css('tr> td:nth-child(2)')).nativeElement;
+    fixture = TestBed.createComponent(TestHostComponent);
+    comp = fixture.componentInstance;
+    de = fixture.debugElement;
+    labelEl = de.query(By.css('tr> td:nth-child(1)')).nativeElement;
+    hintEl = de.query(By.css('tr> td:nth-child(2)')).nativeElement;
   }));
 
-    describe('simple type fields', () => {
+  describe('simple type fields', () => {
 
-        it('should display label returned by label substitution service', () => {
-            let label = 'Label B with valueA=${LabelA} and valueA=${LabelA}:';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text'
-            },  label);
-            comp.eventFields = [comp.caseField];
-            labelSubstitutionService.substituteLabel.and.returnValue('Label B with valueA=ValueA and valueA=ValueA:');
-            fixture.detectChanges();
+    it('should display label returned by label substitution service when value is undefined', () => {
+      let label = 'Label B with valueA=${LabelA} and valueA=${LabelA}:';
+      comp.caseField = field('LabelB', undefined, {
+        id: 'LabelB',
+        type: 'Text'
+      }, label);
+      comp.eventFields = [comp.caseField];
+      labelSubstitutionService.substituteLabel.and.returnValue('Label B with valueA=ValueA and valueA=ValueA:');
+      fixture.detectChanges();
 
-            expect(labelEl.innerText).toBe('Label B with valueA=ValueA and valueA=ValueA:');
-        });
-
-        it('should display help text returned by label substitution service', () => {
-            let label = 'Label';
-            let helpText = 'Label B with valueA=${LabelA} and valueA=${LabelA}:';
-            comp.caseField = field('LabelB', '', {
-              id: 'LabelB',
-              type: 'Text'
-            }, label, helpText);
-            comp.eventFields = [comp.caseField];
-            labelSubstitutionService.substituteLabel.and.returnValues(label, 'Label B with valueA=ValueA and valueA=ValueA:');
-            fixture.detectChanges();
-
-            expect(labelEl.innerText).toBe(label);
-            expect(hintEl.innerText).toBe('Label B with valueA=ValueA and valueA=ValueA:');
-        });
-
-        it('should pass case field value to substitute label when case field value but no form field value present', () => {
-            let label = 'someLabel:';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text'
-            },  label);
-            comp.eventFields = [comp.caseField, field('LabelA', 'ValueA', '')];
-            fixture.detectChanges();
-
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: 'ValueA' }, label);
-        });
-
-        it('should pass form value to substitute label if both case field and form values exist for same field', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text'
-            },  label);
-            comp.eventFields = [comp.caseField, field('LabelA', 'ValueA1', '')];
-            comp.formGroup = new FormGroup({
-                LabelA: new FormControl('ValueA2'),
-            });
-            fixture.detectChanges();
-
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: 'ValueA2' }, label);
-        });
-
-        it('should pass correct values when both form field and case field values present for different fields', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text'
-            }, label);
-            comp.eventFields = [comp.caseField, field('LabelD', 'ValueD', {
-                id: 'LabelD',
-                type: 'Text'
-            }, '')];
-            comp.formGroup = new FormGroup({
-                LabelA: new FormControl('ValueA'),
-                LabelC: new FormControl('ValueC')
-            });
-            fixture.detectChanges();
-
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith(
-                { LabelB: '', LabelA: 'ValueA', LabelC: 'ValueC', LabelD: 'ValueD' }, label);
-        });
+      expect(labelEl.innerText).toBe('Label B with valueA=ValueA and valueA=ValueA:');
     });
 
-    describe('fixed list type fields', () => {
+    it('should display help text returned by label substitution service', () => {
+      let label = 'Label';
+      let helpText = 'Label B with valueA=${LabelA} and valueA=${LabelA}:';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text'
+      }, label, helpText);
+      comp.eventFields = [comp.caseField];
+      labelSubstitutionService.substituteLabel.and.returnValues(label, 'Label B with valueA=ValueA and valueA=ValueA:');
+      fixture.detectChanges();
 
-        it('should pass form field value when field is not read only and no case field value but form field value present', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text',
-            }, label);
-            comp.eventFields = [comp.caseField, field('LabelA', '', {
-                id: 'LabelA',
-                type: 'FixedList',
-                fixed_list_items: [
-                    {
-                        code: 'ValueA',
-                        label: 'Option A'
-                    },
-                    {
-                        code: 'ValueC',
-                        label: 'Option C'
-                    }
-                ]
-            }, '')];
-            comp.formGroup = new FormGroup({
-                LabelA: new FormControl('ValueA')
-            });
-            fixture.detectChanges();
-
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith(
-                { LabelB: '', LabelA: 'Option A' }, label);
-        });
-
-        it('should pass case field value when field is read only and no form field but case field value present', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text',
-            }, label);
-            comp.eventFields = [comp.caseField, field('LabelA', 'ValueC', {
-                id: 'LabelA',
-                type: 'FixedList',
-                fixed_list_items: [
-                    {
-                        code: 'ValueA',
-                        label: 'Option A'
-                    },
-                    {
-                        code: 'ValueC',
-                        label: 'Option C'
-                    }
-                ]
-            }, '')];
-            fixture.detectChanges();
-
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith(
-                { LabelB: '', LabelA: 'Option C' }, label);
-        });
-
-        it('should pass field form value when field is not read only and both form and case field values present', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text',
-            }, label);
-            comp.eventFields = [comp.caseField, field('LabelA', 'ValueC', {
-                id: 'LabelA',
-                type: 'FixedList',
-                fixed_list_items: [
-                    {
-                        code: 'ValueA',
-                        label: 'Option A'
-                    },
-                    {
-                        code: 'ValueC',
-                        label: 'Option C'
-                    }
-                ]
-            }, '')];
-            comp.formGroup = new FormGroup({
-                LabelA: new FormControl('ValueA')
-            });
-            fixture.detectChanges();
-
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith(
-                { LabelB: '', LabelA: 'Option A' }, label);
-        });
+      expect(labelEl.innerText).toBe(label);
+      expect(hintEl.innerText).toBe('Label B with valueA=ValueA and valueA=ValueA:');
     });
 
-    describe('multi list type fields', () => {
+    it('should display label when value is defined', () => {
+      let label = 'Label B with valueA=${LabelA} and valueA=${LabelA}:';
+      comp.caseField = field('LabelB', 'xxx', {
+        id: 'LabelB',
+        type: 'Text'
+      }, label);
+      comp.eventFields = [comp.caseField];
+      labelSubstitutionService.substituteLabel.and.returnValue('Label B with valueA=ValueA and valueA=ValueA:');
+      fixture.detectChanges();
+      expect(labelEl.innerText).toBe(label);
+    });
+    it('should pass case field value to substitute label when case field value but no form field value present', () => {
+      let label = 'someLabel:';
+      comp.caseField = field('LabelB', undefined, {
+        id: 'LabelB',
+        type: 'Text'
+      }, label);
+      comp.eventFields = [comp.caseField, field('LabelA', 'ValueA', '')];
+      fixture.detectChanges();
 
-        it('should pass form field value when field is not read only and no case field value but form field value present', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text',
-            }, label);
-            comp.eventFields = [comp.caseField, field('LabelA', '', {
-                id: 'LabelA',
-                type: 'MultiSelectList',
-                fixed_list_items: [
-                    {
-                        code: 'ValueA',
-                        label: 'Option A'
-                    },
-                    {
-                        code: 'ValueC',
-                        label: 'Option C'
-                    },
-                    {
-                        code: 'ValueD',
-                        label: 'Option D'
-                    }
-                ]
-            }, '')];
-            comp.formGroup = new FormGroup({
-                LabelA: new FormControl(['ValueA', 'ValueD'])
-            });
-            fixture.detectChanges();
-
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith(
-                { LabelB: '', LabelA: ['ValueA', 'ValueD'], 'LabelA-LABEL': ['Option A', 'Option D']}, label);
-        });
-
-        it('should pass case field value when field is read only and no form field but case field value present', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text',
-            }, label);
-            comp.eventFields = [comp.caseField, field('LabelA', ['ValueC', 'ValueD'], {
-                id: 'LabelA',
-                type: 'MultiSelectList',
-                fixed_list_items: [
-                    {
-                        code: 'ValueA',
-                        label: 'Option A'
-                    },
-                    {
-                        code: 'ValueC',
-                        label: 'Option C'
-                    },
-                    {
-                        code: 'ValueD',
-                        label: 'Option D'
-                    }
-                ]
-            }, '')];
-            fixture.detectChanges();
-
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith(
-                { LabelB: '', LabelA: ['ValueC', 'ValueD'], 'LabelA-LABEL': ['Option C', 'Option D']}, label);
-        });
-
-        it('should pass field form value when field is not read only and both form and case field values present', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text',
-            }, label);
-            comp.eventFields = [comp.caseField, field('LabelA', 'ValueC', {
-                id: 'LabelA',
-                type: 'MultiSelectList',
-                fixed_list_items: [
-                    {
-                        code: 'ValueA',
-                        label: 'Option A'
-                    },
-                    {
-                        code: 'ValueC',
-                        label: 'Option C'
-                    },
-                    {
-                        code: 'ValueD',
-                        label: 'Option D'
-                    }
-                ]
-            }, '')];
-            comp.formGroup = new FormGroup({
-                LabelA: new FormControl(['ValueA', 'ValueC'])
-            });
-            fixture.detectChanges();
-
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith(
-                { LabelB: '', LabelA: ['ValueA', 'ValueC'], 'LabelA-LABEL': ['Option A', 'Option C']}, label);
-        });
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: undefined, LabelA: 'ValueA' }, label, false);
     });
 
-    describe('MoneyGBP type fields', () => {
-
-        it('should pass null value for null MoneyGBP', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text'
-            },  label);
-            comp.eventFields = [comp.caseField, field('LabelA', null, {
-                id: 'LabelA',
-                type: 'MoneyGBP'
-            }, '')];
-            fixture.detectChanges();
-
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: null }, label);
-        });
-
-        it('should pass case field value with MoneyGBP when case field value but no form field value present', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text'
-            },  label);
-            comp.eventFields = [comp.caseField, field('LabelA', '20055', {
-                id: 'LabelA',
-                type: 'MoneyGBP'
-            }, '')];
-            fixture.detectChanges();
-
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: '£200.55' }, label);
-        });
-
-        it('should pass form field value with MoneyGBP when form field value but no case field value present', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text'
-            },  label);
-            comp.eventFields = [comp.caseField, field('LabelA', '', {
-                id: 'LabelA',
-                type: 'MoneyGBP'
-            }, '')];
-            comp.formGroup = new FormGroup({
-                LabelA: new FormControl('20055')
-            });
-            fixture.detectChanges();
-
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: '£200.55' }, label);
-        });
-
-        it('should pass form field value with MoneyGBP when both form and case field values present', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text'
-            },  label);
-            comp.eventFields = [comp.caseField, field('LabelA', '99999', {
-                id: 'LabelA',
-                type: 'MoneyGBP'
-            }, '')];
-            comp.formGroup = new FormGroup({
-                LabelA: new FormControl('20055')
-            });
-            fixture.detectChanges();
-
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: '£200.55' }, label);
-        });
-    });
-
-    describe('Date type fields', () => {
-
-        it('should pass case field value with Date when case field value but no form field value present', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text'
-            },  label);
-            comp.eventFields = [comp.caseField, field('LabelA', '2018-03-07', {
-                id: 'LabelA',
-                type: 'Date'
-            }, '')];
-            fixture.detectChanges();
-
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: '7 Mar 2018' }, label);
-        });
-
-        it('should pass form field value with Date when form field value but no case field value present', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text'
-            },  label);
-            comp.eventFields = [comp.caseField, field('LabelA', '', {
-                id: 'LabelA',
-                type: 'Date'
-            }, '')];
-            comp.formGroup = new FormGroup({
-                LabelA: new FormControl('2018-03-07')
-            });
-            fixture.detectChanges();
-
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: '7 Mar 2018' }, label);
-        });
-
-        it('should pass form field value with Date when both form and case field values present', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text'
-            },  label);
-            comp.eventFields = [comp.caseField, field('LabelA', '2018-03-07', {
-                id: 'LabelA',
-                type: 'Date'
-            }, '')];
-            comp.formGroup = new FormGroup({
-                LabelA: new FormControl('2018-03-07')
-            });
-            fixture.detectChanges();
-
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: '7 Mar 2018' }, label);
-        });
-
-        it('should pass form field value with invalid date when both form and case field values present', () => {
-          let label = 'someLabel';
-          comp.caseField = field('LabelB', '', {
-              id: 'LabelB',
-              type: 'Text'
-          },  label);
-          comp.eventFields = [comp.caseField, field('LabelA', '2018-03', {
-              id: 'LabelA',
-              type: 'Date'
-          }, '')];
-          comp.formGroup = new FormGroup({
-              LabelA: new FormControl('2018-03')
-          });
-          fixture.detectChanges();
-
-          expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: '{ Invalid Date: 2018-03 }' }, label);
+    it('should pass form value to substitute label if both case field and form values exist for same field', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text'
+      }, label);
+      comp.eventFields = [comp.caseField, field('LabelA', 'ValueA1', '')];
+      comp.formGroup = new FormGroup({
+        LabelA: new FormControl('ValueA2'),
       });
+      fixture.detectChanges();
+
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: 'ValueA2' }, label, false);
     });
 
-    describe('Collection type fields', () => {
+    it('should pass correct values when both form field and case field values present for different fields', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text'
+      }, label);
+      comp.eventFields = [comp.caseField, field('LabelD', 'ValueD', {
+        id: 'LabelD',
+        type: 'Text'
+      }, '')];
+      comp.formGroup = new FormGroup({
+        LabelA: new FormControl('ValueA'),
+        LabelC: new FormControl('ValueC')
+      });
+      fixture.detectChanges();
 
-        it('should pass form field value with comma delimited text items when case field value but no form field value present', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text'
-            },  label);
-            const VALUES = [
-                {
-                  value: 'Pierre',
-                },
-                {
-                  value: 'Paul',
-                },
-                {
-                  value: 'Jacques',
-                }
-              ];
-            comp.eventFields = [comp.caseField, field('LabelA', VALUES, {
-                id: 'LabelA',
-                type: 'Collection',
-                collection_field_type: {
-                    id: 'Text',
-                    type: 'Text'
-                  }
-            }, '')];
-            fixture.detectChanges();
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith(
+        { LabelB: '', LabelA: 'ValueA', LabelC: 'ValueC', LabelD: 'ValueD' }, label, false);
+    });
+  });
 
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: VALUES}, label);
-        });
+  describe('fixed list type fields', () => {
 
-        it('should pass form field value with comma delimited text items when form field value but no case field value present', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text'
-            },  label);
-            const VALUES = [
-                {
-                  value: 'Pierre',
-                },
-                {
-                  value: 'Paul',
-                },
-                {
-                  value: 'Jacques',
-                }
-              ];
-            comp.eventFields = [comp.caseField, field('LabelA', [], {
-                id: 'LabelA',
-                type: 'Collection',
-                collection_field_type: {
-                    id: 'Text',
-                    type: 'Text'
-                  }
-            }, '')];
-            comp.formGroup = new FormGroup({
-                LabelA: new FormControl(VALUES)
-            });
-            fixture.detectChanges();
+    it('should pass form field value when field is not read only and no case field value but form field value present', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text',
+      }, label);
+      comp.eventFields = [comp.caseField, field('LabelA', '', {
+        id: 'LabelA',
+        type: 'FixedList',
+        fixed_list_items: [
+          {
+            code: 'ValueA',
+            label: 'Option A'
+          },
+          {
+            code: 'ValueC',
+            label: 'Option C'
+          }
+        ]
+      }, '')];
+      comp.formGroup = new FormGroup({
+        LabelA: new FormControl('ValueA')
+      });
+      fixture.detectChanges();
 
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: VALUES}, label);
-        });
-
-        it('should pass form field value with comma delimited text items when both form and case field values present', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text'
-            },  label);
-            const VALUES = [
-                {
-                  value: 'Pierre',
-                },
-                {
-                  value: 'Paul',
-                },
-                {
-                  value: 'Jacques',
-                }
-              ];
-            comp.eventFields = [comp.caseField, field('LabelA', [
-                {
-                  value: 'Tom',
-                },
-                {
-                  value: 'George',
-                },
-                {
-                  value: 'John',
-                }
-              ], {
-                id: 'LabelA',
-                type: 'Collection',
-                collection_field_type: {
-                    id: 'Text',
-                    type: 'Text'
-                  }
-            }, '')];
-            comp.formGroup = new FormGroup({
-                LabelA: new FormControl(VALUES)
-            });
-            fixture.detectChanges();
-
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: VALUES}, label);
-        });
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith(
+        { LabelB: '', LabelA: 'Option A' }, label, false);
     });
 
-    describe('Collection of fixed list type fields', () => {
+    it('should pass case field value when field is read only and no form field but case field value present', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text',
+      }, label);
+      comp.eventFields = [comp.caseField, field('LabelA', 'ValueC', {
+        id: 'LabelA',
+        type: 'FixedList',
+        fixed_list_items: [
+          {
+            code: 'ValueA',
+            label: 'Option A'
+          },
+          {
+            code: 'ValueC',
+            label: 'Option C'
+          }
+        ]
+      }, '')];
+      fixture.detectChanges();
 
-        it('should pass form field value with comma delimited label items when case field value but no form field value present', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text'
-            },  label);
-            const VALUES = [{value: 'ValueA'}, {value: 'ValueC'}, {value: 'ValueD'}];
-            comp.eventFields = [comp.caseField, field('LabelA', VALUES, {
-                id: 'LabelA',
-                type: 'Collection',
-                collection_field_type: {
-                    id: 'FixedList',
-                    type: 'FixedList',
-                    fixed_list_items: [
-                        {
-                            code: 'ValueA',
-                            label: 'Option A'
-                        },
-                        {
-                            code: 'ValueC',
-                            label: 'Option C'
-                        },
-                        {
-                            code: 'ValueD',
-                            label: 'Option D'
-                        }
-                    ]
-                  }
-            }, '')];
-            fixture.detectChanges();
-
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: VALUES}, label);
-        });
-
-        it('should pass form field value with comma delimited label items when form field value but no case field value present', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text'
-            },  label);
-            const VALUES = [{value: 'ValueA'}, {value: 'ValueC'}, {value: 'ValueD'}];
-              comp.eventFields = [comp.caseField, field('LabelA', [], {
-                id: 'LabelA',
-                type: 'Collection',
-                collection_field_type: {
-                    id: 'FixedList',
-                    type: 'FixedList',
-                    fixed_list_items: [
-                        {
-                            code: 'ValueA',
-                            label: 'Option A'
-                        },
-                        {
-                            code: 'ValueC',
-                            label: 'Option C'
-                        },
-                        {
-                            code: 'ValueD',
-                            label: 'Option D'
-                        }
-                    ]
-                  }
-            }, '')];
-            comp.formGroup = new FormGroup({
-                LabelA: new FormControl(VALUES)
-            });
-            fixture.detectChanges();
-
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: VALUES}, label);
-        });
-
-        it('should pass form field value with comma delimited label items when both form and case field values present', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text'
-            },  label);
-            const VALUES = [{value: 'ValueA'}, {value: 'ValueC'}, {value: 'ValueD'}];
-            comp.eventFields = [comp.caseField, field('LabelA', [{value: 'ValueD'}, {value: 'ValueD'}, {value: 'ValueD'}], {
-                id: 'LabelA',
-                type: 'Collection',
-                collection_field_type: {
-                    id: 'FixedList',
-                    type: 'FixedList',
-                    fixed_list_items: [
-                        {
-                            code: 'ValueA',
-                            label: 'Option A'
-                        },
-                        {
-                            code: 'ValueC',
-                            label: 'Option C'
-                        },
-                        {
-                            code: 'ValueD',
-                            label: 'Option D'
-                        }
-                    ]
-                  }
-            }, '')];
-            comp.formGroup = new FormGroup({
-                LabelA: new FormControl(VALUES)
-            });
-            fixture.detectChanges();
-
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: VALUES}, label);
-        });
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith(
+        { LabelB: '', LabelA: 'Option C' }, label, false);
     });
 
-    describe('Collection of MoneyGBP type fields', () => {
+    it('should pass field form value when field is not read only and both form and case field values present', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text',
+      }, label);
+      comp.eventFields = [comp.caseField, field('LabelA', 'ValueC', {
+        id: 'LabelA',
+        type: 'FixedList',
+        fixed_list_items: [
+          {
+            code: 'ValueA',
+            label: 'Option A'
+          },
+          {
+            code: 'ValueC',
+            label: 'Option C'
+          }
+        ]
+      }, '')];
+      comp.formGroup = new FormGroup({
+        LabelA: new FormControl('ValueA')
+      });
+      fixture.detectChanges();
 
-        it('should pass form field value with comma delimited label items when case field value but no form field value present', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text'
-            },  label);
-            const RAW_VALUES = [{value: '12345'}, {value: '34888'}, {value: '9944521'}];
-            const TRANSFORMED_VALUES = [{value: '£123.45'}, {value: '£348.88'}, {value: '£99,445.21'}];
-            comp.eventFields = [comp.caseField, field('LabelA', RAW_VALUES, {
-                id: 'LabelA',
-                type: 'Collection',
-                collection_field_type: {
-                    id: 'MoneyGBP',
-                    type: 'MoneyGBP'
-                  }
-            }, '')];
-            fixture.detectChanges();
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith(
+        { LabelB: '', LabelA: 'Option A' }, label, false);
+    });
+  });
 
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: TRANSFORMED_VALUES}, label);
-        });
+  describe('multi list type fields', () => {
 
-        it('should pass form field value with comma delimited label items when form field value but no case field value present', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text'
-            },  label);
-            const RAW_VALUES = [{value: '12345'}, {value: '34888'}, {value: '9944521'}];
-            const TRANSFORMED_VALUES = [{value: '£123.45'}, {value: '£348.88'}, {value: '£99,445.21'}];
-              comp.eventFields = [comp.caseField, field('LabelA', [], {
-                id: 'LabelA',
-                type: 'Collection',
-                collection_field_type: {
-                    id: 'MoneyGBP',
-                    type: 'MoneyGBP'
-                  }
-            }, '')];
-            comp.formGroup = new FormGroup({
-                LabelA: new FormControl(RAW_VALUES)
-            });
-            fixture.detectChanges();
+    it('should pass form field value when field is not read only and no case field value but form field value present', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text',
+      }, label);
+      comp.eventFields = [comp.caseField, field('LabelA', '', {
+        id: 'LabelA',
+        type: 'MultiSelectList',
+        fixed_list_items: [
+          {
+            code: 'ValueA',
+            label: 'Option A'
+          },
+          {
+            code: 'ValueC',
+            label: 'Option C'
+          },
+          {
+            code: 'ValueD',
+            label: 'Option D'
+          }
+        ]
+      }, '')];
+      comp.formGroup = new FormGroup({
+        LabelA: new FormControl(['ValueA', 'ValueD'])
+      });
+      fixture.detectChanges();
 
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: TRANSFORMED_VALUES}, label);
-        });
-
-        it('should pass form field value with comma delimited label items when both form and case field values present', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text'
-            },  label);
-            const RAW_VALUES = [{value: '12345'}, {value: '34888'}, {value: '9944521'}];
-            const TRANSFORMED_VALUES = [{value: '£123.45'}, {value: '£348.88'}, {value: '£99,445.21'}];
-            comp.eventFields = [comp.caseField, field('LabelA', [{value: 'ValueD'}, {value: 'ValueD'}, {value: 'ValueD'}], {
-                id: 'LabelA',
-                type: 'Collection',
-                collection_field_type: {
-                    id: 'MoneyGBP',
-                    type: 'MoneyGBP'
-                  }
-            }, '')];
-            comp.formGroup = new FormGroup({
-                LabelA: new FormControl(RAW_VALUES)
-            });
-            fixture.detectChanges();
-
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: TRANSFORMED_VALUES}, label);
-        });
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith(
+        { LabelB: '', LabelA: ['ValueA', 'ValueD'], 'LabelA-LABEL': ['Option A', 'Option D'] }, label, false);
     });
 
-    describe('Collection of Date type fields', () => {
+    it('should pass case field value when field is read only and no form field but case field value present', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text',
+      }, label);
+      comp.eventFields = [comp.caseField, field('LabelA', ['ValueC', 'ValueD'], {
+        id: 'LabelA',
+        type: 'MultiSelectList',
+        fixed_list_items: [
+          {
+            code: 'ValueA',
+            label: 'Option A'
+          },
+          {
+            code: 'ValueC',
+            label: 'Option C'
+          },
+          {
+            code: 'ValueD',
+            label: 'Option D'
+          }
+        ]
+      }, '')];
+      fixture.detectChanges();
 
-        it('should pass form field value with comma delimited label items when case field value but no form field value present', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text'
-            },  label);
-            const RAW_VALUES = [{value: '2018-03-07'}, {value: '2015-02-22'}, {value: '2017-12-12'}];
-            const TRANSFORMED_VALUES = [{value: '7 Mar 2018'}, {value: '22 Feb 2015'}, {value: '12 Dec 2017'}];
-            comp.eventFields = [comp.caseField, field('LabelA', RAW_VALUES, {
-                id: 'LabelA',
-                type: 'Collection',
-                collection_field_type: {
-                    id: 'Date',
-                    type: 'Date'
-                  }
-            }, '')];
-            fixture.detectChanges();
-
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: TRANSFORMED_VALUES}, label);
-        });
-
-        it('should pass form field value with comma delimited label items when form field value but no case field value present', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text'
-            },  label);
-            const RAW_VALUES = [{value: '2018-03-07'}, {value: '2015-02-22'}, {value: '2017-12-12'}];
-            const TRANSFORMED_VALUES = [{value: '7 Mar 2018'}, {value: '22 Feb 2015'}, {value: '12 Dec 2017'}];
-              comp.eventFields = [comp.caseField, field('LabelA', [], {
-                id: 'LabelA',
-                type: 'Collection',
-                collection_field_type: {
-                    id: 'Date',
-                    type: 'Date'
-                  }
-            }, '')];
-            comp.formGroup = new FormGroup({
-                LabelA: new FormControl(RAW_VALUES)
-            });
-            fixture.detectChanges();
-
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: TRANSFORMED_VALUES}, label);
-        });
-
-        it('should pass form field value with comma delimited label items when both form and case field values present', () => {
-            let label = 'someLabel';
-            comp.caseField = field('LabelB', '', {
-                id: 'LabelB',
-                type: 'Text'
-            },  label);
-            const RAW_VALUES = [{value: '2018-03-07'}, {value: '2015-02-22'}, {value: '2017-12-12'}];
-            const TRANSFORMED_VALUES = [{value: '7 Mar 2018'}, {value: '22 Feb 2015'}, {value: '12 Dec 2017'}];
-            comp.eventFields = [comp.caseField, field('LabelA', [{value: 'ValueD'}, {value: 'ValueD'}, {value: 'ValueD'}], {
-                id: 'LabelA',
-                type: 'Collection',
-                collection_field_type: {
-                    id: 'Date',
-                    type: 'Date'
-                  }
-            }, '')];
-            comp.formGroup = new FormGroup({
-                LabelA: new FormControl(RAW_VALUES)
-            });
-            fixture.detectChanges();
-
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: TRANSFORMED_VALUES}, label);
-        });
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith(
+        { LabelB: '', LabelA: ['ValueC', 'ValueD'], 'LabelA-LABEL': ['Option C', 'Option D'] }, label, false);
     });
+
+    it('should pass field form value when field is not read only and both form and case field values present', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text',
+      }, label);
+      comp.eventFields = [comp.caseField, field('LabelA', 'ValueC', {
+        id: 'LabelA',
+        type: 'MultiSelectList',
+        fixed_list_items: [
+          {
+            code: 'ValueA',
+            label: 'Option A'
+          },
+          {
+            code: 'ValueC',
+            label: 'Option C'
+          },
+          {
+            code: 'ValueD',
+            label: 'Option D'
+          }
+        ]
+      }, '')];
+      comp.formGroup = new FormGroup({
+        LabelA: new FormControl(['ValueA', 'ValueC'])
+      });
+      fixture.detectChanges();
+
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith(
+        { LabelB: '', LabelA: ['ValueA', 'ValueC'], 'LabelA-LABEL': ['Option A', 'Option C'] }, label, false);
+    });
+  });
+
+  describe('MoneyGBP type fields', () => {
+
+    it('should pass null value for null MoneyGBP', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text'
+      }, label);
+      comp.eventFields = [comp.caseField, field('LabelA', null, {
+        id: 'LabelA',
+        type: 'MoneyGBP'
+      }, '')];
+      fixture.detectChanges();
+
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: null }, label, false);
+    });
+
+    it('should pass case field value with MoneyGBP when case field value but no form field value present', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text'
+      }, label);
+      comp.eventFields = [comp.caseField, field('LabelA', '20055', {
+        id: 'LabelA',
+        type: 'MoneyGBP'
+      }, '')];
+      fixture.detectChanges();
+
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: '£200.55' }, label, false);
+    });
+
+    it('should pass form field value with MoneyGBP when form field value but no case field value present', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text'
+      }, label);
+      comp.eventFields = [comp.caseField, field('LabelA', '', {
+        id: 'LabelA',
+        type: 'MoneyGBP'
+      }, '')];
+      comp.formGroup = new FormGroup({
+        LabelA: new FormControl('20055')
+      });
+      fixture.detectChanges();
+
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: '£200.55' }, label, false);
+    });
+
+    it('should pass form field value with MoneyGBP when both form and case field values present', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text'
+      }, label);
+      comp.eventFields = [comp.caseField, field('LabelA', '99999', {
+        id: 'LabelA',
+        type: 'MoneyGBP'
+      }, '')];
+      comp.formGroup = new FormGroup({
+        LabelA: new FormControl('20055')
+      });
+      fixture.detectChanges();
+
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: '£200.55' }, label, false);
+    });
+  });
+
+  describe('Date type fields', () => {
+
+    it('should pass case field value with Date when case field value but no form field value present', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text'
+      }, label);
+      comp.eventFields = [comp.caseField, field('LabelA', '2018-03-07', {
+        id: 'LabelA',
+        type: 'Date'
+      }, '')];
+      fixture.detectChanges();
+
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: '7 Mar 2018' }, label, false);
+    });
+
+    it('should pass form field value with Date when form field value but no case field value present', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text'
+      }, label);
+      comp.eventFields = [comp.caseField, field('LabelA', '', {
+        id: 'LabelA',
+        type: 'Date'
+      }, '')];
+      comp.formGroup = new FormGroup({
+        LabelA: new FormControl('2018-03-07')
+      });
+      fixture.detectChanges();
+
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: '7 Mar 2018' }, label, false);
+    });
+
+    it('should pass form field value with Date when both form and case field values present', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text'
+      }, label);
+      comp.eventFields = [comp.caseField, field('LabelA', '2018-03-07', {
+        id: 'LabelA',
+        type: 'Date'
+      }, '')];
+      comp.formGroup = new FormGroup({
+        LabelA: new FormControl('2018-03-07')
+      });
+      fixture.detectChanges();
+
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: '7 Mar 2018' }, label, false);
+    });
+
+    it('should pass form field value with invalid date when both form and case field values present', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', undefined, {
+        id: 'LabelB',
+        type: 'Text'
+      }, label);
+      comp.eventFields = [comp.caseField, field('LabelA', '2018-03', {
+        id: 'LabelA',
+        type: 'Date'
+      }, '')];
+      comp.formGroup = new FormGroup({
+        LabelA: new FormControl('2018-03')
+      });
+      fixture.detectChanges();
+
+      expect(labelSubstitutionService.substituteLabel).
+      toHaveBeenCalledWith({ LabelB: undefined, LabelA: '{ Invalid Date: 2018-03 }' }, label, false);
+    });
+  });
+
+  describe('Collection type fields', () => {
+
+    it('should pass form field value with comma delimited text items when case field value but no form field value present', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text'
+      }, label);
+      const VALUES = [
+        {
+          value: 'Pierre',
+        },
+        {
+          value: 'Paul',
+        },
+        {
+          value: 'Jacques',
+        }
+      ];
+      comp.eventFields = [comp.caseField, field('LabelA', VALUES, {
+        id: 'LabelA',
+        type: 'Collection',
+        collection_field_type: {
+          id: 'Text',
+          type: 'Text'
+        }
+      }, '')];
+      fixture.detectChanges();
+
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: VALUES }, label, false);
+    });
+
+    it('should pass form field value with comma delimited text items when form field value but no case field value present', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text'
+      }, label);
+      const VALUES = [
+        {
+          value: 'Pierre',
+        },
+        {
+          value: 'Paul',
+        },
+        {
+          value: 'Jacques',
+        }
+      ];
+      comp.eventFields = [comp.caseField, field('LabelA', [], {
+        id: 'LabelA',
+        type: 'Collection',
+        collection_field_type: {
+          id: 'Text',
+          type: 'Text'
+        }
+      }, '')];
+      comp.formGroup = new FormGroup({
+        LabelA: new FormControl(VALUES)
+      });
+      fixture.detectChanges();
+
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: VALUES }, label, false);
+    });
+
+    it('should pass form field value with comma delimited text items when both form and case field values present', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text'
+      }, label);
+      const VALUES = [
+        {
+          value: 'Pierre',
+        },
+        {
+          value: 'Paul',
+        },
+        {
+          value: 'Jacques',
+        }
+      ];
+      comp.eventFields = [comp.caseField, field('LabelA', [
+        {
+          value: 'Tom',
+        },
+        {
+          value: 'George',
+        },
+        {
+          value: 'John',
+        }
+      ], {
+        id: 'LabelA',
+        type: 'Collection',
+        collection_field_type: {
+          id: 'Text',
+          type: 'Text'
+        }
+      }, '')];
+      comp.formGroup = new FormGroup({
+        LabelA: new FormControl(VALUES)
+      });
+      fixture.detectChanges();
+
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: VALUES }, label, false);
+    });
+  });
+
+  describe('Collection of fixed list type fields', () => {
+
+    it('should pass form field value with comma delimited label items when case field value but no form field value present', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text'
+      }, label);
+      const VALUES = [{ value: 'ValueA' }, { value: 'ValueC' }, { value: 'ValueD' }];
+      comp.eventFields = [comp.caseField, field('LabelA', VALUES, {
+        id: 'LabelA',
+        type: 'Collection',
+        collection_field_type: {
+          id: 'FixedList',
+          type: 'FixedList',
+          fixed_list_items: [
+            {
+              code: 'ValueA',
+              label: 'Option A'
+            },
+            {
+              code: 'ValueC',
+              label: 'Option C'
+            },
+            {
+              code: 'ValueD',
+              label: 'Option D'
+            }
+          ]
+        }
+      }, '')];
+      fixture.detectChanges();
+
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: VALUES }, label, false);
+    });
+
+    it('should pass form field value with comma delimited label items when form field value but no case field value present', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text'
+      }, label);
+      const VALUES = [{ value: 'ValueA' }, { value: 'ValueC' }, { value: 'ValueD' }];
+      comp.eventFields = [comp.caseField, field('LabelA', [], {
+        id: 'LabelA',
+        type: 'Collection',
+        collection_field_type: {
+          id: 'FixedList',
+          type: 'FixedList',
+          fixed_list_items: [
+            {
+              code: 'ValueA',
+              label: 'Option A'
+            },
+            {
+              code: 'ValueC',
+              label: 'Option C'
+            },
+            {
+              code: 'ValueD',
+              label: 'Option D'
+            }
+          ]
+        }
+      }, '')];
+      comp.formGroup = new FormGroup({
+        LabelA: new FormControl(VALUES)
+      });
+      fixture.detectChanges();
+
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: VALUES }, label, false);
+    });
+
+    it('should pass form field value with comma delimited label items when both form and case field values present', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text'
+      }, label);
+      const VALUES = [{ value: 'ValueA' }, { value: 'ValueC' }, { value: 'ValueD' }];
+      comp.eventFields = [comp.caseField, field('LabelA', [{ value: 'ValueD' }, { value: 'ValueD' }, { value: 'ValueD' }], {
+        id: 'LabelA',
+        type: 'Collection',
+        collection_field_type: {
+          id: 'FixedList',
+          type: 'FixedList',
+          fixed_list_items: [
+            {
+              code: 'ValueA',
+              label: 'Option A'
+            },
+            {
+              code: 'ValueC',
+              label: 'Option C'
+            },
+            {
+              code: 'ValueD',
+              label: 'Option D'
+            }
+          ]
+        }
+      }, '')];
+      comp.formGroup = new FormGroup({
+        LabelA: new FormControl(VALUES)
+      });
+      fixture.detectChanges();
+
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: VALUES }, label, false);
+    });
+  });
+
+  describe('Collection of MoneyGBP type fields', () => {
+
+    it('should pass form field value with comma delimited label items when case field value but no form field value present', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text'
+      }, label);
+      const RAW_VALUES = [{ value: '12345' }, { value: '34888' }, { value: '9944521' }];
+      const TRANSFORMED_VALUES = [{ value: '£123.45' }, { value: '£348.88' }, { value: '£99,445.21' }];
+      comp.eventFields = [comp.caseField, field('LabelA', RAW_VALUES, {
+        id: 'LabelA',
+        type: 'Collection',
+        collection_field_type: {
+          id: 'MoneyGBP',
+          type: 'MoneyGBP'
+        }
+      }, '')];
+      fixture.detectChanges();
+
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: TRANSFORMED_VALUES }, label, false);
+    });
+
+    it('should pass form field value with comma delimited label items when form field value but no case field value present', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text'
+      }, label);
+      const RAW_VALUES = [{ value: '12345' }, { value: '34888' }, { value: '9944521' }];
+      const TRANSFORMED_VALUES = [{ value: '£123.45' }, { value: '£348.88' }, { value: '£99,445.21' }];
+      comp.eventFields = [comp.caseField, field('LabelA', [], {
+        id: 'LabelA',
+        type: 'Collection',
+        collection_field_type: {
+          id: 'MoneyGBP',
+          type: 'MoneyGBP'
+        }
+      }, '')];
+      comp.formGroup = new FormGroup({
+        LabelA: new FormControl(RAW_VALUES)
+      });
+      fixture.detectChanges();
+
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: TRANSFORMED_VALUES }, label, false);
+    });
+
+    it('should pass form field value with comma delimited label items when both form and case field values present', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text'
+      }, label);
+      const RAW_VALUES = [{ value: '12345' }, { value: '34888' }, { value: '9944521' }];
+      const TRANSFORMED_VALUES = [{ value: '£123.45' }, { value: '£348.88' }, { value: '£99,445.21' }];
+      comp.eventFields = [comp.caseField, field('LabelA', [{ value: 'ValueD' }, { value: 'ValueD' }, { value: 'ValueD' }], {
+        id: 'LabelA',
+        type: 'Collection',
+        collection_field_type: {
+          id: 'MoneyGBP',
+          type: 'MoneyGBP'
+        }
+      }, '')];
+      comp.formGroup = new FormGroup({
+        LabelA: new FormControl(RAW_VALUES)
+      });
+      fixture.detectChanges();
+
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: TRANSFORMED_VALUES }, label, false);
+    });
+  });
+
+  describe('Collection of Date type fields', () => {
+
+    it('should pass form field value with comma delimited label items when case field value but no form field value present', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text'
+      }, label);
+      const RAW_VALUES = [{ value: '2018-03-07' }, { value: '2015-02-22' }, { value: '2017-12-12' }];
+      const TRANSFORMED_VALUES = [{ value: '7 Mar 2018' }, { value: '22 Feb 2015' }, { value: '12 Dec 2017' }];
+      comp.eventFields = [comp.caseField, field('LabelA', RAW_VALUES, {
+        id: 'LabelA',
+        type: 'Collection',
+        collection_field_type: {
+          id: 'Date',
+          type: 'Date'
+        }
+      }, '')];
+      fixture.detectChanges();
+
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: TRANSFORMED_VALUES }, label, false);
+    });
+
+    it('should pass form field value with comma delimited label items when form field value but no case field value present', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text'
+      }, label);
+      const RAW_VALUES = [{ value: '2018-03-07' }, { value: '2015-02-22' }, { value: '2017-12-12' }];
+      const TRANSFORMED_VALUES = [{ value: '7 Mar 2018' }, { value: '22 Feb 2015' }, { value: '12 Dec 2017' }];
+      comp.eventFields = [comp.caseField, field('LabelA', [], {
+        id: 'LabelA',
+        type: 'Collection',
+        collection_field_type: {
+          id: 'Date',
+          type: 'Date'
+        }
+      }, '')];
+      comp.formGroup = new FormGroup({
+        LabelA: new FormControl(RAW_VALUES)
+      });
+      fixture.detectChanges();
+
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: TRANSFORMED_VALUES }, label, false);
+    });
+
+    it('should pass form field value with comma delimited label items when both form and case field values present', () => {
+      let label = 'someLabel';
+      comp.caseField = field('LabelB', '', {
+        id: 'LabelB',
+        type: 'Text'
+      }, label);
+      const RAW_VALUES = [{ value: '2018-03-07' }, { value: '2015-02-22' }, { value: '2017-12-12' }];
+      const TRANSFORMED_VALUES = [{ value: '7 Mar 2018' }, { value: '22 Feb 2015' }, { value: '12 Dec 2017' }];
+      comp.eventFields = [comp.caseField, field('LabelA', [{ value: 'ValueD' }, { value: 'ValueD' }, { value: 'ValueD' }], {
+        id: 'LabelA',
+        type: 'Collection',
+        collection_field_type: {
+          id: 'Date',
+          type: 'Date'
+        }
+      }, '')];
+      comp.formGroup = new FormGroup({
+        LabelA: new FormControl(RAW_VALUES)
+      });
+      fixture.detectChanges();
+
+      expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: TRANSFORMED_VALUES }, label, false);
+    });
+  });
 });

--- a/src/shared/directives/substitutor/label-substitutor.directive.ts
+++ b/src/shared/directives/substitutor/label-substitutor.directive.ts
@@ -13,6 +13,7 @@ export class LabelSubstitutorDirective implements OnInit, OnDestroy {
   @Input() caseField: CaseField;
   @Input() eventFields: CaseField[] = [];
   @Input() formGroup: FormGroup;
+  @Input() isEmptyIfPlaceholderMissing: Boolean = false;
 
   initialLabel: string;
   initialHintText: string;
@@ -21,13 +22,14 @@ export class LabelSubstitutorDirective implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    if (this.caseField.label) {
+    this.initialLabel = this.getLabel();
+    if (this.initialLabel) {
       this.initialLabel = this.caseField.label;
       this.initialHintText = this.caseField.hint_text;
       this.formGroup = this.formGroup || new FormGroup({});
 
       let fields = this.getReadOnlyAndFormFields();
-      this.caseField.label = this.substituteLabel(fields, this.caseField.label);
+      this.setLabel(this.substituteLabel(fields, this.getLabel()));
       this.caseField.hint_text = this.substituteLabel(fields, this.caseField.hint_text);
     }
   }
@@ -47,7 +49,17 @@ export class LabelSubstitutorDirective implements OnInit, OnDestroy {
   }
 
   private substituteLabel(fields, label) {
-    return this.labelSubstitutionService.substituteLabel(fields, label);
+    return this.labelSubstitutionService.substituteLabel(fields, label, this.isEmptyIfPlaceholderMissing);
   }
 
+  private getLabel() {
+    return this.caseField.value || this.caseField.label;
+  }
+  private setLabel(label: string) {
+    if (this.caseField.value) {
+      this.caseField.value = label;
+    } else {
+      this.caseField.label = label;
+    }
+  }
 }

--- a/src/shared/directives/substitutor/services/label-substitution.service.spec.ts
+++ b/src/shared/directives/substitutor/services/label-substitution.service.spec.ts
@@ -1,9 +1,11 @@
 import { LabelSubstitutionService } from './label-substitution.service';
+import { CaseReferencePipe } from '../../../pipes/case-reference/case-reference.pipe'
 
 describe('LabelSubstitutionService', () => {
 
   let labelSubstitutionService: LabelSubstitutionService;
-
+  let caseReferencePipe: CaseReferencePipe;
+  let isEmptyIfPlaceholderMissing: Boolean = false;
   beforeEach(() => {
     labelSubstitutionService = new LabelSubstitutionService();
   });
@@ -14,98 +16,98 @@ describe('LabelSubstitutionService', () => {
       let pageFormFields = [{}];
       let label = 'Email for ${PersonFirstName} is';
 
-      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label);
+      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label, isEmptyIfPlaceholderMissing);
 
       expect(actual).toBe(label);
     });
 
     it('should not substitute if no label', () => {
-      let pageFormFields = [{'PersonFirstName': 'John'}];
+      let pageFormFields = [{ 'PersonFirstName': 'John' }];
       let label = null;
 
-      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label);
+      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label, isEmptyIfPlaceholderMissing);
 
       expect(actual).toBeNull();
     });
 
     it('should substitute with empty value if page form field is matched and has null value', () => {
-      let pageFormFields = {'PersonFirstName' : null};
+      let pageFormFields = { 'PersonFirstName': null };
       let label = 'Email for ${PersonFirstName} is';
 
-      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label);
+      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label, isEmptyIfPlaceholderMissing);
 
       expect(actual).toBe('Email for  is');
     });
 
     it('should substitute with empty value if page form field is matched and has empty value', () => {
-      let pageFormFields = {'PersonFirstName' : ''};
+      let pageFormFields = { 'PersonFirstName': '' };
       let label = 'Email for ${PersonFirstName} is';
 
-      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label);
+      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label, isEmptyIfPlaceholderMissing);
 
       expect(actual).toBe('Email for  is');
     });
 
     it('should substitute with value if page form field is matched and has value', () => {
-      let pageFormFields = {'Age': 34, 'PersonFirstName' : 'John'};
+      let pageFormFields = { 'Age': 34, 'PersonFirstName': 'John' };
       let label = 'Email for ${PersonFirstName} of ${Age} is';
 
-      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label);
+      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label, isEmptyIfPlaceholderMissing);
 
       expect(actual).toBe('Email for John of 34 is');
     });
 
     it('should substitute with multiple values multiple times if page form field is matched and has value', () => {
-      let pageFormFields = {'PersonFirstName' : 'John', 'PersonLastName': 'Smith'};
+      let pageFormFields = { 'PersonFirstName': 'John', 'PersonLastName': 'Smith' };
       let label = 'Email for ${PersonFirstName} ${PersonLastName} is ${PersonFirstName}.${PersonLastName}@gmail.com';
 
-      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label);
+      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label, isEmptyIfPlaceholderMissing);
 
       expect(actual).toBe('Email for John Smith is John.Smith@gmail.com');
     });
 
     it('should only substitute with the values that are matched from page form fields', () => {
-      let pageFormFields = {'Age' : null, 'Markdownlabel': null, 'PersonAddress': {}, 'D8Document': 'photo.jpg'};
+      let pageFormFields = { 'Age': null, 'Markdownlabel': null, 'PersonAddress': {}, 'D8Document': 'photo.jpg' };
       let label = `First Name is \${Age} years old \${Age} \
 and markdown is \${Markdownlabel} and address is \${Address} and document \${D8Document}`;
 
-      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label);
+      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label, isEmptyIfPlaceholderMissing);
 
       expect(actual).toBe('First Name is  years old  and markdown is  and address is ${Address} and document photo.jpg');
     });
 
     it('should not substitute fields ids with special characters but _', () => {
-      let pageFormFields = {'_1' : 'one', '%2': 'two', '?3': {'field': 'value'}, '$4': 'four', '_5': 'five'};
+      let pageFormFields = { '_1': 'one', '%2': 'two', '?3': { 'field': 'value' }, '$4': 'four', '_5': 'five' };
       let label = '${_1} ${%2} ${?3} ${$4} {_5}';
 
-      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label);
+      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label, isEmptyIfPlaceholderMissing);
 
       expect(actual).toBe('one ${%2} ${?3} ${$4} {_5}');
     });
 
     it('should not substitute nested fields', () => {
-      let pageFormFields = {'_1' : 'one'};
+      let pageFormFields = { '_1': 'one' };
       let label = 'This ${_1} but not this ${${_1}} and not this ${field${_1}field} but this ${_1} too';
 
-      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label);
+      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label, isEmptyIfPlaceholderMissing);
 
       expect(actual).toBe('This one but not this ${${_1}} and not this ${field${_1}field} but this one too');
     });
 
     it('should not substitute if value of a field to substitute refers itself', () => {
-      let pageFormFields = {'_1_one': '${_1_one}'};
+      let pageFormFields = { '_1_one': '${_1_one}' };
       let label = '${_1_one}';
 
-      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label);
+      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label, isEmptyIfPlaceholderMissing);
 
       expect(actual).toBe('${_1_one}');
     });
 
     it('should substitute fields with multi select values', () => {
-      let pageFormFields = {'_1_one': ['code1', 'code2'], '_1_one-LABEL': ['label1', 'label2'], '_3_three': 'simpleValue'};
+      let pageFormFields = { '_1_one': ['code1', 'code2'], '_1_one-LABEL': ['label1', 'label2'], '_3_three': 'simpleValue' };
       let label = '${_1_one} ${_3_three}';
 
-      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label);
+      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label, isEmptyIfPlaceholderMissing);
 
       expect(actual).toBe('label1, label2 simpleValue');
     });
@@ -114,20 +116,24 @@ and markdown is \${Markdownlabel} and address is \${Address} and document \${D8D
   describe('complex types', () => {
 
     it('should substitute complex nested field with simple type leaf value', () => {
-      let pageFormFields = {'complex': {'nested': 'nested value', 'nested2': 'nested value2'
-        , 'nested3': {'doubleNested': 'double nested'}}};
+      let pageFormFields = {
+        'complex': {
+          'nested': 'nested value', 'nested2': 'nested value2'
+          , 'nested3': { 'doubleNested': 'double nested' }
+        }
+      };
       let label = '${complex.nested} and ${complex.nested2} and ${complex.nested3} and ${complex.nested3.doubleNested}';
 
-      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label);
+      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label, isEmptyIfPlaceholderMissing);
 
       expect(actual).toBe('nested value and nested value2 and ${complex.nested3} and double nested');
     });
 
     it('should substitute if complex nested field refers existent field', () => {
-      let pageFormFields = {'complex': {'nested': {'doubleNested': 'double nested'}}};
+      let pageFormFields = { 'complex': { 'nested': { 'doubleNested': 'double nested' } } };
       let label = '${complex} and ${complex.nested} and ${complex.nested.} and ${complex.nested.double} and ${complex.nested.doubleNested}';
 
-      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label);
+      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label, isEmptyIfPlaceholderMissing);
 
       expect(actual).toBe('${complex} and ${complex.nested} and ${complex.nested.} and ${complex.nested.double} and double nested');
     });
@@ -136,38 +142,40 @@ and markdown is \${Markdownlabel} and address is \${Address} and document \${D8D
   describe('collection types', () => {
 
     it('should substitute fields with text collection values', () => {
-      let pageFormFields = {'_1_one': [{'value': 'value1'}, {'value': 'value2'}], '_3_three': 'simpleValue'};
+      let pageFormFields = { '_1_one': [{ 'value': 'value1' }, { 'value': 'value2' }], '_3_three': 'simpleValue' };
       let label = '${_1_one} ${_3_three}';
 
-      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label);
+      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label, isEmptyIfPlaceholderMissing);
 
       expect(actual).toBe('value1, value2 simpleValue');
     });
 
     it('should substitute fields with number collection values', () => {
-      let pageFormFields = {'_1_one': [{'value': 35}, {'value': 45}], '_3_three': 'simpleValue'};
+      let pageFormFields = { '_1_one': [{ 'value': 35 }, { 'value': 45 }], '_3_three': 'simpleValue' };
       let label = '${_1_one} ${_3_three}';
 
-      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label);
+      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label, isEmptyIfPlaceholderMissing);
 
       expect(actual).toBe('35, 45 simpleValue');
     });
 
     it('should not substitute fields with complex collection values', () => {
-      let pageFormFields = {'_1_one': [{'value': {'id': 'complex1'}}, {'value': {'id': 'complex2'}}], '_3_three': 'simpleValue'};
+      let pageFormFields = { '_1_one': [{ 'value': { 'id': 'complex1' } }, { 'value': { 'id': 'complex2' } }], '_3_three': 'simpleValue' };
       let label = '${_1_one} ${_3_three}';
 
-      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label);
+      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label, isEmptyIfPlaceholderMissing);
 
       expect(actual).toBe('${_1_one} simpleValue');
     });
 
     it('should not substitute fields with collection of collection values', () => {
-      let pageFormFields = {'_1_one': [{'value': [{'value': {'id': 'complex1'}}]}, {'value': [{'value': {'id': 'complex2'}}]}],
-        '_3_three': 'simpleValue'};
+      let pageFormFields = {
+        '_1_one': [{ 'value': [{ 'value': { 'id': 'complex1' } }] }, { 'value': [{ 'value': { 'id': 'complex2' } }] }],
+        '_3_three': 'simpleValue'
+      };
       let label = '${_1_one} ${_3_three}';
 
-      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label);
+      let actual = labelSubstitutionService.substituteLabel(pageFormFields, label, isEmptyIfPlaceholderMissing);
 
       expect(actual).toBe('${_1_one} simpleValue');
     });

--- a/src/shared/directives/substitutor/services/label-substitution.service.ts
+++ b/src/shared/directives/substitutor/services/label-substitution.service.ts
@@ -10,7 +10,7 @@ export class LabelSubstitutionService {
     private static readonly OPENING_PLACEHOLDER = '{';
     private static readonly CLOSING_PLACEHOLDER = '}';
 
-    substituteLabel(pageFormFields, label): string {
+    substituteLabel(pageFormFields, label, isEmptyIfPlaceholderMissing): string {
         let startSubstitutionIndex = -1;
         let fieldIdToSubstitute = '';
         let isCollecting = false;
@@ -22,7 +22,7 @@ export class LabelSubstitutionService {
                 } else if (isCollecting) {
                     if (this.isClosingPlaceholder(label, scanIndex)) {
                         if (this.isMatchingLabelIdPattern(fieldIdToSubstitute)
-                            && this.isFieldIdInFormFields(fieldIdToSubstitute, pageFormFields)) {
+                            && this.isFieldIdInFormFields(fieldIdToSubstitute, pageFormFields, isEmptyIfPlaceholderMissing)) {
                             label = this.substitute(pageFormFields, label, startSubstitutionIndex, fieldIdToSubstitute);
                             scanIndex = this.resetScanIndexAfterSubstitution(startSubstitutionIndex, pageFormFields, fieldIdToSubstitute);
                         }
@@ -41,8 +41,11 @@ export class LabelSubstitutionService {
         return fieldIdToSubstitute.match(LabelSubstitutionService.LABEL_ID_PATTERN);
     }
 
-    private isFieldIdInFormFields(fieldIdToSubstitute, pageFormFields) {
+    private isFieldIdInFormFields(fieldIdToSubstitute, pageFormFields, isEmptyIfPlaceholderMissing) {
         let fieldValue = this.getFieldValue(pageFormFields, fieldIdToSubstitute);
+        if (isEmptyIfPlaceholderMissing === true) {
+            fieldValue = fieldValue === undefined ? '' : fieldValue;
+        }
         return fieldValue ? this.isSimpleTypeOrCollectionOfSimpleTypes(fieldValue) : fieldValue !== undefined;
     }
 
@@ -72,8 +75,8 @@ export class LabelSubstitutionService {
 
     private substitute(pageFormFields, label, startSubstitutionIndex, fieldIdToSubstitute): string {
         let replacedString = label.substring(startSubstitutionIndex)
-                                .replace('${'.concat(fieldIdToSubstitute).concat('}'),
-                                        this.getSubstitutionValueOrEmpty(pageFormFields, fieldIdToSubstitute));
+            .replace('${'.concat(fieldIdToSubstitute).concat('}'),
+                this.getSubstitutionValueOrEmpty(pageFormFields, fieldIdToSubstitute));
         return label.substring(0, startSubstitutionIndex).concat(replacedString);
     }
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-2323

Full Name
As a court staff user,
When I view WorkBasketResults or SearchResults screens
I expect to see the citizens first name and last name joined together as a well formed full name.
And the full name is displayed in a single column

Note:- Due to certain changes failing breaking when merging code from master , I have created a branch from master and copied those changes individually on it.Tested it again locally.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
