### PR TITLE
Rdm-2323-1 - label substitution

### DIFF
--- a/src/shared/directives/substitutor/label-substitutor.directive.ts
+++ b/src/shared/directives/substitutor/label-substitutor.directive.ts
@@ -56,10 +56,10 @@ export class LabelSubstitutorDirective implements OnInit, OnDestroy {
     return this.caseField.value || this.caseField.label;
   }
   private setLabel(label: string) {
-    if (this.caseField.value) {
-      this.caseField.value = label;
-    } else {
+    if (this.caseField.value == null) {
       this.caseField.label = label;
+    } else {
+      this.caseField.value = label;
     }
   }
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-2323

Full Name
As a court staff user,
When I view WorkBasketResults or SearchResults screens
I expect to see the citizens first name and last name joined together as a well formed full name.
And the full name is displayed in a single column

Note:- Due to certain changes failing breaking when merging code from master , I have created a branch from master and copied those changes individually on it.Tested it again locally.

**Does this PR introduce a breaking change?** (check one with "x")

```
[X] Yes
[ ] No
```
