### PR TITLE
Ensure yarn.lock is kept up-to-date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 install:
   - npm install -g codecov
   - npm install -g @angular/cli
-  - yarn install
+  - yarn install --frozen-lockfile
 script:
   - yarn --version
   - yarn lint


### PR DESCRIPTION
This ensure a build will fail if yarn.lock needs updating during `yarn
install`.  This should also ensure that anyone doing `yarn add` will
only be commiting changes that actually were caused by the add not by a
micreant install.