### PR TITLE
RDM-3574 Consume new V2 draft endpoints

### DIFF
--- a/demo/src/app/app.config.ts
+++ b/demo/src/app/app.config.ts
@@ -69,11 +69,11 @@ export class AppConfig extends AbstractAppConfig {
       + `/case-history`;
   }
 
-  public getCreateOrUpdateDraftsUrl(jid: string, ctid: string, eventData: CaseEventData) {
-    return this.getCaseDataUrl() + `/caseworkers/:uid/jurisdictions/${jid}/case-types/${ctid}/event-trigger/${eventData.event.id}/drafts/`;
+  public getCreateOrUpdateDraftsUrl(ctid: string) {
+    return this.getCaseDataUrl() + `/case-types/${ctid}/drafts/`;
   }
 
   public getViewOrDeleteDraftsUrl(jid: string, ctid: string, did: string) {
-    return this.getCaseDataUrl() + `/caseworkers/:uid/jurisdictions/${jid}/case-types/${ctid}/drafts/${did}`;
+    return this.getCaseDataUrl() + `/drafts/${did}`;
   }
 }

--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -10,11 +10,7 @@ export abstract class AbstractAppConfig {
   abstract getPostcodeLookupUrl(): string;
   abstract getOAuth2ClientId(): string;
   abstract getPaymentsUrl(): string;
-<<<<<<< Updated upstream
-  abstract getCreateOrUpdateDraftsUrl(jid: string, ctid: string): string
-=======
   abstract getCreateOrUpdateDraftsUrl(ctid: string): string
->>>>>>> Stashed changes
   abstract getViewOrDeleteDraftsUrl(did: string): string
 }
 

--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -10,7 +10,11 @@ export abstract class AbstractAppConfig {
   abstract getPostcodeLookupUrl(): string;
   abstract getOAuth2ClientId(): string;
   abstract getPaymentsUrl(): string;
+<<<<<<< Updated upstream
   abstract getCreateOrUpdateDraftsUrl(jid: string, ctid: string): string
+=======
+  abstract getCreateOrUpdateDraftsUrl(ctid: string): string
+>>>>>>> Stashed changes
   abstract getViewOrDeleteDraftsUrl(did: string): string
 }
 

--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -10,8 +10,8 @@ export abstract class AbstractAppConfig {
   abstract getPostcodeLookupUrl(): string;
   abstract getOAuth2ClientId(): string;
   abstract getPaymentsUrl(): string;
-  abstract getCreateOrUpdateDraftsUrl(jid: string, ctid: string, eventData: CaseEventData): string
-  abstract getViewOrDeleteDraftsUrl(jid: string, ctid: string, did: string): string
+  abstract getCreateOrUpdateDraftsUrl(jid: string, ctid: string): string
+  abstract getViewOrDeleteDraftsUrl(did: string): string
 }
 
 export class CaseEditorConfig {

--- a/src/shared/components/case-editor/case-create/case-create.component.spec.ts
+++ b/src/shared/components/case-editor/case-create/case-create.component.spec.ts
@@ -165,7 +165,7 @@ describe('CaseCreateComponent event trigger resolved and draft does not exist', 
   it('should create a draft when saveDraft called with sanitised data', () => {
     component.saveDraft()(SANITISED_EDIT_FORM);
 
-    expect(draftService.createOrUpdateDraft).toHaveBeenCalledWith(JID, CTID, undefined, SANITISED_EDIT_FORM);
+    expect(draftService.createOrUpdateDraft).toHaveBeenCalledWith(CTID, undefined, SANITISED_EDIT_FORM);
   });
 
 });
@@ -272,7 +272,7 @@ describe('CaseCreateComponent event trigger resolved and draft does exist', () =
   it('should update draft when saveDraft called with sanitised data for second time', () => {
     component.saveDraft()(SANITISED_EDIT_FORM);
 
-    expect(draftService.createOrUpdateDraft).toHaveBeenCalledWith(JID, CTID, DRAFT_PREFIX + DRAFT_ID, SANITISED_EDIT_FORM);
+    expect(draftService.createOrUpdateDraft).toHaveBeenCalledWith(CTID, DRAFT_PREFIX + DRAFT_ID, SANITISED_EDIT_FORM);
   });
 });
 

--- a/src/shared/components/case-editor/case-create/case-create.component.ts
+++ b/src/shared/components/case-editor/case-create/case-create.component.ts
@@ -62,10 +62,9 @@ export class CaseCreateComponent implements OnInit {
 
   saveDraft(): (caseEventData: CaseEventData) => Observable<Draft> {
     if (this.eventTrigger.can_save_draft) {
-      return (caseEventData: CaseEventData) => this.draftService.createOrUpdateDraft(this.jurisdiction,
-            this.caseType,
-            this.eventTrigger.case_id,
-            caseEventData);
+      return (caseEventData: CaseEventData) => this.draftService.createOrUpdateDraft(this.caseType,
+                                                                                     this.eventTrigger.case_id,
+                                                                                     caseEventData);
     }
   }
 

--- a/src/shared/services/draft/draft.service.spec.ts
+++ b/src/shared/services/draft/draft.service.spec.ts
@@ -1,5 +1,5 @@
 import { Observable, throwError } from 'rxjs';
-import { Response, ResponseOptions } from '@angular/http';
+import { Response, ResponseOptions, Headers } from '@angular/http';
 import createSpyObj = jasmine.createSpyObj;
 import { DraftService } from './draft.service';
 import { AbstractAppConfig } from '../../../app.config';

--- a/src/shared/services/draft/draft.service.spec.ts
+++ b/src/shared/services/draft/draft.service.spec.ts
@@ -79,14 +79,18 @@ describe('Drafts Service', () => {
         .subscribe(
           data => expect(data).toEqual(DRAFT_RESPONSE)
         );
-      expect(httpService.post).toHaveBeenCalledWith(CREATE_OR_UPDATE_DRAFT_URL, CASE_EVENT_DATA);
+      expect(httpService.post).toHaveBeenCalledWith(CREATE_OR_UPDATE_DRAFT_URL, CASE_EVENT_DATA, {
+        headers: new Headers({
+          'experimental': 'true',
+          'Accept': DraftService.V2_MEDIATYPE_DRAFT_CREATE
+        })});
     });
 
     it('should set error when error is thrown when creating draft', () => {
       httpService.post.and.returnValue(throwError(ERROR));
 
       draftService.createDraft(JID, CT_ID, CASE_EVENT_DATA)
-        .subscribe(data => {
+        .subscribe(_ => {
         }, err => {
           expect(err).toEqual(ERROR);
           expect(errorService.setError).toHaveBeenCalledWith(ERROR);
@@ -99,14 +103,18 @@ describe('Drafts Service', () => {
         .subscribe(
           data => expect(data).toEqual(DRAFT_RESPONSE)
         );
-      expect(httpService.put).toHaveBeenCalledWith(CREATE_OR_UPDATE_DRAFT_URL + Draft.stripDraftId(DRAFT_ID), CASE_EVENT_DATA);
+      expect(httpService.put).toHaveBeenCalledWith(CREATE_OR_UPDATE_DRAFT_URL + Draft.stripDraftId(DRAFT_ID), CASE_EVENT_DATA, {
+        headers: new Headers({
+          'experimental': 'true',
+          'Accept': DraftService.V2_MEDIATYPE_DRAFT_UPDATE
+        })});
     });
 
     it('should set error when error is thrown when updating draft', () => {
       httpService.put.and.returnValue(throwError(ERROR));
 
       draftService.updateDraft(JID, CT_ID, DRAFT_ID, CASE_EVENT_DATA)
-        .subscribe(data => {
+        .subscribe(_ => {
         }, err => {
           expect(err).toEqual(ERROR);
           expect(errorService.setError).toHaveBeenCalledWith(ERROR);
@@ -147,7 +155,11 @@ describe('Drafts Service', () => {
         .subscribe(
           data => expect(data).toEqual(CASE_VIEW_DATA)
         );
-      expect(httpService.get).toHaveBeenCalledWith(GET_OR_DELETE_DRAFT_URL);
+      expect(httpService.get).toHaveBeenCalledWith(GET_OR_DELETE_DRAFT_URL, {
+        headers: new Headers({
+          'experimental': 'true',
+          'Accept': DraftService.V2_MEDIATYPE_DRAFT_READ
+        })});
     });
 
     it('should set error when error is thrown when getting draft', () => {
@@ -172,7 +184,11 @@ describe('Drafts Service', () => {
       draftService
         .deleteDraft(DRAFT_ID);
 
-      expect(httpService.delete).toHaveBeenCalledWith(GET_OR_DELETE_DRAFT_URL);
+      expect(httpService.delete).toHaveBeenCalledWith(GET_OR_DELETE_DRAFT_URL, {
+        headers: new Headers({
+          'experimental': 'true',
+          'Accept': DraftService.V2_MEDIATYPE_DRAFT_DELETE
+        })});
     });
 
     it('should set error when error is thrown when deleting draft', () => {

--- a/src/shared/services/draft/draft.service.spec.ts
+++ b/src/shared/services/draft/draft.service.spec.ts
@@ -13,9 +13,8 @@ describe('Drafts Service', () => {
   const CT_ID = 'TestAddressBookCase';
   const DRAFT_ID = 'Draft1';
   const EVENT_TRIGGER_ID = 'createCase';
-  const CREATE_OR_UPDATE_DRAFT_URL = DATA_URL +
-    `/caseworkers/:uid/jurisdictions/${JID}/case-types/${CT_ID}/event-trigger/${EVENT_TRIGGER_ID}/drafts/`;
-  const GET_OR_DELETE_DRAFT_URL = DATA_URL + `/caseworkers/:uid/jurisdictions/${JID}/case-types/${CT_ID}/drafts/1`;
+  const CREATE_OR_UPDATE_DRAFT_URL = DATA_URL + `/internal/case-types/${CT_ID}/drafts/`;
+  const GET_OR_DELETE_DRAFT_URL = DATA_URL + `/internal/drafts/1`;
   const ERROR: HttpError = new HttpError();
   ERROR.message = 'Critical error!';
 
@@ -144,7 +143,7 @@ describe('Drafts Service', () => {
 
     it('should get draft on server', () => {
       draftService
-        .getDraft(JID, CT_ID, DRAFT_ID)
+        .getDraft(DRAFT_ID)
         .subscribe(
           data => expect(data).toEqual(CASE_VIEW_DATA)
         );
@@ -154,8 +153,8 @@ describe('Drafts Service', () => {
     it('should set error when error is thrown when getting draft', () => {
       httpService.get.and.returnValue(throwError(ERROR));
       draftService
-        .getDraft(JID, CT_ID, DRAFT_ID)
-        .subscribe(data => {
+        .getDraft(DRAFT_ID)
+        .subscribe(_ => {
         }, err => {
           expect(err).toEqual(ERROR);
           expect(errorService.setError).toHaveBeenCalledWith(ERROR);
@@ -171,7 +170,7 @@ describe('Drafts Service', () => {
 
     it('should delete draft on server', () => {
       draftService
-        .deleteDraft(JID, CT_ID, DRAFT_ID);
+        .deleteDraft(DRAFT_ID);
 
       expect(httpService.delete).toHaveBeenCalledWith(GET_OR_DELETE_DRAFT_URL);
     });
@@ -179,8 +178,8 @@ describe('Drafts Service', () => {
     it('should set error when error is thrown when deleting draft', () => {
       httpService.delete.and.returnValue(throwError(ERROR));
       draftService
-        .deleteDraft(JID, CT_ID, DRAFT_ID)
-        .subscribe(data => {
+        .deleteDraft(DRAFT_ID)
+        .subscribe(_ => {
         }, err => {
           expect(err).toEqual(ERROR);
           expect(errorService.setError).toHaveBeenCalledWith(ERROR);

--- a/src/shared/services/draft/draft.service.spec.ts
+++ b/src/shared/services/draft/draft.service.spec.ts
@@ -75,7 +75,7 @@ describe('Drafts Service', () => {
     it('should create a draft on server', () => {
       let UNDEFINED_DRAFT_ID = undefined;
       draftService
-        .createOrUpdateDraft(JID, CT_ID, UNDEFINED_DRAFT_ID, CASE_EVENT_DATA)
+        .createOrUpdateDraft(CT_ID, UNDEFINED_DRAFT_ID, CASE_EVENT_DATA)
         .subscribe(
           data => expect(data).toEqual(DRAFT_RESPONSE)
         );
@@ -89,7 +89,7 @@ describe('Drafts Service', () => {
     it('should set error when error is thrown when creating draft', () => {
       httpService.post.and.returnValue(throwError(ERROR));
 
-      draftService.createDraft(JID, CT_ID, CASE_EVENT_DATA)
+      draftService.createDraft(CT_ID, CASE_EVENT_DATA)
         .subscribe(_ => {
         }, err => {
           expect(err).toEqual(ERROR);
@@ -99,7 +99,7 @@ describe('Drafts Service', () => {
 
     it('should update a draft on server', () => {
       draftService
-        .createOrUpdateDraft(JID, CT_ID, DRAFT_ID, CASE_EVENT_DATA)
+        .createOrUpdateDraft(CT_ID, DRAFT_ID, CASE_EVENT_DATA)
         .subscribe(
           data => expect(data).toEqual(DRAFT_RESPONSE)
         );
@@ -113,7 +113,7 @@ describe('Drafts Service', () => {
     it('should set error when error is thrown when updating draft', () => {
       httpService.put.and.returnValue(throwError(ERROR));
 
-      draftService.updateDraft(JID, CT_ID, DRAFT_ID, CASE_EVENT_DATA)
+      draftService.updateDraft(CT_ID, DRAFT_ID, CASE_EVENT_DATA)
         .subscribe(_ => {
         }, err => {
           expect(err).toEqual(ERROR);

--- a/src/shared/services/draft/draft.service.ts
+++ b/src/shared/services/draft/draft.service.ts
@@ -1,12 +1,22 @@
 import { Injectable } from '@angular/core';
 import { Observable, throwError } from 'rxjs';
-import { Response } from '@angular/http';
+import { Response, Headers } from '@angular/http';
 import { AbstractAppConfig } from '../../../app.config';
 import { HttpService, HttpErrorService } from '../http';
 import { CaseEventData, Draft, DRAFT_PREFIX, CaseView } from '../../domain';
 
 @Injectable()
 export class DraftService {
+
+  public static readonly V2_MEDIATYPE_DRAFT_CREATE =
+    'application/vnd.uk.gov.hmcts.ccd-data-store-api.ui-draft-create.v2+json;charset=UTF-8';
+  public static readonly V2_MEDIATYPE_DRAFT_UPDATE =
+    'application/vnd.uk.gov.hmcts.ccd-data-store-api.ui-draft-update.v2+json;charset=UTF-8';
+  public static readonly V2_MEDIATYPE_DRAFT_READ =
+    'application/vnd.uk.gov.hmcts.ccd-data-store-api.ui-draft-read.v2+json;charset=UTF-8';
+  public static readonly V2_MEDIATYPE_DRAFT_DELETE =
+    'application/vnd.uk.gov.hmcts.ccd-data-store-api.ui-draft-delete.v2+json;charset=UTF-8';
+
   constructor(
     private http: HttpService,
     private appConfig: AbstractAppConfig,
@@ -14,9 +24,15 @@ export class DraftService {
   ) {}
 
   createDraft(jid: string, ctid: string, eventData: CaseEventData): Observable<Draft> {
-    const saveDraftEndpoint = this.appConfig.getCreateOrUpdateDraftsUrl(jid, ctid, eventData);
+    const url = this.appConfig.getCreateOrUpdateDraftsUrl(jid, ctid);
+
+    const headers = new Headers({
+      'Accept': DraftService.V2_MEDIATYPE_DRAFT_CREATE,
+      'experimental': 'true',
+    });
+
     return this.http
-      .post(saveDraftEndpoint, eventData)
+      .post(url, eventData, {headers})
       .map(response => response.json())
       .catch((error: any): any => {
         this.errorService.setError(error);
@@ -25,9 +41,15 @@ export class DraftService {
   }
 
   updateDraft(jid: string, ctid: string, draftId: string, eventData: CaseEventData): Observable<Draft> {
-    const saveDraftEndpoint = this.appConfig.getCreateOrUpdateDraftsUrl(jid, ctid, eventData) + draftId;
+    const url = this.appConfig.getCreateOrUpdateDraftsUrl(jid, ctid) + draftId;
+
+    const headers = new Headers({
+      'Accept': DraftService.V2_MEDIATYPE_DRAFT_UPDATE,
+      'experimental': 'true',
+    });
+
     return this.http
-      .put(saveDraftEndpoint, eventData)
+      .put(url, eventData, {headers})
       .map(response => response.json())
       .catch((error: any): any => {
         this.errorService.setError(error);
@@ -35,10 +57,16 @@ export class DraftService {
       });
   }
 
-  getDraft(jid: string, ctid: string, draftId: string): Observable<CaseView> {
-    const url = this.appConfig.getViewOrDeleteDraftsUrl(jid, ctid, draftId.slice(DRAFT_PREFIX.length));
+  getDraft(draftId: string): Observable<CaseView> {
+    const url = this.appConfig.getViewOrDeleteDraftsUrl(draftId.slice(DRAFT_PREFIX.length));
+
+    const headers = new Headers({
+      'Accept': DraftService.V2_MEDIATYPE_DRAFT_READ,
+      'experimental': 'true',
+    });
+
     return this.http
-      .get(url)
+      .get(url, {headers})
       .map(response => response.json())
       .catch((error: any): any => {
         this.errorService.setError(error);
@@ -46,10 +74,16 @@ export class DraftService {
       });
   }
 
-  deleteDraft(jid: string, ctid: string, draftId: string): Observable<{} | Response> {
-    const url = this.appConfig.getViewOrDeleteDraftsUrl(jid, ctid, draftId.slice(DRAFT_PREFIX.length));
+  deleteDraft(draftId: string): Observable<{} | Response> {
+    const url = this.appConfig.getViewOrDeleteDraftsUrl(draftId.slice(DRAFT_PREFIX.length));
+
+    const headers = new Headers({
+      'Accept': DraftService.V2_MEDIATYPE_DRAFT_DELETE,
+      'experimental': 'true',
+    });
+
     return this.http
-      .delete(url)
+      .delete(url, {headers})
       .catch((error: any): any => {
         this.errorService.setError(error);
         return throwError(error);

--- a/src/shared/services/draft/draft.service.ts
+++ b/src/shared/services/draft/draft.service.ts
@@ -4,10 +4,12 @@ import { Response, Headers } from '@angular/http';
 import { AbstractAppConfig } from '../../../app.config';
 import { HttpService, HttpErrorService } from '../http';
 import { CaseEventData, Draft, DRAFT_PREFIX, CaseView } from '../../domain';
+import { Headers } from '@angular/http';
 
 @Injectable()
 export class DraftService {
 
+<<<<<<< Updated upstream
   public static readonly V2_MEDIATYPE_DRAFT_CREATE =
     'application/vnd.uk.gov.hmcts.ccd-data-store-api.ui-draft-create.v2+json;charset=UTF-8';
   public static readonly V2_MEDIATYPE_DRAFT_UPDATE =
@@ -16,6 +18,16 @@ export class DraftService {
     'application/vnd.uk.gov.hmcts.ccd-data-store-api.ui-draft-read.v2+json;charset=UTF-8';
   public static readonly V2_MEDIATYPE_DRAFT_DELETE =
     'application/vnd.uk.gov.hmcts.ccd-data-store-api.ui-draft-delete.v2+json;charset=UTF-8';
+=======
+  public static readonly V2_MEDIATYPE_DRAFT_READ =
+  'application/vnd.uk.gov.hmcts.ccd-data-store-api.ui-draft-read.v2+json;charset=UTF-8';
+  public static readonly V2_MEDIATYPE_DRAFT_CREATE =
+  'application/vnd.uk.gov.hmcts.ccd-data-store-api.ui-draft-create.v2+json;charset=UTF-8';
+  public static readonly V2_MEDIATYPE_DRAFT_UPDATE =
+  'application/vnd.uk.gov.hmcts.ccd-data-store-api.ui-draft-update.v2+json;charset=UTF-8';
+  public static readonly V2_MEDIATYPE_DRAFT_DELETE =
+  'application/vnd.uk.gov.hmcts.ccd-data-store-api.ui-draft-delete.v2+json;charset=UTF-8';
+>>>>>>> Stashed changes
 
   constructor(
     private http: HttpService,
@@ -23,6 +35,7 @@ export class DraftService {
     private errorService: HttpErrorService
   ) {}
 
+<<<<<<< Updated upstream
   createDraft(jid: string, ctid: string, eventData: CaseEventData): Observable<Draft> {
     const url = this.appConfig.getCreateOrUpdateDraftsUrl(jid, ctid);
 
@@ -33,6 +46,16 @@ export class DraftService {
 
     return this.http
       .post(url, eventData, {headers})
+=======
+  createDraft(ctid: string, eventData: CaseEventData): Observable<Draft> {
+    const saveDraftEndpoint = this.appConfig.getCreateOrUpdateDraftsUrl(ctid);
+    let headers = new Headers({
+      'experimental': 'true',
+      'Accept': DraftService.V2_MEDIATYPE_DRAFT_CREATE
+    });
+    return this.http
+      .post(saveDraftEndpoint, eventData, {headers})
+>>>>>>> Stashed changes
       .map(response => response.json())
       .catch((error: any): any => {
         this.errorService.setError(error);
@@ -40,6 +63,7 @@ export class DraftService {
       });
   }
 
+<<<<<<< Updated upstream
   updateDraft(jid: string, ctid: string, draftId: string, eventData: CaseEventData): Observable<Draft> {
     const url = this.appConfig.getCreateOrUpdateDraftsUrl(jid, ctid) + draftId;
 
@@ -50,6 +74,16 @@ export class DraftService {
 
     return this.http
       .put(url, eventData, {headers})
+=======
+  updateDraft(ctid: string, draftId: string, eventData: CaseEventData): Observable<Draft> {
+    const saveDraftEndpoint = this.appConfig.getCreateOrUpdateDraftsUrl(ctid) + draftId;
+    let headers = new Headers({
+      'experimental': 'true',
+      'Accept': DraftService.V2_MEDIATYPE_DRAFT_UPDATE
+    });
+    return this.http
+      .put(saveDraftEndpoint, eventData, {headers})
+>>>>>>> Stashed changes
       .map(response => response.json())
       .catch((error: any): any => {
         this.errorService.setError(error);
@@ -59,12 +93,19 @@ export class DraftService {
 
   getDraft(draftId: string): Observable<CaseView> {
     const url = this.appConfig.getViewOrDeleteDraftsUrl(draftId.slice(DRAFT_PREFIX.length));
+<<<<<<< Updated upstream
 
     const headers = new Headers({
       'Accept': DraftService.V2_MEDIATYPE_DRAFT_READ,
       'experimental': 'true',
     });
 
+=======
+    let headers = new Headers({
+      'experimental': 'true',
+      'Accept': DraftService.V2_MEDIATYPE_DRAFT_READ
+    });
+>>>>>>> Stashed changes
     return this.http
       .get(url, {headers})
       .map(response => response.json())
@@ -76,12 +117,19 @@ export class DraftService {
 
   deleteDraft(draftId: string): Observable<{} | Response> {
     const url = this.appConfig.getViewOrDeleteDraftsUrl(draftId.slice(DRAFT_PREFIX.length));
+<<<<<<< Updated upstream
 
     const headers = new Headers({
       'Accept': DraftService.V2_MEDIATYPE_DRAFT_DELETE,
       'experimental': 'true',
     });
 
+=======
+    let headers = new Headers({
+      'experimental': 'true',
+      'Accept': DraftService.V2_MEDIATYPE_DRAFT_DELETE
+    });
+>>>>>>> Stashed changes
     return this.http
       .delete(url, {headers})
       .catch((error: any): any => {
@@ -90,11 +138,11 @@ export class DraftService {
       });
   }
 
-  createOrUpdateDraft(jurisdictionId: string, caseTypeId: string, draftId: string, caseEventData: CaseEventData): Observable<Draft> {
+  createOrUpdateDraft(caseTypeId: string, draftId: string, caseEventData: CaseEventData): Observable<Draft> {
     if (!draftId) {
-      return this.createDraft(jurisdictionId, caseTypeId, caseEventData);
+      return this.createDraft(caseTypeId, caseEventData);
     } else {
-      return this.updateDraft(jurisdictionId, caseTypeId, Draft.stripDraftId(draftId), caseEventData);
+      return this.updateDraft(caseTypeId, Draft.stripDraftId(draftId), caseEventData);
     }
   }
 }

--- a/src/shared/services/draft/draft.service.ts
+++ b/src/shared/services/draft/draft.service.ts
@@ -4,12 +4,10 @@ import { Response, Headers } from '@angular/http';
 import { AbstractAppConfig } from '../../../app.config';
 import { HttpService, HttpErrorService } from '../http';
 import { CaseEventData, Draft, DRAFT_PREFIX, CaseView } from '../../domain';
-import { Headers } from '@angular/http';
 
 @Injectable()
 export class DraftService {
 
-<<<<<<< Updated upstream
   public static readonly V2_MEDIATYPE_DRAFT_CREATE =
     'application/vnd.uk.gov.hmcts.ccd-data-store-api.ui-draft-create.v2+json;charset=UTF-8';
   public static readonly V2_MEDIATYPE_DRAFT_UPDATE =
@@ -18,16 +16,6 @@ export class DraftService {
     'application/vnd.uk.gov.hmcts.ccd-data-store-api.ui-draft-read.v2+json;charset=UTF-8';
   public static readonly V2_MEDIATYPE_DRAFT_DELETE =
     'application/vnd.uk.gov.hmcts.ccd-data-store-api.ui-draft-delete.v2+json;charset=UTF-8';
-=======
-  public static readonly V2_MEDIATYPE_DRAFT_READ =
-  'application/vnd.uk.gov.hmcts.ccd-data-store-api.ui-draft-read.v2+json;charset=UTF-8';
-  public static readonly V2_MEDIATYPE_DRAFT_CREATE =
-  'application/vnd.uk.gov.hmcts.ccd-data-store-api.ui-draft-create.v2+json;charset=UTF-8';
-  public static readonly V2_MEDIATYPE_DRAFT_UPDATE =
-  'application/vnd.uk.gov.hmcts.ccd-data-store-api.ui-draft-update.v2+json;charset=UTF-8';
-  public static readonly V2_MEDIATYPE_DRAFT_DELETE =
-  'application/vnd.uk.gov.hmcts.ccd-data-store-api.ui-draft-delete.v2+json;charset=UTF-8';
->>>>>>> Stashed changes
 
   constructor(
     private http: HttpService,
@@ -35,18 +23,6 @@ export class DraftService {
     private errorService: HttpErrorService
   ) {}
 
-<<<<<<< Updated upstream
-  createDraft(jid: string, ctid: string, eventData: CaseEventData): Observable<Draft> {
-    const url = this.appConfig.getCreateOrUpdateDraftsUrl(jid, ctid);
-
-    const headers = new Headers({
-      'Accept': DraftService.V2_MEDIATYPE_DRAFT_CREATE,
-      'experimental': 'true',
-    });
-
-    return this.http
-      .post(url, eventData, {headers})
-=======
   createDraft(ctid: string, eventData: CaseEventData): Observable<Draft> {
     const saveDraftEndpoint = this.appConfig.getCreateOrUpdateDraftsUrl(ctid);
     let headers = new Headers({
@@ -55,7 +31,6 @@ export class DraftService {
     });
     return this.http
       .post(saveDraftEndpoint, eventData, {headers})
->>>>>>> Stashed changes
       .map(response => response.json())
       .catch((error: any): any => {
         this.errorService.setError(error);
@@ -63,18 +38,6 @@ export class DraftService {
       });
   }
 
-<<<<<<< Updated upstream
-  updateDraft(jid: string, ctid: string, draftId: string, eventData: CaseEventData): Observable<Draft> {
-    const url = this.appConfig.getCreateOrUpdateDraftsUrl(jid, ctid) + draftId;
-
-    const headers = new Headers({
-      'Accept': DraftService.V2_MEDIATYPE_DRAFT_UPDATE,
-      'experimental': 'true',
-    });
-
-    return this.http
-      .put(url, eventData, {headers})
-=======
   updateDraft(ctid: string, draftId: string, eventData: CaseEventData): Observable<Draft> {
     const saveDraftEndpoint = this.appConfig.getCreateOrUpdateDraftsUrl(ctid) + draftId;
     let headers = new Headers({
@@ -83,7 +46,6 @@ export class DraftService {
     });
     return this.http
       .put(saveDraftEndpoint, eventData, {headers})
->>>>>>> Stashed changes
       .map(response => response.json())
       .catch((error: any): any => {
         this.errorService.setError(error);
@@ -93,19 +55,10 @@ export class DraftService {
 
   getDraft(draftId: string): Observable<CaseView> {
     const url = this.appConfig.getViewOrDeleteDraftsUrl(draftId.slice(DRAFT_PREFIX.length));
-<<<<<<< Updated upstream
-
-    const headers = new Headers({
-      'Accept': DraftService.V2_MEDIATYPE_DRAFT_READ,
-      'experimental': 'true',
-    });
-
-=======
     let headers = new Headers({
       'experimental': 'true',
       'Accept': DraftService.V2_MEDIATYPE_DRAFT_READ
     });
->>>>>>> Stashed changes
     return this.http
       .get(url, {headers})
       .map(response => response.json())
@@ -117,19 +70,10 @@ export class DraftService {
 
   deleteDraft(draftId: string): Observable<{} | Response> {
     const url = this.appConfig.getViewOrDeleteDraftsUrl(draftId.slice(DRAFT_PREFIX.length));
-<<<<<<< Updated upstream
-
-    const headers = new Headers({
-      'Accept': DraftService.V2_MEDIATYPE_DRAFT_DELETE,
-      'experimental': 'true',
-    });
-
-=======
     let headers = new Headers({
       'experimental': 'true',
       'Accept': DraftService.V2_MEDIATYPE_DRAFT_DELETE
     });
->>>>>>> Stashed changes
     return this.http
       .delete(url, {headers})
       .catch((error: any): any => {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-3574


### Change description ###
Data Store + UI Toolkit: Post/Put/Get/Delete Draft endpoint in API v2

v2 endpoints:

POST /case-types/{ctid}/drafts
PUT /case-types/{ctid}/drafts/{did}
GET /drafts/{did}
DELETE /drafts/{did}
To do:

Produces custom vnd media type
Use HATEOAS/HAL resource
Swagger doc annotation
Functional tests

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
