### PR TITLE
RDM-3628: Add null check for CaseLinks

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,8 @@
 ## RELEASE NOTES
 
+### Version 2.20.1 - January 9 2019
+**RDM-3628** - Add null check for CaseLinks
+
 ### Version 2.20.0 - January 9 2019
 **RDM-2455** - CRUD contract on Collection Items - Standard API
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "engines": {
     "yarn": "^1.9.2",
     "npm": "^5.6.0"

--- a/src/shared/components/palette/case-link/read-case-link-field.component.spec.ts
+++ b/src/shared/components/palette/case-link/read-case-link-field.component.spec.ts
@@ -1,0 +1,78 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReadCaseLinkFieldComponent } from './read-case-link-field.component';
+import { DebugElement } from '@angular/core';
+import { FieldType } from '../../../domain/definition/field-type.model';
+import { CaseField } from '../../../domain/definition/case-field.model';
+import { CaseReferencePipe } from '../../../pipes/case-reference/case-reference.pipe';
+import { By } from '@angular/platform-browser';
+
+const $LINK = By.css('a');
+const CASE_REFERENCE_RAW = '1234123412341238';
+const CASE_REFERENCE_FORMATTED = '1234-1234-1234-1238';
+
+describe('ReadCaseLinkFieldComponent', () => {
+
+  const FIELD_TYPE: FieldType = {
+    id: 'CaseLink',
+    type: 'Complex'
+  };
+  const VALUE = {
+    CaseReference: CASE_REFERENCE_RAW
+  };
+  const CASE_FIELD: CaseField = {
+    id: 'aCaseLink',
+    label: 'A case link',
+    field_type: FIELD_TYPE,
+    value: VALUE,
+    display_context: 'READONLY'
+  };
+
+  let fixture: ComponentFixture<ReadCaseLinkFieldComponent>;
+  let component: ReadCaseLinkFieldComponent;
+  let de: DebugElement;
+
+  beforeEach(async(() => {
+    TestBed
+      .configureTestingModule({
+        imports: [],
+        declarations: [
+          ReadCaseLinkFieldComponent,
+          CaseReferencePipe
+        ],
+        providers: []
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(ReadCaseLinkFieldComponent);
+    component = fixture.componentInstance;
+
+    component.caseField = CASE_FIELD;
+
+    de = fixture.debugElement;
+    fixture.detectChanges();
+  }));
+
+  it('render provided reference as link', () => {
+    component.caseField.value = VALUE;
+    fixture.detectChanges();
+
+    const linkDe = de.query($LINK);
+
+    expect(linkDe).toBeTruthy();
+    expect(linkDe.nativeElement.textContent).toEqual(CASE_REFERENCE_FORMATTED);
+  });
+
+  it('render undefined value as empty string', () => {
+    component.caseField.value = undefined;
+    fixture.detectChanges();
+
+    expect(de.nativeElement.textContent).toEqual('');
+  });
+
+  it('render null value as empty string', () => {
+    component.caseField.value = null;
+    fixture.detectChanges();
+
+    expect(de.nativeElement.textContent).toEqual('');
+  });
+});

--- a/src/shared/components/palette/case-link/read-case-link-field.component.ts
+++ b/src/shared/components/palette/case-link/read-case-link-field.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { AbstractFieldReadComponent } from '../base-field/abstract-field-read.component';
 
 @Component({
@@ -6,4 +6,8 @@ import { AbstractFieldReadComponent } from '../base-field/abstract-field-read.co
   templateUrl: 'read-case-link-field.html'
 })
 export class ReadCaseLinkFieldComponent extends AbstractFieldReadComponent {
+
+  public hasReference(): boolean {
+    return this.caseField.value && this.caseField.value.CaseReference;
+  }
 }

--- a/src/shared/components/palette/case-link/read-case-link-field.html
+++ b/src/shared/components/palette/case-link/read-case-link-field.html
@@ -1,3 +1,3 @@
-<a href="/v2/case/{{caseField.value.CaseReference}}" target="_blank">
+<a *ngIf="hasReference()" href="/v2/case/{{caseField.value.CaseReference}}" target="_blank">
   <span class="text-16">{{caseField.value.CaseReference ? (caseField.value.CaseReference | ccdCaseReference) : ''}}</span>
 </a>


### PR DESCRIPTION
### JIRA link (if applicable) ###

RDM-3628

### Change description ###

- Add null check to case links to make them safe to use in case list
- Add tests for read CaseLink component

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
