### PR TITLE
run polling outside angular zone to fix protractor tests

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -64,6 +64,7 @@ import 'core-js/es7/reflect';
  * Zone JS is required by default for Angular itself.
  */
 import 'zone.js/dist/zone';  // Included with Angular CLI.
+import 'zone.js/dist/zone-patch-rxjs';
 
 /***************************************************************************************************
  * APPLICATION IMPORTS

--- a/src/shared/components/case-viewer/case-event-trigger/case-event-trigger.component.ts
+++ b/src/shared/components/case-viewer/case-event-trigger/case-event-trigger.component.ts
@@ -6,6 +6,7 @@ import { DisplayMode, CaseEventTrigger, CaseView, Activity, CaseEventData } from
 import { CaseService, CasesService } from '../../case-editor';
 import { AlertService, ActivityPollingService, EventStatusService } from '../../../services';
 import { CaseReferencePipe } from '../../../pipes';
+import { NgZone } from '@angular/core';
 
 @Component({
   selector: 'ccd-case-event-trigger',
@@ -19,6 +20,7 @@ export class CaseEventTriggerComponent implements OnInit, OnDestroy {
   parentUrl: string;
 
   constructor(
+    private ngZone: NgZone,
     private casesService: CasesService,
     private caseService: CaseService,
     private router: Router,
@@ -38,8 +40,10 @@ export class CaseEventTriggerComponent implements OnInit, OnDestroy {
     }
     this.eventTrigger = this.route.snapshot.data.eventTrigger;
     if (this.activityPollingService.isEnabled) {
-      this.subscription = this.postEditActivity().subscribe((_resolved) => {
-        // console.log('Posted EDIT activity and result is: ' + JSON.stringify(resolved));
+      this.ngZone.runOutsideAngular( () => {
+        this.subscription = this.postEditActivity().subscribe((_resolved) => {
+          // console.log('Posted EDIT activity and result is: ' + JSON.stringify(_resolved));
+        });
       });
     }
     this.route.parent.url.subscribe(path => {

--- a/src/shared/components/case-viewer/case-viewer.component.ts
+++ b/src/shared/components/case-viewer/case-viewer.component.ts
@@ -19,6 +19,7 @@ import { CallbackErrorsContext } from '../../components/error/domain';
 import { DraftService } from '../../services/draft';
 import { MatDialog, MatDialogConfig } from '@angular/material';
 import { CaseService } from '../case-editor';
+import { NgZone } from '@angular/core';
 
 @Component({
   selector: 'ccd-case-viewer',
@@ -46,6 +47,7 @@ export class CaseViewerComponent implements OnInit, OnDestroy {
   callbackErrorsSubject: Subject<any> = new Subject();
 
   constructor(
+    private ngZone: NgZone,
     private route: ActivatedRoute,
     private router: Router,
     private orderService: OrderService,
@@ -88,8 +90,10 @@ export class CaseViewerComponent implements OnInit, OnDestroy {
     this.sortedTabs = this.sortTabFieldsAndFilterTabs(this.sortedTabs);
 
     if (this.activityPollingService.isEnabled) {
-      this.subscription = this.postViewActivity().subscribe((_resolved) => {
-        // console.log('Posted VIEW activity and result is: ' + JSON.stringify(resolved));
+      this.ngZone.runOutsideAngular( () => {
+        this.subscription = this.postViewActivity().subscribe((_resolved) => {
+          // console.log('Posted VIEW activity and result is: ' + JSON.stringify(_resolved));
+        });
       });
     }
   }

--- a/src/shared/services/activity/activity.polling.service.spec.ts
+++ b/src/shared/services/activity/activity.polling.service.spec.ts
@@ -16,6 +16,8 @@ describe('ActivityPollingService', () => {
 
   beforeEach(() => {
     ngZone = jasmine.createSpyObj<NgZone>('ngZone', ['run', 'runOutsideAngular']);
+    ngZone.runOutsideAngular.and.callFake((fn: Function) => fn());
+
     activityService = jasmine.createSpyObj<ActivityService>('activityService', ['getActivities', 'postActivity']);
     activityService.getActivities.and.returnValue(Observable.of());
     activityService.isEnabled = true;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-3430

### Change description ###
within the activity service, run rx-js polling outside the angular zone so that it does not continuously trigger change detection as this breaks the waiting mechanism in the protractor functional tests.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
