### PR TITLE
Allow failure on latest node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ node_js:
   - "lts/*"   # Latest Node LTS
   - "10.6.0"  # Highest Azure 10.*
   - "node"    # Latest stable Node
+matrix:
+  # Allow node 12.x to fail until dependencies start working
+  allow_failures:
+    - node_js: "node"
 cache: yarn
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s --


### PR DESCRIPTION
Node 12.x has some dependency build issues.  Allow failures here until
those are fixed.



### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```