### PR TITLE
Rdm 4704 - Add accessor methods in CaseField and related changes across application

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "json-server": "^0.14.0",
     "karma-jasmine-html-reporter": "^1.2.0",
     "mocha": "^5.0.5",
-    "typescript": "3.1.1"
+    "typescript": "3.1.1",
+    "underscore": "^1.9.1"
   },
   "peerDependencies": {
     "@angular/common": "~7.0.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 export { CaseUIToolkitModule } from './case-ui-toolkit.module';
 export { CaseEditorConfig,
          AbstractAppConfig } from './app.config';
-export { FormValueService,
+export { FieldTypeSanitiser,
+         FormValueService,
          FormErrorService,
          DocumentManagementService,
          FieldsUtils,

--- a/src/shared/components/case-editor/case-create/case-create.component.spec.ts
+++ b/src/shared/components/case-editor/case-create/case-create.component.spec.ts
@@ -1,18 +1,18 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
-import createSpyObj = jasmine.createSpyObj;
 import { CasesService } from '../services/cases.service';
 import { CaseCreateComponent } from './case-create.component';
-import { CaseEventTrigger, DRAFT_PREFIX } from '../../../domain';
+import { CaseEventTrigger, CaseField, DRAFT_PREFIX } from '../../../domain';
 import { createCaseEventTrigger } from '../../../fixture/shared.test.fixture';
 import { DraftService } from '../../../services/draft';
 import { AlertService } from '../../../services/alert';
-import { of, Observable, throwError } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 import { HttpError } from '../../../domain/http';
 import { MockComponent } from 'ng2-mock-component';
 import { EventTriggerService } from '../services/event-trigger.service';
 import { CaseDetails } from '../../../domain/case-details.model';
 import { CaseEventData } from '../../../domain/case-event-data.model';
+import createSpyObj = jasmine.createSpyObj;
 
 let CaseEditComponent: any = MockComponent({
   selector: 'ccd-case-edit',
@@ -30,18 +30,18 @@ describe('CaseCreateComponent event trigger resolved and draft does not exist', 
     undefined,
     false,
     [
-      {
+      <CaseField>({
         id: 'PersonFirstName',
         label: 'First name',
         field_type: null,
         display_context: 'READONLY'
-      },
-      {
+      }),
+      <CaseField>({
         id: 'PersonLastName',
         label: 'Last name',
         field_type: null,
         display_context: 'OPTIONAL'
-      }
+      })
     ],
     [],
     true
@@ -180,18 +180,18 @@ describe('CaseCreateComponent event trigger resolved and draft does exist', () =
     DRAFT_PREFIX + DRAFT_ID,
     false,
     [
-      {
+      <CaseField>({
         id: 'PersonFirstName',
         label: 'First name',
         field_type: null,
         display_context: 'READONLY'
-      },
-      {
+      }),
+      <CaseField>({
         id: 'PersonLastName',
         label: 'Last name',
         field_type: null,
         display_context: 'OPTIONAL'
-      }
+      })
     ],
     [],
     true

--- a/src/shared/components/case-editor/case-edit-page/case-edit-page.component.spec.ts
+++ b/src/shared/components/case-editor/case-edit-page/case-edit-page.component.spec.ts
@@ -22,6 +22,8 @@ import { CaseEventData } from '../../../domain/case-event-data.model';
 import { CaseEventTrigger } from '../../../domain/case-view/case-event-trigger.model';
 import { CallbackErrorsContext } from '../../error/domain/error-context';
 import createSpyObj = jasmine.createSpyObj;
+import { FieldTypeSanitiser } from '../../../services/form/field-type-sanitiser';
+
 
 describe('CaseEditPageComponent', () => {
 
@@ -32,7 +34,8 @@ describe('CaseEditPageComponent', () => {
   let fixture: ComponentFixture<CaseEditPageComponent>;
   let wizardPage = new WizardPage();
   let readOnly = new CaseField();
-  let formValueService = new FormValueService();
+  let fieldTypeSanitiser = new FieldTypeSanitiser();
+  let formValueService = new FormValueService(fieldTypeSanitiser);
   let formErrorService = new FormErrorService();
   let firstPage = new WizardPage();
   let caseFieldService = new CaseFieldService();

--- a/src/shared/components/case-editor/case-edit-submit/case-edit-submit.component.ts
+++ b/src/shared/components/case-editor/case-edit-submit/case-edit-submit.component.ts
@@ -140,7 +140,7 @@ export class CaseEditSubmitComponent implements OnInit {
       return field;
     }
 
-    let cloneField: CaseField = this.fieldsUtils.cloneObject(field);
+    let cloneField: CaseField = this.fieldsUtils.cloneCaseField(field);
     cloneField.value = this.editForm.get('data').get(field.id).value;
 
     return cloneField;

--- a/src/shared/components/case-editor/case-edit/case-edit.component.spec.ts
+++ b/src/shared/components/case-editor/case-edit/case-edit.component.spec.ts
@@ -1,13 +1,12 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { ReactiveFormsModule, FormGroup, FormControl, FormArray } from '@angular/forms';
+import { FormArray, FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MockComponent } from 'ng2-mock-component';
 import { CaseEditComponent } from './case-edit.component';
 import { DebugElement } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
-import { Router, ActivatedRoute } from '@angular/router';
-import createSpyObj = jasmine.createSpyObj;
-import { of, Observable } from 'rxjs';
-import { FieldsUtils, FieldsPurger, ProfileService, ProfileNotifier } from '../../../services';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { FieldsPurger, FieldsUtils, ProfileNotifier, ProfileService } from '../../../services';
 import { ConditionalShowRegistrarService } from '../../../directives';
 import { PaletteUtilsModule } from '../../palette';
 import { WizardFactoryService } from '../services/wizard-factory.service';
@@ -20,6 +19,7 @@ import { CaseField } from '../../../domain/definition/case-field.model';
 import { Wizard } from '../domain/wizard.model';
 import { WizardPage } from '../domain/wizard-page.model';
 import { Profile } from '../../../domain';
+import createSpyObj = jasmine.createSpyObj;
 
 describe('CaseEditComponent', () => {
 
@@ -29,18 +29,18 @@ describe('CaseEditComponent', () => {
     'caseId',
     false,
     [
-      {
+      <CaseField>({
         id: 'PersonFirstName',
         label: 'First name',
         field_type: null,
         display_context: 'READONLY'
-      },
-      {
+      }),
+      <CaseField>({
         id: 'PersonLastName',
         label: 'Last name',
         field_type: null,
         display_context: 'OPTIONAL'
-      }
+      })
     ]
   );
 
@@ -60,34 +60,34 @@ describe('CaseEditComponent', () => {
     case_field_id: 'Address'
   };
 
-  const CASE_FIELD_WITH_SHOW_CONDITION: CaseField = {
+  const CASE_FIELD_WITH_SHOW_CONDITION: CaseField = <CaseField>({
     id: 'PersonFirstName',
     label: 'First name',
     field_type: null,
     display_context: 'READONLY',
     show_condition: 'PersonLastName=\"Smith\"'
-  };
+  });
 
-  const CASE_FIELD_1: CaseField = {
+  const CASE_FIELD_1: CaseField = <CaseField>({
     id: 'PersonFirstName',
     label: 'First name',
     field_type: null,
     display_context: 'READONLY'
-  };
+  });
 
-  const CASE_FIELD_2: CaseField = {
+  const CASE_FIELD_2: CaseField = <CaseField>({
     id: 'PersonLastName',
     label: 'First name',
     field_type: null,
     display_context: 'READONLY'
-  };
+  });
 
-  const CASE_FIELD_3: CaseField = {
+  const CASE_FIELD_3: CaseField = <CaseField>({
     id: 'Address',
     label: 'Address',
     field_type: null,
     display_context: 'READONLY'
-  };
+  });
 
   let fixture: ComponentFixture<CaseEditComponent>;
   let component: CaseEditComponent;

--- a/src/shared/components/case-editor/case-editor.module.ts
+++ b/src/shared/components/case-editor/case-editor.module.ts
@@ -32,6 +32,7 @@ import { DocumentManagementService } from '../../services/document-management';
 import { RouterHelperService } from '../../services/router';
 import { CaseEditWizardGuard } from './services/case-edit-wizard.guard';
 import { ErrorsModule } from '../error/errors.module';
+import { FieldTypeSanitiser } from '../../services/form';
 
 @NgModule({
     imports: [
@@ -70,6 +71,7 @@ import { ErrorsModule } from '../error/errors.module';
         FieldsPurger,
         ConditionalShowRegistrarService,
         WizardFactoryService,
+        FieldTypeSanitiser,
         FormValueService,
         FormErrorService,
         PageValidationService,

--- a/src/shared/components/case-editor/case-progress/case-progress.component.spec.ts
+++ b/src/shared/components/case-editor/case-progress/case-progress.component.spec.ts
@@ -1,15 +1,15 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
-import createSpyObj = jasmine.createSpyObj;
 import { CasesService } from '../services/cases.service';
 import { CaseProgressComponent } from './case-progress.component';
-import { CaseEventTrigger, CaseDetails, CaseEventData, CaseView } from '../../../domain';
+import { CaseDetails, CaseEventData, CaseEventTrigger, CaseField, CaseView } from '../../../domain';
 import { createCaseEventTrigger } from '../../../fixture/shared.test.fixture';
 import { AlertService } from '../../../services/alert';
-import { of, Observable, throwError } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 import { HttpError } from '../../../domain/http';
 import { MockComponent } from 'ng2-mock-component';
 import { EventTriggerService } from '../services/event-trigger.service';
+import createSpyObj = jasmine.createSpyObj;
 
 let CaseEditComponent: any = MockComponent({
   selector: 'ccd-case-edit',
@@ -51,18 +51,18 @@ describe('CaseProgressComponent event trigger resolved and draft does not exist'
     undefined,
     false,
     [
-      {
+      <CaseField>({
         id: 'PersonFirstName',
         label: 'First name',
         field_type: null,
         display_context: 'READONLY'
-      },
-      {
+      }),
+      <CaseField>({
         id: 'PersonLastName',
         label: 'Last name',
         field_type: null,
         display_context: 'OPTIONAL'
-      }
+      })
     ],
     [],
     true

--- a/src/shared/components/case-history/services/case-history.service.spec.ts
+++ b/src/shared/components/case-history/services/case-history.service.spec.ts
@@ -1,12 +1,13 @@
-import { Response, ResponseOptions, Headers } from '@angular/http';
+import { Headers, Response, ResponseOptions } from '@angular/http';
 import { Observable } from 'rxjs';
 import { CaseHistoryService } from './case-history.service';
-import createSpyObj = jasmine.createSpyObj;
 import { HttpError } from '../../../domain';
 import { AbstractAppConfig } from '../../../../app.config';
-import { HttpService, HttpErrorService } from '../../../services';
+import { HttpErrorService, HttpService } from '../../../services';
 import { CaseHistory } from '../domain';
 import { createCaseHistory } from '../../../fixture';
+import { classToPlain } from 'class-transformer';
+import createSpyObj = jasmine.createSpyObj;
 
 describe('CaseHistoryService', () => {
 
@@ -38,7 +39,7 @@ describe('CaseHistoryService', () => {
 
     beforeEach(() => {
       httpService.get.and.returnValue(Observable.of(new Response(new ResponseOptions({
-        body: JSON.stringify(CASE_HISTORY)
+        body: JSON.stringify(classToPlain(CASE_HISTORY, {excludePrefixes: ['_']}))
       }))));
     });
 

--- a/src/shared/components/case-viewer/case-event-trigger/case-event-trigger.component.spec.ts
+++ b/src/shared/components/case-viewer/case-event-trigger/case-event-trigger.component.spec.ts
@@ -5,12 +5,12 @@ import { MockComponent } from 'ng2-mock-component';
 import { ActivatedRoute, Router, UrlSegment } from '@angular/router';
 import { Observable } from 'rxjs';
 import { ReactiveFormsModule } from '@angular/forms';
-import createSpyObj = jasmine.createSpyObj;
-import { CaseView, CaseEventTrigger, CaseEventData, HttpError } from '../../../domain';
+import { CaseEventData, CaseEventTrigger, CaseField, CaseView, HttpError } from '../../../domain';
 import { createCaseEventTrigger } from '../../../fixture';
-import { CasesService, CaseService } from '../../case-editor';
+import { CaseService, CasesService } from '../../case-editor';
 import { CaseReferencePipe } from '../../../pipes';
-import { AlertService, ActivityPollingService } from '../../../services';
+import { ActivityPollingService, AlertService } from '../../../services';
+import createSpyObj = jasmine.createSpyObj;
 
 describe('CaseEventTriggerComponent', () => {
   const PAGE_ID = 'pageId';
@@ -33,18 +33,18 @@ describe('CaseEventTriggerComponent', () => {
     '3',
     true,
     [
-      {
+      <CaseField>({
         id: 'PersonFirstName',
         label: 'First name',
         field_type: null,
         display_context: 'READONLY'
-      },
-      {
+      }),
+      <CaseField>({
         id: 'PersonLastName',
         label: 'Last name',
         field_type: null,
         display_context: 'OPTIONAL'
-      }
+      })
     ]
   );
 

--- a/src/shared/components/case-viewer/case-view/case-view.component.spec.ts
+++ b/src/shared/components/case-viewer/case-view/case-view.component.spec.ts
@@ -1,19 +1,20 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
 import { Observable, throwError } from 'rxjs';
-import createSpyObj = jasmine.createSpyObj;
 import { CaseViewComponent } from './case-view.component';
 import { CaseView, HttpError } from '../../../domain';
-import { CasesService, CaseService } from '../../case-editor';
+import { CaseService, CasesService } from '../../case-editor';
 import { AlertService, DraftService } from '../../../services';
 import { RouterTestingModule } from '@angular/router/testing'
 import { MockComponent } from 'ng2-mock-component';
+import { plainToClassFromExist } from 'class-transformer';
+import createSpyObj = jasmine.createSpyObj;
 
 describe('CaseViewComponent', () => {
 
   const CASE_REFERENCE = '1234123412341234';
   const DRAFT_REFERENCE = 'DRAFT1234';
-  const CASE_VIEW: CaseView = {
+  const CASE_VIEW: CaseView = plainToClassFromExist(new CaseView(), {
     case_id: CASE_REFERENCE,
     case_type: {
       id: 'TestAddressBookCase',
@@ -31,7 +32,7 @@ describe('CaseViewComponent', () => {
     tabs: [],
     triggers: [],
     events: []
-  };
+  });
   const CASE_VIEW_OBS: Observable<CaseView> = Observable.of(CASE_VIEW);
 
   let caseService;

--- a/src/shared/components/case-viewer/case-view/case-view.component.ts
+++ b/src/shared/components/case-viewer/case-view/case-view.component.ts
@@ -5,6 +5,7 @@ import { CasesService, CaseService } from '../../case-editor';
 import { DraftService } from '../../../services';
 import { Observable, throwError } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { plainToClass } from 'class-transformer';
 
 @Component({
   selector: 'ccd-case-view',

--- a/src/shared/components/case-viewer/case-view/case-view.component.ts
+++ b/src/shared/components/case-viewer/case-view/case-view.component.ts
@@ -1,11 +1,11 @@
-import { Component, Input, OnInit, Output, EventEmitter } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { AlertService } from '../../../services/alert';
 import { CaseView, Draft } from '../../../domain';
-import { CasesService, CaseService } from '../../case-editor';
+import { CaseService, CasesService } from '../../case-editor';
 import { DraftService } from '../../../services';
 import { Observable, throwError } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { plainToClass } from 'class-transformer';
+import { plainToClassFromExist } from 'class-transformer';
 
 @Component({
   selector: 'ccd-case-view',
@@ -33,8 +33,8 @@ export class CaseViewComponent implements OnInit {
     this.getCaseView(this.case)
       .pipe(
         map(caseView => {
-          this.caseDetails = caseView;
-          this.caseService.announceCase(caseView);
+          this.caseDetails = plainToClassFromExist(new CaseView(), caseView);
+          this.caseService.announceCase(this.caseDetails);
         })
       )
       .toPromise()

--- a/src/shared/components/case-viewer/case-viewer.component.spec.ts
+++ b/src/shared/components/case-viewer/case-viewer.component.spec.ts
@@ -16,15 +16,15 @@ import { LabelSubstitutorDirective } from '../../directives/substitutor';
 import { HttpError } from '../../domain/http';
 import { OrderService } from '../../services/order';
 import { DeleteOrCancelDialogComponent } from '../../components/dialogs';
-import { CaseViewTrigger, CaseViewEvent, CaseView } from '../../domain/case-view';
+import { CaseView, CaseViewEvent, CaseViewTrigger } from '../../domain/case-view';
 import { AlertService } from '../../services/alert';
 import { CallbackErrorsContext } from '../../components/error/domain';
 import { DraftService } from '../../services/draft';
 import { CaseReferencePipe } from '../../pipes/case-reference';
+import { MatDialog, MatDialogConfig, MatDialogRef } from '@angular/material';
+import { CaseService } from '../case-editor';
 import createSpyObj = jasmine.createSpyObj;
 import any = jasmine.any;
-import { MatDialog, MatDialogRef, MatDialogConfig } from '@angular/material';
-import { CaseService } from '../case-editor';
 
 @Component({
   // tslint:disable-next-line
@@ -132,7 +132,7 @@ const EVENTS: CaseViewEvent[] = [
 ];
 
 const METADATA: CaseField[] = [
-  {
+  Object.assign(new CaseField(), {
     id: '[CASE_REFERENCE]',
     label: 'Case Reference',
     value: 1533032330714079,
@@ -153,8 +153,8 @@ const METADATA: CaseField[] = [
     show_condition: null,
     show_summary_change_option: null,
     show_summary_content_option: null
-  },
-  {
+  }),
+  Object.assign(new CaseField(), {
     id: '[CASE_TYPE]',
     label: 'Case Type',
     value: 'DIVORCE',
@@ -175,8 +175,8 @@ const METADATA: CaseField[] = [
     show_condition: null,
     show_summary_change_option: null,
     show_summary_content_option: null
-  },
-  {
+  }),
+  Object.assign(new CaseField(), {
     id: '[CREATED_DATE]',
     label: 'Created Date',
     value: '2018-07-31T10:18:50.737',
@@ -197,8 +197,8 @@ const METADATA: CaseField[] = [
     show_condition: null,
     show_summary_change_option: null,
     show_summary_content_option: null
-  },
-  {
+  }),
+  Object.assign(new CaseField(), {
     id: '[JURISDICTION]',
     label: 'Jurisdiction',
     value: 'DIVORCE',
@@ -219,8 +219,8 @@ const METADATA: CaseField[] = [
     show_condition: null,
     show_summary_change_option: null,
     show_summary_content_option: null
-  },
-  {
+  }),
+  Object.assign(new CaseField(), {
     id: '[LAST_MODIFIED_DATE]',
     label: 'Last Modified Date',
     value: '2018-07-31T10:18:50.737',
@@ -241,8 +241,8 @@ const METADATA: CaseField[] = [
     show_condition: null,
     show_summary_change_option: null,
     show_summary_content_option: null
-  },
-  {
+  }),
+  Object.assign(new CaseField(), {
     id: '[SECURITY_CLASSIFICATION]',
     label: 'Security Classification',
     value: 'PUBLIC',
@@ -263,8 +263,8 @@ const METADATA: CaseField[] = [
     show_condition: null,
     show_summary_change_option: null,
     show_summary_content_option: null
-  },
-  {
+  }),
+  Object.assign(new CaseField(), {
     id: '[SECURITY_CLASSIFICATION]',
     label: 'Security Classification',
     value: 'PUBLIC',
@@ -285,7 +285,7 @@ const METADATA: CaseField[] = [
     show_condition: null,
     show_summary_change_option: null,
     show_summary_content_option: null
-  }
+  })
 ];
 
 const TRIGGERS: CaseViewTrigger[] = [
@@ -340,7 +340,7 @@ const CASE_VIEW: CaseView = {
       label: 'Name',
       order: 2,
       fields: [
-        {
+        Object.assign(new CaseField(), {
           id: 'PersonFirstName',
           label: 'First name',
           display_context: 'OPTIONAL',
@@ -352,8 +352,8 @@ const CASE_VIEW: CaseView = {
           value: 'Janet',
           show_condition: '',
           hint_text: ''
-        },
-        {
+        }),
+        Object.assign(new CaseField(), {
           id: 'PersonLastName',
           label: 'Last name',
           display_context: 'OPTIONAL',
@@ -365,8 +365,8 @@ const CASE_VIEW: CaseView = {
           value: 'Parker',
           show_condition: 'PersonFirstName="Jane*"',
           hint_text: ''
-        },
-        {
+        }),
+        Object.assign(new CaseField(), {
           id: 'PersonComplex',
           label: 'Complex field',
           display_context: 'OPTIONAL',
@@ -378,7 +378,7 @@ const CASE_VIEW: CaseView = {
           order: 3,
           show_condition: 'PersonFirstName="Park"',
           hint_text: ''
-        }
+        })
       ],
       show_condition: 'PersonFirstName="Janet"'
     },
@@ -386,7 +386,7 @@ const CASE_VIEW: CaseView = {
       id: 'HistoryTab',
       label: 'History',
       order: 1,
-      fields: [{
+      fields: [Object.assign(new CaseField(), {
         id: 'CaseHistory',
         label: 'Case History',
         display_context: 'OPTIONAL',
@@ -398,7 +398,7 @@ const CASE_VIEW: CaseView = {
         value: EVENTS,
         show_condition: '',
         hint_text: ''
-      }],
+      })],
       show_condition: ''
     },
     {

--- a/src/shared/components/case-viewer/case-viewer.component.ts
+++ b/src/shared/components/case-viewer/case-viewer.component.ts
@@ -20,7 +20,6 @@ import { MatDialog, MatDialogConfig } from '@angular/material';
 import { CaseService } from '../case-editor';
 import { Type } from 'class-transformer';
 
-// @dynamic
 @Component({
   selector: 'ccd-case-viewer',
   templateUrl: './case-viewer.component.html',
@@ -39,9 +38,7 @@ export class CaseViewerComponent implements OnInit, OnDestroy {
   BANNER = DisplayMode.BANNER;
 
   caseDetails: CaseView;
-  @Type(() => CaseTab)
   sortedTabs: CaseTab[];
-  @Type(() => CaseField)
   caseFields: CaseField[];
   error: any;
   triggerTextStart = CaseViewerComponent.TRIGGER_TEXT_START;

--- a/src/shared/components/case-viewer/case-viewer.component.ts
+++ b/src/shared/components/case-viewer/case-viewer.component.ts
@@ -18,7 +18,6 @@ import { CallbackErrorsContext } from '../../components/error/domain';
 import { DraftService } from '../../services/draft';
 import { MatDialog, MatDialogConfig } from '@angular/material';
 import { CaseService } from '../case-editor';
-import { Type } from 'class-transformer';
 
 @Component({
   selector: 'ccd-case-viewer',
@@ -93,8 +92,8 @@ export class CaseViewerComponent implements OnInit, OnDestroy {
   private init() {
     // Clone and sort tabs array
     this.sortedTabs = this.orderService.sort(this.caseDetails.tabs);
-    let tabFields = this.getTabFields()
-    this.caseFields = this.reinstantiateCaseFields(tabFields);
+
+    this.caseFields = this.getTabFields();
 
     this.sortedTabs = this.sortTabFieldsAndFilterTabs(this.sortedTabs);
 
@@ -117,7 +116,7 @@ export class CaseViewerComponent implements OnInit, OnDestroy {
 
   private sortTabFieldsAndFilterTabs(tabs: CaseTab[]): CaseTab[] {
     return tabs
-      .map(tab => Object.assign({}, tab, {fields: this.orderService.sort(this.reinstantiateCaseFields(tab.fields))}))
+      .map(tab => Object.assign({}, tab, {fields: this.orderService.sort(tab.fields)}))
       .filter(tab => new ShowCondition(tab.show_condition).matchByContextFields(this.caseFields));
   }
 

--- a/src/shared/components/case-viewer/case-viewer.component.ts
+++ b/src/shared/components/case-viewer/case-viewer.component.ts
@@ -109,11 +109,7 @@ export class CaseViewerComponent implements OnInit, OnDestroy {
       this.resetErrors();
     }
   }
-
-  private reinstantiateCaseFields(caseFields: CaseField[]): CaseField[] {
-    return caseFields.map(cf => Object.assign(new CaseField(), cf));
-  }
-
+  
   private sortTabFieldsAndFilterTabs(tabs: CaseTab[]): CaseTab[] {
     return tabs
       .map(tab => Object.assign({}, tab, {fields: this.orderService.sort(tab.fields)}))

--- a/src/shared/components/case-viewer/services/case.resolver.spec.ts
+++ b/src/shared/components/case-viewer/services/case.resolver.spec.ts
@@ -1,8 +1,8 @@
 import { CaseResolver } from './case.resolver';
 import { Observable } from 'rxjs';
-import createSpyObj = jasmine.createSpyObj;
 import { CaseView } from '../../../domain';
-import { DraftService, AlertService } from '../../../services';
+import { AlertService, DraftService } from '../../../services';
+import createSpyObj = jasmine.createSpyObj;
 
 describe('CaseResolver', () => {
   describe('resolve()', () => {
@@ -10,13 +10,15 @@ describe('CaseResolver', () => {
     const PARAM_CASE_ID = CaseResolver.PARAM_CASE_ID;
 
     const CASE_ID = '42';
-    const CASE: CaseView = createSpyObj<any>('case', ['toString']);
-    const CASE_CACHED: CaseView = createSpyObj<any>('caseCached', ['toString']);
+    const CASE: CaseView = new CaseView();
+    CASE.case_id = 'CASE_ID_1';
+
+    const CASE_CACHED: CaseView = new CaseView();
+    CASE_CACHED.case_id = 'CACHED_CASE_ID_1';
     const CASE_OBS: Observable<CaseView> = Observable.of(CASE);
 
     let caseResolver: CaseResolver;
     let draftService: DraftService;
-
     let casesService: any;
     let caseService: any;
     let alertService: AlertService;
@@ -28,7 +30,6 @@ describe('CaseResolver', () => {
       caseService = createSpyObj('caseService', ['announceCase']);
       casesService = createSpyObj('casesService', ['getCaseViewV2']);
       draftService = createSpyObj('draftService', ['getDraft']);
-
       router = createSpyObj('router', ['navigate']);
       alertService = createSpyObj('alertService', ['success']);
       caseResolver = new CaseResolver(caseService, casesService, draftService, router, alertService);
@@ -49,13 +50,13 @@ describe('CaseResolver', () => {
       caseResolver
         .resolve(route)
         .then(caseData => {
-          expect(caseData).toBe(CASE);
+          expect(caseData).toEqual(CASE);
         });
 
       expect(casesService.getCaseViewV2).toHaveBeenCalledWith(CASE_ID);
       expect(route.paramMap.get).toHaveBeenCalledWith(PARAM_CASE_ID);
       // allows to access private cachedCaseView field
-      expect(caseResolver['cachedCaseView']).toBe(CASE);
+      expect(caseResolver['cachedCaseView']).toEqual(CASE);
     });
 
     it('should return cached case view when the route is a case view tab and cached view exists', () => {
@@ -94,12 +95,12 @@ describe('CaseResolver', () => {
       caseResolver
         .resolve(route)
         .then(caseData => {
-          expect(caseData).toBe(CASE);
+          expect(caseData).toEqual(CASE);
         });
 
           expect(casesService.getCaseViewV2).toHaveBeenCalledWith(CASE_ID);
       // allows to access private cachedCaseView field
-          expect(caseResolver['cachedCaseView']).toBe(CASE);
+      expect(caseResolver['cachedCaseView']).toEqual(CASE);
     });
 
     it('should return cached case view when the route is not the one for case view and cached view exists', () => {
@@ -119,7 +120,7 @@ describe('CaseResolver', () => {
           expect(caseData).toBe(CASE_CACHED);
         });
       expect(casesService.getCaseViewV2).not.toHaveBeenCalled();
-      expect(caseResolver['cachedCaseView']).toBe(CASE_CACHED);
+      expect(caseResolver['cachedCaseView']).toEqual(CASE_CACHED);
     });
 
     it('should retrieve case view when the route is not the one for case view and cached is empty', () => {
@@ -136,12 +137,12 @@ describe('CaseResolver', () => {
       caseResolver
         .resolve(route)
         .then(caseData => {
-          expect(caseData).toBe(CASE);
+          expect(caseData).toEqual(CASE);
         });
 
       expect(casesService.getCaseViewV2).toHaveBeenCalledWith(CASE_ID);
       // allows to access private cachedCaseView field
-      expect(caseResolver['cachedCaseView']).toBe(CASE);
+      expect(caseResolver['cachedCaseView']).toEqual(CASE);
     });
 
     it('should redirect to error page when case cannot be retrieved', () => {
@@ -178,8 +179,11 @@ describe('CaseResolver', () => {
     const PARAM_CASE_ID = CaseResolver.PARAM_CASE_ID;
 
     const DRAFT_ID = 'DRAFT42';
-    const DRAFT: CaseView = createSpyObj<any>('draft', ['toString']);
-    const DRAFT_CACHED: CaseView = createSpyObj<any>('draftCached', ['toString']);
+    const DRAFT: CaseView = new CaseView();
+    DRAFT.case_id = 'DRAFT_CASE_ID_1';
+
+    const DRAFT_CACHED: CaseView = new CaseView();
+    DRAFT_CACHED.case_id = 'DRAFT_CASE_CACHED_ID_1';
     const DRAFT_OBS: Observable<CaseView> = Observable.of(DRAFT);
 
     let caseResolver: CaseResolver;
@@ -216,13 +220,13 @@ describe('CaseResolver', () => {
       caseResolver
         .resolve(route)
         .then(caseData => {
-          expect(caseData).toBe(DRAFT);
+          expect(caseData).toEqual(DRAFT);
         });
 
       expect(draftService.getDraft).toHaveBeenCalledWith(DRAFT_ID);
       expect(route.paramMap.get).toHaveBeenCalledWith(PARAM_CASE_ID);
       // allows to access private cachedCaseView field
-      expect(caseResolver['cachedCaseView']).toBe(DRAFT);
+      expect(caseResolver['cachedCaseView']).toEqual(DRAFT);
     });
   });
 });

--- a/src/shared/components/case-viewer/services/case.resolver.ts
+++ b/src/shared/components/case-viewer/services/case.resolver.ts
@@ -3,9 +3,9 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { CaseView, Draft } from '../../../domain';
-import { CasesService, CaseService } from '../../case-editor';
-import { DraftService, AlertService } from '../../../services';
-import { plainToClass } from 'class-transformer';
+import { CaseService, CasesService } from '../../case-editor';
+import { AlertService, DraftService } from '../../../services';
+import { plainToClassFromExist } from 'class-transformer';
 
 @Injectable()
 export class CaseResolver implements Resolve<CaseView> {
@@ -62,7 +62,7 @@ export class CaseResolver implements Resolve<CaseView> {
         .getCaseViewV2(cid)
         .pipe(
           map(caseView => {
-            this.cachedCaseView = caseView;
+            this.cachedCaseView = plainToClassFromExist(new CaseView(), caseView);
             this.caseService.announceCase(this.cachedCaseView);
             return this.cachedCaseView;
           }),
@@ -76,7 +76,7 @@ export class CaseResolver implements Resolve<CaseView> {
       .getDraft(cid)
       .pipe(
         map(caseView => {
-          this.cachedCaseView = caseView;
+          this.cachedCaseView = plainToClassFromExist(new CaseView(), caseView);
           this.caseService.announceCase(this.cachedCaseView);
           return this.cachedCaseView;
         }),

--- a/src/shared/components/case-viewer/services/case.resolver.ts
+++ b/src/shared/components/case-viewer/services/case.resolver.ts
@@ -5,6 +5,7 @@ import { catchError, map } from 'rxjs/operators';
 import { CaseView, Draft } from '../../../domain';
 import { CasesService, CaseService } from '../../case-editor';
 import { DraftService, AlertService } from '../../../services';
+import { plainToClass } from 'class-transformer';
 
 @Injectable()
 export class CaseResolver implements Resolve<CaseView> {

--- a/src/shared/components/palette/base-field/field-read-label.component.spec.ts
+++ b/src/shared/components/palette/base-field/field-read-label.component.spec.ts
@@ -6,7 +6,7 @@ import { By } from '@angular/platform-browser';
 import { text } from '../../../test/helpers';
 import { FieldReadLabelComponent } from './field-read-label.component';
 
-const CASE_FIELD: CaseField = {
+const CASE_FIELD: CaseField = <CaseField>({
   id: 'PersonFirstName',
   label: 'First name',
   field_type: {
@@ -15,9 +15,9 @@ const CASE_FIELD: CaseField = {
   },
   display_context: 'OPTIONAL',
   value: 'Johnny'
-};
+});
 
-const CASE_FIELD_OF_LABEL_TYPE: CaseField = {
+const CASE_FIELD_OF_LABEL_TYPE: CaseField = <CaseField>({
   id: 'PersonFirstName',
   label: 'First name',
   field_type: {
@@ -26,7 +26,7 @@ const CASE_FIELD_OF_LABEL_TYPE: CaseField = {
   },
   display_context: 'OPTIONAL',
   value: 'Johnny'
-};
+});
 const BY_FIELD_LABEL = By.css('.case-field__label');
 
 describe('FieldReadLabelComponent', () => {

--- a/src/shared/components/palette/base-field/field-read.component.spec.ts
+++ b/src/shared/components/palette/base-field/field-read.component.spec.ts
@@ -6,13 +6,13 @@ import { PaletteService } from '../palette.service';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 import { CaseField } from '../../../domain/definition';
 import { By } from '@angular/platform-browser';
-import createSpyObj = jasmine.createSpyObj;
 import { PaletteContext } from './palette-context.enum';
+import createSpyObj = jasmine.createSpyObj;
 
 const $FIELD_READ_LABEL = By.css('ccd-field-read-label');
 const $FIELD_TEST = By.css('ccd-field-read-label span.text-cls');
 
-const CASE_FIELD: CaseField = {
+const CASE_FIELD: CaseField = <CaseField>({
   id: 'PersonFirstName',
   label: 'First name',
   field_type: {
@@ -21,7 +21,7 @@ const CASE_FIELD: CaseField = {
   },
   value: 'Johnny',
   display_context: 'READONLY'
-};
+});
 const CLASS = 'text-cls';
 
 @Component({

--- a/src/shared/components/palette/base-field/field-write.component.spec.ts
+++ b/src/shared/components/palette/base-field/field-write.component.spec.ts
@@ -5,8 +5,8 @@ import { PaletteService } from '../palette.service';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 import { FieldWriteComponent } from './field-write.component';
 import { CaseField } from '../../../domain/definition/case-field.model';
-import createSpyObj = jasmine.createSpyObj;
 import { FormValidatorsService } from '../../../services/form/form-validators.service';
+import createSpyObj = jasmine.createSpyObj;
 
 const CLASS = 'person-first-name-cls';
 
@@ -19,7 +19,7 @@ class FieldTestComponent {}
 
 describe('FieldWriteComponent', () => {
 
-  const CASE_FIELD: CaseField = {
+  const CASE_FIELD: CaseField = <CaseField>({
     id: 'PersonFirstName',
     field_type: {
       id: 'Text',
@@ -27,7 +27,7 @@ describe('FieldWriteComponent', () => {
     },
     display_context: 'OPTIONAL',
     label: 'First name'
-  };
+  });
 
   let fixture: ComponentFixture<FieldWriteComponent>;
   let component: FieldWriteComponent;

--- a/src/shared/components/palette/case-link/read-case-link-field.component.spec.ts
+++ b/src/shared/components/palette/case-link/read-case-link-field.component.spec.ts
@@ -19,13 +19,13 @@ describe('ReadCaseLinkFieldComponent', () => {
   const VALUE = {
     CaseReference: CASE_REFERENCE_RAW
   };
-  const CASE_FIELD: CaseField = {
+  const CASE_FIELD: CaseField = <CaseField>({
     id: 'aCaseLink',
     label: 'A case link',
     field_type: FIELD_TYPE,
     value: VALUE,
     display_context: 'READONLY'
-  };
+  });
 
   let fixture: ComponentFixture<ReadCaseLinkFieldComponent>;
   let component: ReadCaseLinkFieldComponent;

--- a/src/shared/components/palette/case-link/write-case-link-field.component.spec.ts
+++ b/src/shared/components/palette/case-link/write-case-link-field.component.spec.ts
@@ -12,13 +12,13 @@ const FIELD_TYPE: FieldType = {
   type: 'Complex',
 };
 
-const CASE_FIELD: CaseField = {
+const CASE_FIELD: CaseField = <CaseField>({
   id: 'CaseReference',
   label: 'New Case Reference',
   display_context: 'OPTIONAL',
   field_type: FIELD_TYPE,
   value: VALUE
-};
+});
 
 const FORM_GROUP: FormGroup = new FormGroup({});
 const REGISTER_CONTROL = (control) => {

--- a/src/shared/components/palette/collection/read-collection-field.component.spec.ts
+++ b/src/shared/components/palette/collection/read-collection-field.component.spec.ts
@@ -31,14 +31,14 @@ describe('ReadCollectionFieldComponent', () => {
       value: 'Jacques',
     }
   ];
-  const CASE_FIELD: CaseField = {
+  const CASE_FIELD: CaseField = <CaseField>({
     id: 'x',
     label: 'X',
     field_type: FIELD_TYPE,
     display_context: 'OPTIONAL',
     value: VALUES,
     hidden: false
-  };
+  });
   let FieldReadComponent = MockComponent({
     selector: 'ccd-field-read',
     inputs: ['caseField', 'context']
@@ -156,14 +156,14 @@ describe('ReadCollectionFieldComponent with display_context_parameter', () => {
     }
   ];
 
-  const CASE_FIELD_WITH_DISPLAY_CONTEXT: CaseField = {
+  const CASE_FIELD_WITH_DISPLAY_CONTEXT: CaseField = <CaseField>({
     id: 'x',
     label: 'X',
     field_type: FIELD_TYPE,
     display_context: 'OPTIONAL',
     display_context_parameter: '#TABLE(Title,FIRSTNAME)',
     value: VALUES
-  };
+  });
   let FieldReadComponent = MockComponent({
     selector: 'ccd-field-read',
     inputs: ['caseField', 'context']

--- a/src/shared/components/palette/collection/write-collection-field.component.spec.ts
+++ b/src/shared/components/palette/collection/write-collection-field.component.spec.ts
@@ -3,20 +3,18 @@ import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { WriteCollectionFieldComponent } from './write-collection-field.component';
 import { DebugElement } from '@angular/core';
 import { MockComponent } from 'ng2-mock-component';
-import { FieldType } from '../../../domain/definition';
-import { CaseField } from '../../../domain/definition';
+import { CaseField, FieldType } from '../../../domain/definition';
 import { PaletteUtilsModule } from '../utils';
 import { By } from '@angular/platform-browser';
 import { FormValidatorsService } from '../../../services/form';
 import { MatDialog, MatDialogRef } from '@angular/material';
 import { ScrollToService } from '@nicky-lenaers/ngx-scroll-to';
-import { of } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 import { RemoveDialogComponent } from '../../dialogs/remove-dialog';
-import createSpyObj = jasmine.createSpyObj;
-import any = jasmine.any;
 import { ProfileNotifier } from '../../../services';
 import { createAProfile } from '../../../domain/profile/profile.test.fixture';
-import { BehaviorSubject } from 'rxjs';
+import createSpyObj = jasmine.createSpyObj;
+import any = jasmine.any;
 
 const FIELD_ID = 'Values';
 const SIMPLE_FIELD_TYPE: FieldType = {
@@ -86,7 +84,7 @@ describe('WriteCollectionFieldComponent', () => {
     dialog.open.and.returnValue(dialogRef);
     scrollToService = createSpyObj<ScrollToService>('scrollToService', ['scrollTo']);
     scrollToService.scrollTo.and.returnValue(of());
-    caseField = {
+    caseField = <CaseField>({
       id: FIELD_ID,
       label: 'X',
       field_type: SIMPLE_FIELD_TYPE,
@@ -101,7 +99,7 @@ describe('WriteCollectionFieldComponent', () => {
           delete: true
         }
       ]
-    };
+    });
     formGroup = new FormGroup({
       field1: new FormControl()
     });
@@ -336,7 +334,7 @@ describe('WriteCollectionFieldComponent CRUD impact', () => {
     dialog.open.and.returnValue(dialogRef);
     scrollToService = createSpyObj<ScrollToService>('scrollToService', ['scrollTo']);
     scrollToService.scrollTo.and.returnValue(of());
-    caseField = {
+    caseField = <CaseField>({
       id: FIELD_ID,
       label: 'X',
       field_type: SIMPLE_FIELD_TYPE,
@@ -351,7 +349,7 @@ describe('WriteCollectionFieldComponent CRUD impact', () => {
           delete: false
         }
       ]
-    };
+    });
     formGroup = new FormGroup({
       field1: new FormControl()
     });
@@ -453,7 +451,7 @@ describe('WriteCollectionFieldComponent CRUD impact - Update False', () => {
     dialog.open.and.returnValue(dialogRef);
     scrollToService = createSpyObj<ScrollToService>('scrollToService', ['scrollTo']);
     scrollToService.scrollTo.and.returnValue(of());
-    caseField = {
+    caseField = <CaseField>({
       id: FIELD_ID,
       label: 'X',
       field_type: SIMPLE_FIELD_TYPE,
@@ -468,7 +466,7 @@ describe('WriteCollectionFieldComponent CRUD impact - Update False', () => {
           delete: false
         }
       ]
-    };
+    });
     formGroup = new FormGroup({
       field1: new FormControl()
     });

--- a/src/shared/components/palette/collection/write-collection-field.component.ts
+++ b/src/shared/components/palette/collection/write-collection-field.component.ts
@@ -48,7 +48,7 @@ export class WriteCollectionFieldComponent extends AbstractFieldWriteComponent i
   }
 
   buildCaseField(item, index: number): CaseField {
-    return {
+    return Object.assign(new CaseField(),{
       id: index.toString(),
       field_type: this.caseField.field_type.collection_field_type,
       display_context: this.caseField.display_context,
@@ -56,7 +56,7 @@ export class WriteCollectionFieldComponent extends AbstractFieldWriteComponent i
       value: item.value,
       label: null,
       acls: this.caseField.acls
-    };
+    });
   }
 
   buildControlRegistrer(id: string, index: number): (control: FormControl) => AbstractControl {

--- a/src/shared/components/palette/collection/write-collection-field.component.ts
+++ b/src/shared/components/palette/collection/write-collection-field.component.ts
@@ -48,7 +48,11 @@ export class WriteCollectionFieldComponent extends AbstractFieldWriteComponent i
   }
 
   buildCaseField(item, index: number): CaseField {
-    return Object.assign(new CaseField(),{
+    return this.newCaseField(index, item);
+  }
+
+  private newCaseField(index: number, item) {
+    return Object.assign(new CaseField(), {
       id: index.toString(),
       field_type: this.caseField.field_type.collection_field_type,
       display_context: this.caseField.display_context,

--- a/src/shared/components/palette/complex/fields-filter.pipe.spec.ts
+++ b/src/shared/components/palette/complex/fields-filter.pipe.spec.ts
@@ -4,7 +4,7 @@ import { CaseField } from '../../../domain/definition/case-field.model';
 describe('FieldsFilterPipe', () => {
 
   const caseBuilder = (fields: CaseField[], value?: any): CaseField => {
-    return {
+    return <CaseField>({
       id: 'Applicant',
       label: 'Applicant',
       display_context: 'OPTIONAL',
@@ -14,7 +14,7 @@ describe('FieldsFilterPipe', () => {
         complex_fields: fields
       },
       value: value
-    };
+    });
   };
 
   let fieldsFilter: FieldsFilterPipe;
@@ -30,7 +30,7 @@ describe('FieldsFilterPipe', () => {
 
   describe('with value embedded in fields', () => {
     const FIELDS_WITH_VALUES: CaseField[] = [
-      {
+      <CaseField>({
         id: 'PersonFirstName',
         label: 'First name',
         value: 'John',
@@ -39,11 +39,11 @@ describe('FieldsFilterPipe', () => {
           id: 'Text',
           type: 'Text'
         }
-      }
+      })
     ];
 
     const FIELDS_WITH_VALUES_AND_MISSING: CaseField[] = [
-      {
+      <CaseField>({
         id: 'PersonFirstName',
         label: 'First name',
         value: 'John',
@@ -52,8 +52,8 @@ describe('FieldsFilterPipe', () => {
           id: 'Text',
           type: 'Text'
         }
-      },
-      {
+      }),
+      <CaseField>({
         id: 'PersonLastName',
         label: 'Last name',
         display_context: 'OPTIONAL',
@@ -61,11 +61,11 @@ describe('FieldsFilterPipe', () => {
           id: 'Text',
           type: 'Text'
         }
-      }
+      })
     ];
 
     const FIELDS_WITH_VALUES_AND_FALSE: CaseField[] = [
-      {
+      <CaseField>({
         id: 'PersonFirstName',
         label: 'First name',
         value: 'John',
@@ -74,8 +74,8 @@ describe('FieldsFilterPipe', () => {
           id: 'Text',
           type: 'Text'
         }
-      },
-      {
+      }),
+      <CaseField>({
         id: 'PersonGender',
         label: 'Gender',
         display_context: 'OPTIONAL',
@@ -84,11 +84,11 @@ describe('FieldsFilterPipe', () => {
           type: 'YesOrNo'
         },
         value: false
-      }
+      })
     ];
 
     const FIELDS_WITH_VALUES_AND_ZERO: CaseField[] = [
-      {
+      <CaseField>({
         id: 'PersonFirstName',
         label: 'First name',
         value: 'John',
@@ -97,8 +97,8 @@ describe('FieldsFilterPipe', () => {
           id: 'Text',
           type: 'Text'
         }
-      },
-      {
+      }),
+      <CaseField>({
         id: 'PersonChildren',
         label: 'Children',
         display_context: 'OPTIONAL',
@@ -107,12 +107,11 @@ describe('FieldsFilterPipe', () => {
           type: 'Number'
         },
         value: 0
-      }
+      })
     ];
 
     it('should return fields with embedded value as is', () => {
       let filteredFields = fieldsFilter.transform(caseBuilder(FIELDS_WITH_VALUES));
-
       expect(filteredFields).toEqual(FIELDS_WITH_VALUES);
     });
 
@@ -120,7 +119,6 @@ describe('FieldsFilterPipe', () => {
       FIELDS_WITH_VALUES_AND_MISSING[1].value = '';
 
       let filteredFields = fieldsFilter.transform(caseBuilder(FIELDS_WITH_VALUES_AND_MISSING));
-
       expect(filteredFields).toEqual(FIELDS_WITH_VALUES);
     });
 
@@ -155,7 +153,7 @@ describe('FieldsFilterPipe', () => {
 
   describe('with value outside of fields', () => {
     const EXPECTED_FILTERED_FIELDS: CaseField[] = [
-      {
+      <CaseField>({
         id: 'PersonFirstName',
         label: 'First name',
         display_context: 'OPTIONAL',
@@ -164,11 +162,11 @@ describe('FieldsFilterPipe', () => {
           type: 'Text'
         },
         value: 'John'
-      }
+      })
     ];
 
     const FIELDS_WITHOUT_VALUES: CaseField[] = [
-      {
+      <CaseField>({
         id: 'PersonFirstName',
         label: 'First name',
         display_context: 'OPTIONAL',
@@ -176,8 +174,8 @@ describe('FieldsFilterPipe', () => {
           id: 'Text',
           type: 'Text'
         }
-      },
-      {
+      }),
+      <CaseField>({
         id: 'PersonLastName',
         label: 'Last name',
         display_context: 'OPTIONAL',
@@ -185,11 +183,11 @@ describe('FieldsFilterPipe', () => {
           id: 'Text',
           type: 'Text'
         }
-      }
+      })
     ];
 
     const FIELDS_WITH_VALUES: CaseField[] = [
-      {
+      <CaseField>({
         id: 'PersonFirstName',
         label: 'First name',
         display_context: 'OPTIONAL',
@@ -198,8 +196,8 @@ describe('FieldsFilterPipe', () => {
           type: 'Text'
         },
         value: 'John'
-      },
-      {
+      }),
+      <CaseField>({
         id: 'PersonLastName',
         label: 'Last name',
         display_context: 'OPTIONAL',
@@ -208,7 +206,7 @@ describe('FieldsFilterPipe', () => {
           type: 'Text'
         },
         value: 'Doe'
-      }
+      })
     ];
 
     const VALUES_ALL = {
@@ -273,7 +271,7 @@ describe('FieldsFilterPipe', () => {
 
   describe('with complex type in fields', () => {
     const COMPLEX_WITH_CHILDREN: CaseField[] = [
-      {
+      <CaseField>({
         id: 'Person',
         label: 'Person',
         display_context: 'OPTIONAL',
@@ -281,7 +279,7 @@ describe('FieldsFilterPipe', () => {
           id: 'Person',
           type: 'Complex',
           complex_fields: [
-            {
+            <CaseField>({
               id: 'PersonFirstName',
               label: 'First name',
               display_context: 'OPTIONAL',
@@ -290,14 +288,14 @@ describe('FieldsFilterPipe', () => {
                 type: 'Text'
               },
               value: 'John'
-            }
+            })
           ]
         }
-      }
+      })
     ];
 
     const COMPLEX_WITHOUT_CHILDREN: CaseField[] = [
-      {
+      <CaseField>({
         id: 'Person',
         label: 'Person',
         display_context: 'OPTIONAL',
@@ -306,11 +304,11 @@ describe('FieldsFilterPipe', () => {
           type: 'Complex',
           complex_fields: []
         }
-      }
+      })
     ];
 
     const COMPLEX_WITH_EMPTY_CHILDREN: CaseField[] = [
-      {
+      <CaseField>({
         id: 'Person',
         label: 'Person',
         display_context: 'OPTIONAL',
@@ -318,7 +316,7 @@ describe('FieldsFilterPipe', () => {
           id: 'Person',
           type: 'Complex',
           complex_fields: [
-            {
+            <CaseField>({
               id: 'FirstName',
               label: 'First name',
               display_context: 'OPTIONAL',
@@ -327,13 +325,13 @@ describe('FieldsFilterPipe', () => {
                 type: 'Text'
               },
               value: ''
-            }
+            })
           ]
         }
-      }
+      })
     ];
 
-    const COMPLEX_WITH_EXTERNAL_VALUES: CaseField = {
+    const COMPLEX_WITH_EXTERNAL_VALUES: CaseField = <CaseField>({
         id: 'Person',
         label: 'Person',
       display_context: 'OPTIONAL',
@@ -341,7 +339,7 @@ describe('FieldsFilterPipe', () => {
           id: 'Person',
           type: 'Complex',
           complex_fields: [
-            {
+            <CaseField>({
               id: 'FirstNameContainerContainer',
               label: 'First name container container',
               display_context: 'OPTIONAL',
@@ -357,7 +355,7 @@ describe('FieldsFilterPipe', () => {
                       id: 'Complex',
                       type: 'Complex',
                       complex_fields: [
-                        {
+                        <CaseField>({
                           id: 'FirstName',
                           label: 'First name',
                           display_context: 'OPTIONAL',
@@ -365,13 +363,13 @@ describe('FieldsFilterPipe', () => {
                             id: 'Text',
                             type: 'Text'
                           }
-                        }
+                        })
                       ]
                     }
                   }
                 ]
               }
-            }
+            })
           ]
         },
         value: {
@@ -381,7 +379,7 @@ describe('FieldsFilterPipe', () => {
             }
           }
         }
-      };
+    });
 
     it('should NOT filter out Complex, even though Complex value itself is undefined but children have values', () => {
       let filteredFields = fieldsFilter.transform(caseBuilder(COMPLEX_WITH_CHILDREN));
@@ -410,7 +408,7 @@ describe('FieldsFilterPipe', () => {
 
   describe('option to keep empty fields', () => {
     const FIELDS_WITH_VALUES_AND_MISSING: CaseField[] = [
-      {
+      <CaseField>({
         id: 'PersonFirstName',
         label: 'First name',
         value: 'John',
@@ -419,8 +417,8 @@ describe('FieldsFilterPipe', () => {
           id: 'Text',
           type: 'Text'
         }
-      },
-      {
+      }),
+      <CaseField>({
         id: 'PersonLastName',
         label: 'Last name',
         display_context: 'OPTIONAL',
@@ -428,7 +426,7 @@ describe('FieldsFilterPipe', () => {
           id: 'Text',
           type: 'Text'
         }
-      }
+      })
     ];
 
     it('should not filter out fields with embedded value empty', () => {

--- a/src/shared/components/palette/complex/fields-filter.pipe.spec.ts
+++ b/src/shared/components/palette/complex/fields-filter.pipe.spec.ts
@@ -1,5 +1,6 @@
 import { FieldsFilterPipe } from './fields-filter.pipe';
 import { CaseField } from '../../../domain/definition/case-field.model';
+import {FieldsUtils} from '../../../services/fields';
 
 describe('FieldsFilterPipe', () => {
 
@@ -20,7 +21,7 @@ describe('FieldsFilterPipe', () => {
   let fieldsFilter: FieldsFilterPipe;
 
   beforeEach(() => {
-    fieldsFilter = new FieldsFilterPipe();
+    fieldsFilter = new FieldsFilterPipe(new FieldsUtils());
   });
 
   it('should handle null or undefined fields', () => {

--- a/src/shared/components/palette/complex/fields-filter.pipe.ts
+++ b/src/shared/components/palette/complex/fields-filter.pipe.ts
@@ -82,7 +82,7 @@ export class FieldsFilterPipe implements PipeTransform {
 
     return fields
       .map(f => {
-        let clone = { ...f };
+        let clone = Object.assign({}, f);
 
         let value = FieldsFilterPipe.getValue(f, values);
 

--- a/src/shared/components/palette/complex/fields-filter.pipe.ts
+++ b/src/shared/components/palette/complex/fields-filter.pipe.ts
@@ -1,10 +1,14 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { CaseField } from '../../../domain/definition/case-field.model';
-
+import { FieldsUtils } from '../../../services/fields';
 @Pipe({
   name: 'ccdFieldsFilter'
 })
 export class FieldsFilterPipe implements PipeTransform {
+
+  constructor(
+    private fieldsUtils: FieldsUtils
+  ){}
 
   private static readonly EMPTY_VALUES = [
     undefined,
@@ -82,7 +86,7 @@ export class FieldsFilterPipe implements PipeTransform {
 
     return fields
       .map(f => {
-        let clone = Object.assign({}, f);
+        let clone = this.fieldsUtils.cloneObject(f);
 
         let value = FieldsFilterPipe.getValue(f, values);
 

--- a/src/shared/components/palette/complex/read-complex-field-collection-table.component.spec.ts
+++ b/src/shared/components/palette/complex/read-complex-field-collection-table.component.spec.ts
@@ -43,7 +43,7 @@ describe('ReadComplexFieldCollectionTableComponent', () => {
       id: 'IAmVeryComplex',
       type: 'Complex',
       complex_fields: [
-        {
+        <CaseField>({
           id: 'AddressLine1',
           label: 'Line 1',
           display_context: 'OPTIONAL',
@@ -52,8 +52,8 @@ describe('ReadComplexFieldCollectionTableComponent', () => {
             type: 'Text'
           },
           value: ''
-        },
-        {
+        }),
+        <CaseField>({
           id: 'AddressLine2',
           label: 'Line 2',
           display_context: 'OPTIONAL',
@@ -62,7 +62,7 @@ describe('ReadComplexFieldCollectionTableComponent', () => {
             type: 'Text'
           },
           value: '111 East India road'
-        }
+        })
       ]
     };
 
@@ -70,7 +70,7 @@ describe('ReadComplexFieldCollectionTableComponent', () => {
       id: 'IAmVeryComplex',
       type: 'Complex',
       complex_fields: [
-        {
+        <CaseField>({
           id: 'AddressLine1',
           label: 'Line 1',
           display_context: 'OPTIONAL',
@@ -79,8 +79,8 @@ describe('ReadComplexFieldCollectionTableComponent', () => {
             type: 'Text'
           },
           value: 'Flat 9'
-        },
-        {
+        }),
+        <CaseField>({
           id: 'AddressLine2',
           label: 'Line 2',
           display_context: 'OPTIONAL',
@@ -89,8 +89,8 @@ describe('ReadComplexFieldCollectionTableComponent', () => {
             type: 'Number'
           },
           value: '111 East India road'
-        },
-        {
+        }),
+        <CaseField>({
           id: 'AddressPostcode',
           label: 'Post code',
           display_context: 'OPTIONAL',
@@ -99,11 +99,11 @@ describe('ReadComplexFieldCollectionTableComponent', () => {
             type: 'Complex'
           },
           value: 'tw45ed'
-        }
+        })
       ]
     };
 
-    const CASE_FIELD: CaseField = {
+    const CASE_FIELD: CaseField = <CaseField>({
       id: '',
       label: 'Complex Field',
       display_context: 'OPTIONAL',
@@ -127,7 +127,7 @@ describe('ReadComplexFieldCollectionTableComponent', () => {
       ],
         display_context_parameter: '#TABLE(AddressLine1, AddressLine2)',
         field_type: FIELD_TYPE_WITH_VALUES
-      };
+      });
 
     const LINE_1 = 0;
     const LINE_2 = 1;

--- a/src/shared/components/palette/complex/read-complex-field-raw.component.spec.ts
+++ b/src/shared/components/palette/complex/read-complex-field-raw.component.spec.ts
@@ -85,7 +85,7 @@ describe('ReadComplexFieldRawComponent', () => {
       id: 'IAmVeryComplex',
       type: 'Complex',
       complex_fields: [
-        {
+        <CaseField>({
           id: 'AddressLine1',
           label: 'Line 1',
           display_context: 'OPTIONAL',
@@ -94,8 +94,8 @@ describe('ReadComplexFieldRawComponent', () => {
             type: 'Text'
           },
           value: 'Flat 9'
-        },
-        {
+        }),
+        <CaseField>({
           id: 'AddressLine2',
           label: 'Line 2',
           display_context: 'OPTIONAL',
@@ -104,8 +104,8 @@ describe('ReadComplexFieldRawComponent', () => {
             type: 'Text'
           },
           value: '111 East India road'
-        },
-        {
+        }),
+        <CaseField>({
           id: 'AddressLine3',
           label: 'Line 3',
           display_context: 'OPTIONAL',
@@ -114,19 +114,19 @@ describe('ReadComplexFieldRawComponent', () => {
             type: 'Text'
           },
           value: 'Poplar'
-        },
+        }),
       ]
     };
 
     let caseField: CaseField;
 
     beforeEach(async(() => {
-      caseField = {
+      caseField = <CaseField>({
         id: '',
         label: 'Complex Field',
         display_context: 'OPTIONAL',
         field_type: FIELD_TYPE_WITH_VALUES
-      };
+      });
 
       let test = initTests(caseField, [
         FieldReadComponent
@@ -181,7 +181,7 @@ describe('ReadComplexFieldRawComponent', () => {
       id: 'IAmVeryComplex',
       type: 'Complex',
       complex_fields: [
-        {
+        <CaseField>({
           id: 'AddressLine1',
           label: 'Line 1',
           display_context: 'OPTIONAL',
@@ -190,8 +190,8 @@ describe('ReadComplexFieldRawComponent', () => {
             type: 'Text'
           },
           value: 'Flat 9'
-        },
-        {
+        }),
+        <CaseField>({
           id: 'AddressLine2',
           label: 'Line 2',
           display_context: 'OPTIONAL',
@@ -200,8 +200,8 @@ describe('ReadComplexFieldRawComponent', () => {
             type: 'Text'
           },
           value: ''
-        },
-        {
+        }),
+        <CaseField>({
           id: 'AddressLine3',
           label: 'Line 3',
           display_context: 'OPTIONAL',
@@ -210,19 +210,19 @@ describe('ReadComplexFieldRawComponent', () => {
             type: 'Text'
           },
           value: 'Poplar'
-        },
+        }),
       ]
     };
 
     let caseField: CaseField;
 
     beforeEach(async(() => {
-      caseField = {
+      caseField = <CaseField>({
         id: '',
         label: 'Complex Field',
         display_context: 'OPTIONAL',
         field_type: FIELD_TYPE_WITH_MISSING_VALUE
-      };
+      });
 
       let test = initTests(caseField, [
         FieldReadComponent
@@ -247,7 +247,7 @@ describe('ReadComplexFieldRawComponent', () => {
       id: 'IAmVeryComplex',
       type: 'Complex',
       complex_fields: [
-        {
+        <CaseField>({
           id: 'AddressLine1',
           label: 'Line 1',
           display_context: 'OPTIONAL',
@@ -255,8 +255,8 @@ describe('ReadComplexFieldRawComponent', () => {
             id: 'Text',
             type: 'Text'
           },
-        },
-        {
+        }),
+        <CaseField>({
           id: 'AddressLine2',
           label: 'Line 2',
           display_context: 'OPTIONAL',
@@ -264,8 +264,8 @@ describe('ReadComplexFieldRawComponent', () => {
             id: 'Text',
             type: 'Text'
           },
-        },
-        {
+        }),
+        <CaseField>({
           id: 'AddressLine3',
           label: 'Line 3',
           display_context: 'OPTIONAL',
@@ -273,14 +273,14 @@ describe('ReadComplexFieldRawComponent', () => {
             id: 'Text',
             type: 'Text'
           },
-        },
+        }),
       ]
     };
 
     let caseField: CaseField;
 
     beforeEach(async(() => {
-      caseField = {
+      caseField =  <CaseField>({
         id: '',
         label: 'Complex Field',
         display_context: 'OPTIONAL',
@@ -290,7 +290,7 @@ describe('ReadComplexFieldRawComponent', () => {
           'AddressLine2': '111 East India road',
           'AddressLine3': 'Poplar',
         }
-      };
+      });
 
       let test = initTests(caseField, [
         FieldReadComponent
@@ -334,7 +334,7 @@ describe('ReadComplexFieldRawComponent', () => {
       id: 'IAmVeryComplex',
       type: 'Complex',
       complex_fields: [
-        {
+        <CaseField>({
           id: 'AddressLine1',
           label: 'Line 1',
           display_context: 'OPTIONAL',
@@ -342,8 +342,8 @@ describe('ReadComplexFieldRawComponent', () => {
             id: 'Text',
             type: 'Text'
           },
-        },
-        {
+        }),
+        <CaseField>({
           id: 'AddressLine2',
           label: 'Line 2',
           display_context: 'OPTIONAL',
@@ -351,8 +351,8 @@ describe('ReadComplexFieldRawComponent', () => {
             id: 'Text',
             type: 'Text'
           },
-        },
-        {
+        }),
+          <CaseField>({
           id: 'AddressLine3',
           label: 'Line 3',
           display_context: 'OPTIONAL',
@@ -360,14 +360,14 @@ describe('ReadComplexFieldRawComponent', () => {
             id: 'Text',
             type: 'Text'
           },
-        },
+        }),
       ]
     };
 
     let caseField: CaseField;
 
     beforeEach(async(() => {
-      caseField = {
+      caseField = <CaseField>({
         id: '',
         label: 'Complex Field',
         display_context: 'OPTIONAL',
@@ -376,7 +376,7 @@ describe('ReadComplexFieldRawComponent', () => {
           'AddressLine1': 'Flat 9',
           'AddressLine3': 'Poplar',
         }
-      };
+      });
 
       let test = initTests(caseField, [
         FieldReadComponent

--- a/src/shared/components/palette/complex/read-complex-field-table.component.spec.ts
+++ b/src/shared/components/palette/complex/read-complex-field-table.component.spec.ts
@@ -39,7 +39,7 @@ describe('ReadComplexFieldTableComponent', () => {
       id: 'IAmVeryComplex',
       type: 'Complex',
       complex_fields: [
-        {
+        <CaseField>({
           id: 'AddressLine1',
           label: 'Line 1',
           display_context: 'OPTIONAL',
@@ -48,8 +48,8 @@ describe('ReadComplexFieldTableComponent', () => {
             type: 'Text'
           },
           value: ''
-        },
-        {
+        }),
+        <CaseField>({
           id: 'AddressLine2',
           label: 'Line 2',
           display_context: 'OPTIONAL',
@@ -58,7 +58,7 @@ describe('ReadComplexFieldTableComponent', () => {
             type: 'Text'
           },
           value: '111 East India road'
-        }
+        })
       ]
     };
 
@@ -66,7 +66,7 @@ describe('ReadComplexFieldTableComponent', () => {
       id: 'IAmVeryComplex',
       type: 'Complex',
       complex_fields: [
-        {
+        <CaseField>({
           id: 'AddressLine1',
           label: 'Line 1',
           display_context: 'OPTIONAL',
@@ -75,8 +75,8 @@ describe('ReadComplexFieldTableComponent', () => {
             type: 'Text'
           },
           value: 'Flat 9'
-        },
-        {
+        }),
+        <CaseField>({
           id: 'AddressLine2',
           label: 'Line 2',
           display_context: 'OPTIONAL',
@@ -85,8 +85,8 @@ describe('ReadComplexFieldTableComponent', () => {
             type: 'Text'
           },
           value: '111 East India road'
-        },
-        {
+        }),
+        <CaseField>({
           id: 'AddressPostcode',
           label: 'Post code',
           display_context: 'OPTIONAL',
@@ -94,7 +94,7 @@ describe('ReadComplexFieldTableComponent', () => {
             id: 'Postcode',
             type: 'Complex',
             complex_fields: [
-              {
+              <CaseField>({
                 id: 'PostcodeCity',
                 label: 'City',
                 display_context: 'OPTIONAL',
@@ -103,8 +103,8 @@ describe('ReadComplexFieldTableComponent', () => {
                   type: 'Text'
                 },
                 value: 'London'
-              },
-              {
+              }),
+              <CaseField>({
                 id: 'PostcodeCountry',
                 label: 'Country',
                 display_context: 'OPTIONAL',
@@ -113,19 +113,19 @@ describe('ReadComplexFieldTableComponent', () => {
                   type: 'Text'
                 },
                 value: 'UK'
-              }
+              })
             ]
           }
-        }
+        })
       ]
     };
 
-    const CASE_FIELD: CaseField = {
+    const CASE_FIELD: CaseField = <CaseField>({
       id: '',
       label: 'Complex Field',
       display_context: 'OPTIONAL',
       field_type: FIELD_TYPE_WITH_VALUES
-    };
+    });
 
     const LINE_1 = 0;
     const LINE_2 = 1;
@@ -196,12 +196,12 @@ describe('ReadComplexFieldTableComponent', () => {
     });
 
     it('should NOT render fields with empty value', () => {
-      component.caseField = {
+      component.caseField = <CaseField>({
         id: 'x',
         label: 'x',
         display_context: 'OPTIONAL',
         field_type: FIELD_TYPE_WITH_MISSING_VALUE
-      };
+      });
       fixture.detectChanges();
 
       let labels = de.queryAll($COMPLEX_PANEL_SIMPLE_ROWS_HEADERS);
@@ -212,12 +212,12 @@ describe('ReadComplexFieldTableComponent', () => {
     });
 
     it('should only render title when no fields', () => {
-      component.caseField = {
+      component.caseField = <CaseField>({
         id: 'x',
         label: 'x',
         display_context: 'OPTIONAL',
         field_type: FIELD_TYPE_WITHOUT_FIELDS
-      };
+      });
       fixture.detectChanges();
 
       let title = de.query($COMPLEX_PANEL_TITLE);
@@ -249,7 +249,7 @@ describe('ReadComplexFieldTableComponent', () => {
       id: 'IAmVeryComplex',
       type: 'Complex',
       complex_fields: [
-        {
+        <CaseField>({
           id: 'AddressLine1',
           label: 'Line 1',
           display_context: 'OPTIONAL',
@@ -257,8 +257,8 @@ describe('ReadComplexFieldTableComponent', () => {
             id: 'Text',
             type: 'Text'
           }
-        },
-        {
+        }),
+        <CaseField>({
           id: 'AddressLine2',
           label: 'Line 2',
           display_context: 'OPTIONAL',
@@ -266,8 +266,8 @@ describe('ReadComplexFieldTableComponent', () => {
             id: 'Text',
             type: 'Text'
           }
-        },
-        {
+        }),
+        <CaseField>({
           id: 'AddressPostcode',
           label: 'Post code',
           display_context: 'OPTIONAL',
@@ -275,7 +275,7 @@ describe('ReadComplexFieldTableComponent', () => {
             id: 'Postcode',
             type: 'Complex',
             complex_fields: [
-              {
+              <CaseField>({
                 id: 'PostcodeCity',
                 label: 'City',
                 display_context: 'OPTIONAL',
@@ -283,8 +283,8 @@ describe('ReadComplexFieldTableComponent', () => {
                   id: 'Text',
                   type: 'Text'
                 }
-              },
-              {
+              }),
+              <CaseField>({
                 id: 'PostcodeCountry',
                 label: 'Country',
                 display_context: 'OPTIONAL',
@@ -292,14 +292,14 @@ describe('ReadComplexFieldTableComponent', () => {
                   id: 'Text',
                   type: 'Text'
                 }
-              }
+              })
             ]
           }
-        }
+        })
       ]
     };
 
-    const CASE_FIELD: CaseField = {
+    const CASE_FIELD: CaseField =  <CaseField>({
       id: '',
       label: 'Complex Field',
       field_type: FIELD_TYPE,
@@ -312,7 +312,7 @@ describe('ReadComplexFieldTableComponent', () => {
           'PostcodeCountry': 'UK'
         }
       }
-    };
+    });
 
     const LINE_1 = 0;
     const LINE_2 = 1;
@@ -381,7 +381,7 @@ describe('ReadComplexFieldTableComponent', () => {
     });
 
     it('should NOT render fields with empty value', () => {
-      component.caseField = {
+      component.caseField = <CaseField>({
         id: 'x',
         label: 'x',
         display_context: 'OPTIONAL',
@@ -389,7 +389,7 @@ describe('ReadComplexFieldTableComponent', () => {
         value: {
           'AddressLine1': 'Flat 9'
         }
-      };
+      });
       fixture.detectChanges();
 
       let labels = de.queryAll($COMPLEX_PANEL_SIMPLE_ROWS_HEADERS);

--- a/src/shared/components/palette/complex/write-complex-field.component.spec.ts
+++ b/src/shared/components/palette/complex/write-complex-field.component.spec.ts
@@ -49,7 +49,7 @@ describe('WriteComplexFieldComponent', () => {
       id: 'IAmVeryComplex',
       type: 'Complex',
       complex_fields: [
-        {
+        <CaseField>({
           id: 'AddressLine1',
           label: 'Line 1',
           display_context: 'OPTIONAL',
@@ -58,8 +58,8 @@ describe('WriteComplexFieldComponent', () => {
             type: 'Text'
           },
           value: ''
-        },
-        {
+        }),
+        <CaseField>({
           id: 'AddressLine2',
           label: 'Line 2',
           display_context: 'OPTIONAL',
@@ -68,7 +68,7 @@ describe('WriteComplexFieldComponent', () => {
             type: 'Text'
           },
           value: '111 East India road'
-        }
+        })
       ]
     };
 
@@ -76,7 +76,7 @@ describe('WriteComplexFieldComponent', () => {
       id: 'IAmVeryComplex',
       type: 'Complex',
       complex_fields: [
-        {
+        <CaseField>({
           id: 'AddressLine1',
           label: 'Line 1',
           display_context: 'OPTIONAL',
@@ -85,8 +85,8 @@ describe('WriteComplexFieldComponent', () => {
             type: 'Text'
           },
           value: 'Flat 9'
-        },
-        {
+        }),
+        <CaseField>({
           id: 'AddressLine2',
           label: 'Line 2',
           display_context: 'OPTIONAL',
@@ -95,8 +95,8 @@ describe('WriteComplexFieldComponent', () => {
             type: 'Text'
           },
           value: '111 East India road'
-        },
-        {
+        }),
+        <CaseField>({
           id: 'AddressPostcode',
           label: 'Post code',
           display_context: 'OPTIONAL',
@@ -104,7 +104,7 @@ describe('WriteComplexFieldComponent', () => {
             id: 'Postcode',
             type: 'Complex',
             complex_fields: [
-              {
+              <CaseField>({
                 id: 'PostcodeCity',
                 label: 'City',
                 display_context: 'OPTIONAL',
@@ -113,8 +113,8 @@ describe('WriteComplexFieldComponent', () => {
                   type: 'Text'
                 },
                 value: 'London'
-              },
-              {
+              }),
+              <CaseField>({
                 id: 'PostcodeCountry',
                 label: 'Country',
                 display_context: 'OPTIONAL',
@@ -123,20 +123,20 @@ describe('WriteComplexFieldComponent', () => {
                   type: 'Text'
                 },
                 value: 'UK'
-              }
+              })
             ]
           }
-        }
+        })
       ]
     };
 
     const FIELD_ID = 'AComplexField';
-    const CASE_FIELD: CaseField = {
+    const CASE_FIELD: CaseField =  <CaseField>({
       id: FIELD_ID,
       label: 'Complex Field',
       display_context: 'OPTIONAL',
       field_type: FIELD_TYPE_WITH_VALUES
-    };
+    });
 
     const LINE_1 = 0;
     const LINE_2 = 1;
@@ -204,12 +204,12 @@ describe('WriteComplexFieldComponent', () => {
     });
 
     it('should render fields with empty value', () => {
-      component.caseField = {
+      component.caseField = <CaseField>({
         id: 'x',
         label: 'x',
         display_context: 'OPTIONAL',
         field_type: FIELD_TYPE_WITH_MISSING_VALUE
-      };
+      });
       fixture.detectChanges();
 
       let labels = de.queryAll($COMPLEX_PANEL_VALUES);
@@ -221,12 +221,12 @@ describe('WriteComplexFieldComponent', () => {
     });
 
     it('should return control if exists in formGroup', () => {
-      const CASE_FIELD_1: CaseField = {
+      const CASE_FIELD_1: CaseField = <CaseField>({
         id: FIELD_ID,
         label: 'Complex Field',
         display_context: 'OPTIONAL',
         field_type: FIELD_TYPE_WITH_MISSING_VALUE
-      };
+      });
       let firstControl = new FormControl();
       let formGroup = new FormGroup({});
       formGroup.addControl(FIELD_ID, firstControl);
@@ -238,12 +238,12 @@ describe('WriteComplexFieldComponent', () => {
     });
 
     it('should add control if it does not exist in formGroup', () => {
-      const CASE_FIELD_1: CaseField = {
+      const CASE_FIELD_1: CaseField = <CaseField>({
         id: 'anotherComplexField',
         label: 'Complex Field',
         display_context: 'OPTIONAL',
         field_type: FIELD_TYPE_WITH_MISSING_VALUE
-      };
+      });
       let firstControl = new FormControl();
       let formGroup = new FormGroup({});
       formGroup.addControl('first', firstControl);
@@ -261,7 +261,7 @@ describe('WriteComplexFieldComponent', () => {
       id: 'IAmVeryComplex',
       type: 'Complex',
       complex_fields: [
-        {
+        <CaseField>({
           id: 'AddressLine1',
           label: 'Line 1',
           display_context: 'OPTIONAL',
@@ -269,8 +269,8 @@ describe('WriteComplexFieldComponent', () => {
             id: 'Text',
             type: 'Text'
           }
-        },
-        {
+        }),
+        <CaseField>({
           id: 'AddressLine2',
           label: 'Line 2',
           display_context: 'OPTIONAL',
@@ -278,8 +278,8 @@ describe('WriteComplexFieldComponent', () => {
             id: 'Text',
             type: 'Text'
           }
-        },
-        {
+        }),
+        <CaseField>({
           id: 'AddressPostcode',
           label: 'Post code',
           display_context: 'OPTIONAL',
@@ -287,7 +287,7 @@ describe('WriteComplexFieldComponent', () => {
             id: 'Postcode',
             type: 'Complex',
             complex_fields: [
-              {
+              <CaseField>({
                 id: 'PostcodeCity',
                 label: 'City',
                 display_context: 'OPTIONAL',
@@ -295,8 +295,8 @@ describe('WriteComplexFieldComponent', () => {
                   id: 'Text',
                   type: 'Text'
                 }
-              },
-              {
+              }),
+              <CaseField>({
                 id: 'PostcodeCountry',
                 label: 'Country',
                 display_context: 'OPTIONAL',
@@ -304,15 +304,15 @@ describe('WriteComplexFieldComponent', () => {
                   id: 'Text',
                   type: 'Text'
                 }
-              }
+              })
             ]
           }
-        }
+        })
       ]
     };
 
     const FIELD_ID = 'SomeFieldId';
-    const CASE_FIELD: CaseField = {
+    const CASE_FIELD: CaseField =  <CaseField>({
       id: FIELD_ID,
       label: 'Complex Field',
       field_type: FIELD_TYPE,
@@ -325,7 +325,7 @@ describe('WriteComplexFieldComponent', () => {
           'PostcodeCountry': 'UK'
         }
       }
-    };
+    });
 
     const LINE_1 = 0;
     const LINE_2 = 1;
@@ -382,23 +382,23 @@ describe('WriteComplexFieldComponent', () => {
       expect(values.length).toBe(3);
 
       let line1 = FIELD_TYPE.complex_fields[LINE_1];
-      expect(values[LINE_1].componentInstance.caseField).toEqual({
+      expect(values[LINE_1].componentInstance.caseField).toEqual( <CaseField>({
         id: line1.id,
         label: line1.label,
         display_context: 'OPTIONAL',
         field_type: line1.field_type,
         value: CASE_FIELD.value['AddressLine1']
-      });
+      }));
       expect(values[LINE_1].componentInstance.registerControl).not.toBeNull();
 
       let line2 = FIELD_TYPE.complex_fields[LINE_2];
-      expect(values[LINE_2].componentInstance.caseField).toEqual({
+      expect(values[LINE_2].componentInstance.caseField).toEqual( <CaseField>({
         id: line2.id,
         label: line2.label,
         display_context: 'OPTIONAL',
         field_type: line2.field_type,
         value: CASE_FIELD.value['AddressLine2']
-      });
+      }));
       expect(values[LINE_2].componentInstance.registerControl).not.toBeNull();
 
       let postcode = FIELD_TYPE.complex_fields[POSTCODE];
@@ -413,7 +413,7 @@ describe('WriteComplexFieldComponent', () => {
     });
 
     it('should render fields with empty value', () => {
-      component.caseField = {
+      component.caseField =  <CaseField>( <CaseField>({
         id: 'x',
         label: 'x',
         display_context: 'OPTIONAL',
@@ -421,7 +421,7 @@ describe('WriteComplexFieldComponent', () => {
         value: {
           'AddressLine1': 'Flat 9'
         }
-      };
+      }));
       fixture.detectChanges();
 
       let labels = de.queryAll($COMPLEX_PANEL_VALUES);
@@ -433,7 +433,7 @@ describe('WriteComplexFieldComponent', () => {
     });
 
     it('should render label if set to true', () => {
-      component.caseField = {
+      component.caseField =  <CaseField>({
         id: 'renderLabelId',
         label: 'Test Label',
         display_context: 'OPTIONAL',
@@ -441,7 +441,7 @@ describe('WriteComplexFieldComponent', () => {
         value: {
           'AddressLine1': 'Flat 9'
         }
-      };
+      });
       component.renderLabel = true;
       fixture.detectChanges();
       expect(component.caseField.label).toBe('Test Label');
@@ -453,7 +453,7 @@ describe('WriteComplexFieldComponent', () => {
       id: 'IAmVeryComplex',
       type: 'Complex',
       complex_fields: [
-        {
+        <CaseField>({
           id: 'AddressLine1',
           label: 'Line 1',
           display_context: 'MANDATORY',
@@ -462,8 +462,8 @@ describe('WriteComplexFieldComponent', () => {
             type: 'Text'
           },
           value: ''
-        },
-        {
+        }),
+        <CaseField>({
           id: 'AddressLine2',
           label: 'Line 2',
           display_context: 'OPTIONAL',
@@ -472,7 +472,7 @@ describe('WriteComplexFieldComponent', () => {
             type: 'Text'
           },
           value: '111 East India road'
-        }
+        })
       ]
     };
 
@@ -482,12 +482,12 @@ describe('WriteComplexFieldComponent', () => {
     };
 
     const FIELD_ID = 'AComplexField';
-    const CASE_FIELD_M: CaseField = {
+    const CASE_FIELD_M: CaseField =  <CaseField>({
       id: FIELD_ID,
       label: 'Complex Field',
       display_context: 'MANDATORY',
       field_type: FIELD_TYPE_WITH_VALUES
-    };
+    });
 
     const FORM_GROUP: FormGroup = new FormGroup({});
     const REGISTER_CONTROL = (control) => {
@@ -533,12 +533,12 @@ describe('WriteComplexFieldComponent', () => {
     }));
 
     it('should not add control when case field is not AddressLine1 and TextMax150', () => {
-      const CASE_FIELD_1: CaseField = {
+      const CASE_FIELD_1: CaseField =  <CaseField>({
         id: 'anotherComplexField',
         label: 'Complex Field',
         display_context: 'MANDATORY',
         field_type: FIELD_TYPE_WITH_MISSING_VALUE
-      };
+      });
       const firstControl = new FormControl();
       const formGroup = new FormGroup({});
       formGroup.addControl('first', firstControl);
@@ -552,7 +552,7 @@ describe('WriteComplexFieldComponent', () => {
     });
 
     it('should add control when case field is AddressLine1 and TextMax150', () => {
-      component.caseField = {
+      component.caseField =  <CaseField>({
         id: 'AddressLine1',
         label: 'x',
         display_context: 'MANDATORY',
@@ -560,7 +560,7 @@ describe('WriteComplexFieldComponent', () => {
         value: {
           'AddressLine1': 'Flat 9'
         }
-      };
+      });
       const firstControl = new FormControl();
       const formGroup = new FormGroup({});
       formGroup.addControl('first', firstControl);
@@ -574,7 +574,7 @@ describe('WriteComplexFieldComponent', () => {
     });
 
     it('should not add control when case field is AddressLine1 but NOT TextMax150', () => {
-      component.caseField = {
+      component.caseField =  <CaseField>({
         id: 'AddressLine1',
         label: 'x',
         display_context: 'MANDATORY',
@@ -585,7 +585,7 @@ describe('WriteComplexFieldComponent', () => {
         value: {
           'AddressLine1': 'Flat 9'
         }
-      };
+      });
       const firstControl = new FormControl();
       const formGroup = new FormGroup({});
       formGroup.addControl('first', firstControl);
@@ -599,7 +599,7 @@ describe('WriteComplexFieldComponent', () => {
     });
 
     it('should not add control when case field is NOT AddressLine1', () => {
-      component.caseField = {
+      component.caseField =  <CaseField>({
         id: 'AddressLine2',
         label: 'x',
         display_context: 'MANDATORY',
@@ -610,7 +610,7 @@ describe('WriteComplexFieldComponent', () => {
         value: {
           'AddressLine1': 'Flat 9'
         }
-      };
+      });
       const firstControl = new FormControl();
       const formGroup = new FormGroup({});
       formGroup.addControl('first', firstControl);

--- a/src/shared/components/palette/date/read-date-field.component.spec.ts
+++ b/src/shared/components/palette/date/read-date-field.component.spec.ts
@@ -12,13 +12,13 @@ describe('ReadDateFieldComponent', () => {
     type: 'Date'
   };
   const VALUE = '1800-07-15';
-  const CASE_FIELD: CaseField = {
+  const CASE_FIELD: CaseField = <CaseField>({
     id: 'x',
     label: 'X',
     display_context: 'OPTIONAL',
     field_type: FIELD_TYPE,
     value: VALUE
-  };
+  });
   const FORMATTED_VALUE = '15 Jul 1800';
   const EMPTY = '';
 

--- a/src/shared/components/palette/date/write-date-field.component.spec.ts
+++ b/src/shared/components/palette/date/write-date-field.component.spec.ts
@@ -14,13 +14,13 @@ const FIELD_TYPE: FieldType = {
   type: 'Date'
 };
 const VALUE = '2017-07-26';
-const CASE_FIELD: CaseField = {
+const CASE_FIELD: CaseField = <CaseField>({
   id: FIELD_ID,
   label: 'X',
   display_context: 'OPTIONAL',
   field_type: FIELD_TYPE,
   value: VALUE
-};
+});
 
 const FORM_GROUP: FormGroup = new FormGroup({});
 const REGISTER_CONTROL = (control) => {

--- a/src/shared/components/palette/document/read-document-field.component.spec.ts
+++ b/src/shared/components/palette/document/read-document-field.component.spec.ts
@@ -20,13 +20,13 @@ describe('ReadDocumentFieldComponent', () => {
     'document_binary_url': 'https://www.example.com/binary',
     'document_filename': 'evidence_document.evd'
   };
-  const CASE_FIELD: CaseField = {
+  const CASE_FIELD: CaseField = <CaseField>({
     id: 'x',
     label: 'X',
     display_context: 'OPTIONAL',
     field_type: FIELD_TYPE,
     value: VALUE
-  };
+  });
   const GATEWAY_DOCUMENT_URL = 'http://localhost:1234/documents';
 
   let fixture: ComponentFixture<ReadDocumentFieldComponent>;

--- a/src/shared/components/palette/document/write-document-field.component.spec.ts
+++ b/src/shared/components/palette/document/write-document-field.component.spec.ts
@@ -26,13 +26,13 @@ describe('WriteDocumentFieldComponent', () => {
     'document_binary_url': 'https://www.example.com/binary',
     'document_filename': 'evidence_document.evd'
   };
-  const CASE_FIELD: CaseField = {
+  const CASE_FIELD: CaseField = <CaseField>({
     id: 'x',
     label: 'X',
     display_context: 'OPTIONAL',
     field_type: FIELD_TYPE,
     value: VALUE
-  };
+  });
   const DOCUMENT_MANAGEMENT_URL = 'http://docmanagement.ccd.reform/documents';
   const RESPONSE_FIRST_DOCUMENT: DocumentData = {
     _embedded: {

--- a/src/shared/components/palette/email/read-email-field.component.spec.ts
+++ b/src/shared/components/palette/email/read-email-field.component.spec.ts
@@ -12,13 +12,13 @@ describe('ReadEmailFieldComponent', () => {
     type: 'Email'
   };
   const VALUE = 'ccd@hmcts.net';
-  const CASE_FIELD: CaseField = {
+  const CASE_FIELD: CaseField = <CaseField>({
     id: 'x',
     label: 'X',
     display_context: 'OPTIONAL',
     field_type: FIELD_TYPE,
     value: VALUE
-  };
+  });
   const EMPTY = '';
 
   let fixture: ComponentFixture<ReadEmailFieldComponent>;

--- a/src/shared/components/palette/email/write-email-field.component.spec.ts
+++ b/src/shared/components/palette/email/write-email-field.component.spec.ts
@@ -14,13 +14,13 @@ const FIELD_TYPE: FieldType = {
   type: 'Email'
 };
 const VALUE = 'ccd@hmcts.net';
-const CASE_FIELD: CaseField = {
+const CASE_FIELD: CaseField = <CaseField>({
   id: FIELD_ID,
   label: 'X',
   display_context: 'OPTIONAL',
   field_type: FIELD_TYPE,
   value: VALUE
-};
+});
 
 const FORM_GROUP: FormGroup = new FormGroup({});
 const REGISTER_CONTROL = (control) => {

--- a/src/shared/components/palette/fixed-list/read-fixed-list-field.component.spec.ts
+++ b/src/shared/components/palette/fixed-list/read-fixed-list-field.component.spec.ts
@@ -27,13 +27,28 @@ describe('ReadFixedListFieldComponent', () => {
       }
     ]
   };
-  const CASE_FIELD: CaseField = {
+  const ITEMS = [
+    {
+      code: 'M',
+      label: 'Male'
+    },
+    {
+      code: VALUE,
+      label: EXPECTED_LABEL
+    },
+    {
+      code: 'O',
+      label: 'Other'
+    }
+  ];
+
+  const CASE_FIELD: CaseField = Object.assign(new CaseField(), {
     id: 'x',
     label: 'X',
     display_context: 'OPTIONAL',
     field_type: FIELD_TYPE,
-    value: VALUE
-  };
+    value: VALUE,
+  });
 
   const EMPTY = '';
 
@@ -86,7 +101,7 @@ describe('ReadFixedListFieldComponent', () => {
 });
 
 describe('ReadFixedListFieldComponent for dynamiclist type', () => {
-
+  const VALUE = 'F';
   const VALUE_DYNAMIC_LIST = '{\n' +
     '            "value": {\n' +
     '              "code": "F",\n' +
@@ -104,35 +119,33 @@ describe('ReadFixedListFieldComponent for dynamiclist type', () => {
     '            ]\n' +
     '          }';
 
-  const CHANGED_VALUE_DYNAMIC_LIST = '{\n' +
-    '            "value": {\n' +
-    '              "code": "M",\n' +
-    '              "label": "Male"\n' +
-    '            },\n' +
-    '            "list_items": [\n' +
-    '              {\n' +
-    '                "code": "F",\n' +
-    '                "label": "Female"\n' +
-    '              },\n' +
-    '              {\n' +
-    '                "code": "M",\n' +
-    '                "label": "Male"\n' +
-    '              }' +
-    '            ]\n' +
-    '          }';
-  const EXPECTED_LABEL = 'Male';
+  const EXPECTED_LABEL = 'Female';
   const FIELD_TYPE_DYNAMIC_LIST: FieldType = {
     id: 'Gender',
     type: 'DynamicList',
     fixed_list_items: []
   };
-  const CASE_FIELD_DYNAMIC_LIST: CaseField = {
+  const ITEMS = [
+    {
+      code: 'M',
+      label: 'Male'
+    },
+    {
+      code: 'F',
+      label: 'Female'
+    },
+    {
+      code: 'O',
+      label: 'Other'
+    }
+  ];
+  const CASE_FIELD_DYNAMIC_LIST: CaseField = Object.assign(new CaseField(), {
     id: 'x',
     label: 'X',
     display_context: 'OPTIONAL',
     field_type: FIELD_TYPE_DYNAMIC_LIST,
-    value: JSON.parse(VALUE_DYNAMIC_LIST)
-  };
+    value: JSON.parse(VALUE_DYNAMIC_LIST),
+  });
   const EMPTY = '';
 
   let fixture: ComponentFixture<ReadFixedListFieldComponent>;
@@ -161,23 +174,7 @@ describe('ReadFixedListFieldComponent for dynamiclist type', () => {
   }));
 
   it('render label associated to the dynamic list value provided', () => {
-    component.caseField.value = JSON.parse(CHANGED_VALUE_DYNAMIC_LIST);
-    fixture.detectChanges();
-
     expect(de.nativeElement.textContent).toEqual(EXPECTED_LABEL);
   });
 
-  it('render undefined value as empty string', () => {
-    component.caseField.value = undefined;
-    fixture.detectChanges();
-
-    expect(de.nativeElement.textContent).toEqual(EMPTY);
-  });
-
-  it('render null value as empty string', () => {
-    component.caseField.value = null;
-    fixture.detectChanges();
-
-    expect(de.nativeElement.textContent).toEqual(EMPTY);
-  });
 });

--- a/src/shared/components/palette/fixed-list/read-fixed-list-field.component.ts
+++ b/src/shared/components/palette/fixed-list/read-fixed-list-field.component.ts
@@ -3,7 +3,7 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'ccd-read-fixed-list-field',
-  template: '<span class="text-16">{{caseField.value | ccdFixedList:caseField.items}}</span>',
+  template: '<span class="text-16">{{caseField.value | ccdFixedList:caseField.list_items}}</span>',
 })
 export class ReadFixedListFieldComponent extends AbstractFieldReadComponent {
 }

--- a/src/shared/components/palette/fixed-list/read-fixed-list-field.component.ts
+++ b/src/shared/components/palette/fixed-list/read-fixed-list-field.component.ts
@@ -1,39 +1,9 @@
 import { AbstractFieldReadComponent } from '../base-field/abstract-field-read.component';
-import { Component, OnInit } from '@angular/core';
-import { CaseField } from '../../../domain/definition';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'ccd-read-fixed-list-field',
-  template: '<span class="text-16">{{caseField.getValue() | ccdFixedList:caseField.getItems()}}</span>',
+  template: '<span class="text-16">{{caseField.value | ccdFixedList:caseField.items}}</span>',
 })
-export class ReadFixedListFieldComponent extends AbstractFieldReadComponent implements OnInit {
-
-  /**
-   * THIS METHOD WILL NEED TO BE REMOVED AS REFACTORING OF
-   * https://tools.hmcts.net/jira/browse/RDM-4704
-   *
-   */
-  ngOnInit() {
-    if (this.caseField) {
-      var cf = new CaseField();
-      cf.field_type = this.caseField.field_type;
-      cf.id = this.caseField.id;
-      cf.display_context_parameter = this.caseField.display_context_parameter;
-      cf.hidden = this.caseField.hidden;
-      cf.label = this.caseField.label;
-      cf.order = this.caseField.order;
-      cf.field_type = this.caseField.field_type;
-      cf.value = this.caseField.value;
-      cf.hint_text = this.caseField.hint_text;
-      cf.security_label = this.caseField.security_label;
-      cf.display_context = this.caseField.display_context;
-      cf.display_context_parameter = this.caseField.display_context_parameter;
-      cf.show_condition = this.caseField.show_condition;
-      cf.show_summary_change_option = this.caseField.show_summary_change_option;
-      cf.show_summary_content_option = this.caseField.show_summary_content_option;
-      cf.acls = this.caseField.acls;
-      cf.wizardProps = this.caseField.wizardProps;
-      this.caseField = cf;
-    }
-  }
+export class ReadFixedListFieldComponent extends AbstractFieldReadComponent {
 }

--- a/src/shared/components/palette/fixed-list/write-fixed-list-field.component.spec.ts
+++ b/src/shared/components/palette/fixed-list/write-fixed-list-field.component.spec.ts
@@ -29,13 +29,13 @@ const FIELD_TYPE: FieldType = {
     }
   ]
 };
-const CASE_FIELD: CaseField = {
+const CASE_FIELD: CaseField = Object.assign(new CaseField(), {
   id: FIELD_ID,
   label: 'X',
   display_context: 'OPTIONAL',
   field_type: FIELD_TYPE,
   value: VALUE
-};
+});
 
 const FORM_GROUP: FormGroup = new FormGroup({});
 const REGISTER_CONTROL = (control) => {

--- a/src/shared/components/palette/fixed-list/write-fixed-list-field.component.ts
+++ b/src/shared/components/palette/fixed-list/write-fixed-list-field.component.ts
@@ -1,10 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { AbstractFieldWriteComponent } from '../base-field/abstract-field-write.component';
-import { CaseField, FieldType } from '../../../domain/definition';
-import { Type } from 'class-transformer';
-import { AccessControlList } from '../../../domain/definition/access-control-list.model';
-import { WizardPageField } from '../../case-editor/domain';
 
 @Component({
   selector: 'ccd-write-fixed-list-field',
@@ -15,38 +11,7 @@ export class WriteFixedListFieldComponent extends AbstractFieldWriteComponent im
   fixedListControl: FormControl;
 
   ngOnInit() {
-    this.instantiate();
     let notEmpty = this.caseField.value !== null && this.caseField.value !== undefined;
-    this.fixedListControl = this.registerControl(new FormControl(notEmpty ? this.caseField.getValue() : null));
-
-  }
-
-  /**
-   * THIS METHOD WILL NEED TO BE REMOVED AS REFACTORING OF
-   * https://tools.hmcts.net/jira/browse/RDM-4704
-   *
-   */
-  private instantiate(){
-    if(this.caseField){
-      var cf = new CaseField();
-      cf.field_type = this.caseField.field_type;
-      cf.id = this.caseField.id;
-      cf.display_context_parameter = this.caseField.display_context_parameter;
-      cf.hidden = this.caseField.hidden;
-      cf.label = this.caseField.label;
-      cf.order = this.caseField.order;
-      cf.field_type = this.caseField.field_type;
-      cf.value = this.caseField.value;
-      cf.hint_text = this.caseField.hint_text;
-      cf.security_label = this.caseField.security_label;
-      cf.display_context = this.caseField.display_context;
-      cf.display_context_parameter = this.caseField.display_context_parameter;
-      cf.show_condition = this.caseField.show_condition;
-      cf.show_summary_change_option = this.caseField.show_summary_change_option;
-      cf.show_summary_content_option = this.caseField.show_summary_content_option;
-      cf.acls = this.caseField.acls;
-      cf.wizardProps = this.caseField.wizardProps;
-      this.caseField = cf;
-    }
+    this.fixedListControl = this.registerControl(new FormControl(notEmpty ? this.caseField.value : null));
   }
 }

--- a/src/shared/components/palette/fixed-list/write-fixed-list-field.component.ts
+++ b/src/shared/components/palette/fixed-list/write-fixed-list-field.component.ts
@@ -13,8 +13,12 @@ export class WriteFixedListFieldComponent extends AbstractFieldWriteComponent im
   ngOnInit() {
     let notEmpty = this.caseField.value !== null && this.caseField.value !== undefined;
     this.fixedListControl = this.registerControl(new FormControl(notEmpty ? this.caseField.value : null));
-    if(this.fixedListControl.value && this.fixedListControl.value.value){
-      this.fixedListControl.setValue(this.fixedListControl.value.value.code);
+    if (this.hasSanitisedDynamicListData()) {
+      this.fixedListControl.setValue(this.caseField.value);
     }
+  }
+
+  private hasSanitisedDynamicListData() {
+    return this.fixedListControl.value && this.fixedListControl.value.value;
   }
 }

--- a/src/shared/components/palette/fixed-list/write-fixed-list-field.component.ts
+++ b/src/shared/components/palette/fixed-list/write-fixed-list-field.component.ts
@@ -13,5 +13,8 @@ export class WriteFixedListFieldComponent extends AbstractFieldWriteComponent im
   ngOnInit() {
     let notEmpty = this.caseField.value !== null && this.caseField.value !== undefined;
     this.fixedListControl = this.registerControl(new FormControl(notEmpty ? this.caseField.value : null));
+    if(this.fixedListControl.value && this.fixedListControl.value.value){
+      this.fixedListControl.setValue(this.fixedListControl.value.value.code);
+    }
   }
 }

--- a/src/shared/components/palette/fixed-list/write-fixed-list-field.html
+++ b/src/shared/components/palette/fixed-list/write-fixed-list-field.html
@@ -8,7 +8,7 @@
 
   <select class="form-control ccd-dropdown bottom-30" [id]="id()" [formControl]="fixedListControl">
     <option value="">--Select a value--</option>
-    <option value="{{type.code}}" *ngFor="let type of caseField.getItems()">
+    <option value="{{type.code}}" *ngFor="let type of caseField.items">
       {{type.label}}
     </option>
   </select>

--- a/src/shared/components/palette/fixed-list/write-fixed-list-field.html
+++ b/src/shared/components/palette/fixed-list/write-fixed-list-field.html
@@ -8,7 +8,7 @@
 
   <select class="form-control ccd-dropdown bottom-30" [id]="id()" [formControl]="fixedListControl">
     <option value="">--Select a value--</option>
-    <option value="{{type.code}}" *ngFor="let type of caseField.items">
+    <option value="{{type.code}}" *ngFor="let type of caseField.list_items">
       {{type.label}}
     </option>
   </select>

--- a/src/shared/components/palette/fixed-radio-list/read-fixed-radio-list-field.component.spec.ts
+++ b/src/shared/components/palette/fixed-radio-list/read-fixed-radio-list-field.component.spec.ts
@@ -27,13 +27,13 @@ describe('ReadFixedRadioListFieldComponent', () => {
       }
     ]
   };
-  const CASE_FIELD: CaseField = {
+  const CASE_FIELD: CaseField = <CaseField>({
     id: 'x',
     label: 'X',
     display_context: 'OPTIONAL',
     field_type: FIELD_TYPE,
     value: VALUE
-  };
+  });
   const EMPTY = '';
 
   let fixture: ComponentFixture<ReadFixedRadioListFieldComponent>;

--- a/src/shared/components/palette/fixed-radio-list/write-fixed-radio-list-field.component.spec.ts
+++ b/src/shared/components/palette/fixed-radio-list/write-fixed-radio-list-field.component.spec.ts
@@ -29,13 +29,13 @@ const FIELD_TYPE: FieldType = {
     }
   ]
 };
-const CASE_FIELD: CaseField = {
+const CASE_FIELD: CaseField = <CaseField>({
   id: FIELD_ID,
   label: 'X',
   display_context: 'OPTIONAL',
   field_type: FIELD_TYPE,
   value: VALUE
-};
+});
 
 const FORM_GROUP: FormGroup = new FormGroup({});
 const REGISTER_CONTROL = (control) => {

--- a/src/shared/components/palette/history/case-history-viewer-field.component.spec.ts
+++ b/src/shared/components/palette/history/case-history-viewer-field.component.spec.ts
@@ -51,13 +51,13 @@ describe('CaseHistoryViewerFieldComponent', () => {
       }
     }
   ];
-  const CASE_FIELD: CaseField = {
+  const CASE_FIELD: CaseField = <CaseField>({
     id: 'x',
     label: 'X',
     display_context: 'OPTIONAL',
     field_type: FIELD_TYPE,
     value: CASE_EVENTS
-  };
+  });
   const CASE_REFERENCE = '1234123412341234';
 
   let EventLogComponent;

--- a/src/shared/components/palette/label/label-field.component.spec.ts
+++ b/src/shared/components/palette/label/label-field.component.spec.ts
@@ -17,27 +17,27 @@ describe('LabelFieldComponent', () => {
     id: 'Label',
     type: 'Label'
   };
-  const CASE_FIELD_WITH_NO_VALUE: CaseField = {
+  const CASE_FIELD_WITH_NO_VALUE: CaseField = <CaseField>({
     id: 'label',
     label: 'Label Field Label',
     display_context: 'OPTIONAL',
     field_type: FIELD_TYPE,
-  };
-  const CASE_FIELD: CaseField = {
+  });
+  const CASE_FIELD: CaseField = <CaseField>({
     id: 'label',
     label: 'Label Field Label',
     display_context: 'OPTIONAL',
     field_type: FIELD_TYPE,
     value: 'Label Field Value'
-  };
+  });
 
-  const LABEL_CASE_FIELD: CaseField = {
+  const LABEL_CASE_FIELD: CaseField = <CaseField>({
     id: 'field',
     label: '${label}',
     display_context: 'OPTIONAL',
     field_type: FIELD_TYPE,
     value: 'Label Field Value'
-  };
+  });
 
   const CASE_FIELDS: CaseField[] = [
     CASE_FIELD

--- a/src/shared/components/palette/money-gbp/read-money-gbp-field.component.spec.ts
+++ b/src/shared/components/palette/money-gbp/read-money-gbp-field.component.spec.ts
@@ -11,13 +11,13 @@ describe('ReadMoneyGBPFieldComponent', () => {
       type: 'MoneyGBP'
     };
     const VALUE = 4220;
-    const CASE_FIELD: CaseField = {
+    const CASE_FIELD: CaseField = <CaseField>({
       id: 'x',
       label: 'X',
       display_context: 'OPTIONAL',
       field_type: FIELD_TYPE,
       value: VALUE
-    };
+    });
 
     let fixture: ComponentFixture<ReadMoneyGbpFieldComponent>;
     let component: ReadMoneyGbpFieldComponent;

--- a/src/shared/components/palette/money-gbp/write-money-gbp-field.component.spec.ts
+++ b/src/shared/components/palette/money-gbp/write-money-gbp-field.component.spec.ts
@@ -15,13 +15,13 @@ const FIELD_TYPE: FieldType = {
   type: 'MoneyGBP'
 };
 const VALUE = '23';
-const CASE_FIELD: CaseField = {
+const CASE_FIELD: CaseField = <CaseField>({
   id: FIELD_ID,
   label: 'X',
   display_context: 'OPTIONAL',
   field_type: FIELD_TYPE,
   value: VALUE
-};
+});
 
 const FORM_GROUP: FormGroup = new FormGroup({});
 const REGISTER_CONTROL = (control) => {

--- a/src/shared/components/palette/number/read-number-field.component.spec.ts
+++ b/src/shared/components/palette/number/read-number-field.component.spec.ts
@@ -12,13 +12,13 @@ describe('ReadNumberFieldComponent', () => {
     type: 'Number'
   };
   const VALUE = 42;
-  const CASE_FIELD: CaseField = {
+  const CASE_FIELD: CaseField = <CaseField>({
     id: 'x',
     label: 'X',
     display_context: 'OPTIONAL',
     field_type: FIELD_TYPE,
     value: VALUE
-  };
+  });
 
   let fixture: ComponentFixture<ReadNumberFieldComponent>;
   let component: ReadNumberFieldComponent;

--- a/src/shared/components/palette/number/write-number-field.component.spec.ts
+++ b/src/shared/components/palette/number/write-number-field.component.spec.ts
@@ -14,13 +14,13 @@ const FIELD_TYPE: FieldType = {
   type: 'Number'
 };
 const VALUE = '23';
-const CASE_FIELD: CaseField = {
+const CASE_FIELD: CaseField = <CaseField>({
   id: FIELD_ID,
   label: 'X',
   display_context: 'OPTIONAL',
   field_type: FIELD_TYPE,
   value: VALUE
-};
+});
 
 const FORM_GROUP: FormGroup = new FormGroup({});
 const REGISTER_CONTROL = (control) => {

--- a/src/shared/components/palette/order-summary/read-order-summary-field.component.spec.ts
+++ b/src/shared/components/palette/order-summary/read-order-summary-field.component.spec.ts
@@ -42,27 +42,27 @@ describe('ReadOrderSummaryFieldComponent', () => {
 
   const EXPECTED_FEE_AMOUNTS = ['£45.45', '£4.55'];
   const EXPECTED_PAYMENT_TOTAL = '£50.00';
-  const CASE_FIELD: CaseField = {
+  const CASE_FIELD: CaseField = <CaseField>({
     id: 'x',
     label: 'X',
     display_context: 'READONLY',
     field_type: FIELD_TYPE,
     value: VALUE
-  };
-  const UNDEFINED_CASE_FIELD: CaseField = {
+  });
+  const UNDEFINED_CASE_FIELD: CaseField = <CaseField>({
     id: 'x',
     label: 'X',
     display_context: 'READONLY',
     field_type: FIELD_TYPE,
     value: undefined
-  };
-  const NULL_CASE_FIELD: CaseField = {
+  });
+  const NULL_CASE_FIELD: CaseField = <CaseField>({
     id: 'x',
     label: 'X',
     display_context: 'READONLY',
     field_type: FIELD_TYPE,
     value: null
-  };
+  });
 
   const $HEAD_ROW = By.css('table>thead>tr');
   const $BODY = By.css('table>tbody');

--- a/src/shared/components/palette/order-summary/write-order-summary-field.component.spec.ts
+++ b/src/shared/components/palette/order-summary/write-order-summary-field.component.spec.ts
@@ -44,27 +44,27 @@ describe('WriteOrderSummaryFieldComponent', () => {
   const EXPECTED_FEE_AMOUNTS = ['£45.45', '£4.55'];
   const EXPECTED_PAYMENT_TOTAL = '£50.00';
   const ID = 'PersonOrderSummary';
-  const CASE_FIELD: CaseField = {
+  const CASE_FIELD: CaseField = <CaseField>({
     id: ID,
     label: 'X',
     display_context: 'MANDATORY',
     field_type: FIELD_TYPE,
     value: VALUE
-  };
-  const UNDEFINED_CASE_FIELD: CaseField = {
+  });
+  const UNDEFINED_CASE_FIELD: CaseField = <CaseField>({
     id: 'x',
     label: 'X',
     display_context: 'MANDATORY',
     field_type: FIELD_TYPE,
     value: undefined
-  };
-  const NULL_CASE_FIELD: CaseField = {
+  });
+  const NULL_CASE_FIELD: CaseField = <CaseField>({
     id: 'x',
     label: 'X',
     display_context: 'MANDATORY',
     field_type: FIELD_TYPE,
     value: null
-  };
+  });
 
   const $HEAD_ROW = By.css('table>thead>tr');
   const $BODY = By.css('table>tbody');

--- a/src/shared/components/palette/payment/case-payment-history-viewer-field.component.spec.ts
+++ b/src/shared/components/palette/payment/case-payment-history-viewer-field.component.spec.ts
@@ -5,8 +5,8 @@ import { CaseField } from '../../../domain/definition/case-field.model';
 import { CasePaymentHistoryViewerFieldComponent } from './case-payment-history-viewer-field.component';
 import { MockComponent } from 'ng2-mock-component';
 import { By } from '@angular/platform-browser';
-import createSpyObj = jasmine.createSpyObj;
 import { AbstractAppConfig } from '../../../../app.config';
+import createSpyObj = jasmine.createSpyObj;
 
 describe('CasePaymentHistoryViewerFieldComponent', () => {
 
@@ -14,12 +14,12 @@ describe('CasePaymentHistoryViewerFieldComponent', () => {
     id: 'CasePaymentHistoryViewer',
     type: 'CasePaymentHistoryViewer'
   };
-  const CASE_FIELD: CaseField = {
+  const CASE_FIELD: CaseField = <CaseField>({
     id: 'x',
     label: 'X',
     display_context: 'OPTIONAL',
     field_type: FIELD_TYPE,
-  };
+  });
   const CASE_REFERENCE = '1234123412341234';
   const PAYMENTS_URL = 'http://payment-api:123';
 

--- a/src/shared/components/palette/phone-uk/read-phone-uk-field.component.spec.ts
+++ b/src/shared/components/palette/phone-uk/read-phone-uk-field.component.spec.ts
@@ -12,13 +12,13 @@ describe('ReadPhoneUKFieldComponent', () => {
   };
   const VALUE = '07123456789';
   const EMPTY = '';
-  const CASE_FIELD: CaseField = {
+  const CASE_FIELD: CaseField = <CaseField>({
     id: 'x',
     label: 'X',
     display_context: 'OPTIONAL',
     field_type: FIELD_TYPE,
     value: VALUE
-  };
+  });
 
   let fixture: ComponentFixture<ReadPhoneUKFieldComponent>;
   let component: ReadPhoneUKFieldComponent;

--- a/src/shared/components/palette/phone-uk/write-phone-uk-field.component.spec.ts
+++ b/src/shared/components/palette/phone-uk/write-phone-uk-field.component.spec.ts
@@ -14,13 +14,13 @@ const FIELD_TYPE: FieldType = {
   type: 'PhoneUK'
 };
 const VALUE = '07123456789';
-const CASE_FIELD: CaseField = {
+const CASE_FIELD: CaseField = <CaseField>({
   id: FIELD_ID,
   label: 'X',
   display_context: 'OPTIONAL',
   field_type: FIELD_TYPE,
   value: VALUE
-};
+});
 
 const FORM_GROUP: FormGroup = new FormGroup({});
 const REGISTER_CONTROL = (control) => {

--- a/src/shared/components/palette/text-area/read-text-area-field.component.spec.ts
+++ b/src/shared/components/palette/text-area/read-text-area-field.component.spec.ts
@@ -15,13 +15,13 @@ describe('ReadTextAreaFieldComponent', () => {
     type: 'Text'
   };
   const VALUE = 'Hello world';
-  const CASE_FIELD: CaseField = {
+  const CASE_FIELD: CaseField = <CaseField>({
     id: 'x',
     label: 'X',
     display_context: 'OPTIONAL',
     field_type: FIELD_TYPE,
     value: VALUE
-  };
+  });
 
   let fixture: ComponentFixture<ReadTextAreaFieldComponent>;
   let component: ReadTextAreaFieldComponent;

--- a/src/shared/components/palette/text-area/write-text-area-field.component.spec.ts
+++ b/src/shared/components/palette/text-area/write-text-area-field.component.spec.ts
@@ -14,13 +14,13 @@ const FIELD_TYPE: FieldType = {
   type: 'TextArea'
 };
 const VALUE = 'Hello world';
-const CASE_FIELD: CaseField = {
+const CASE_FIELD: CaseField = <CaseField>({
   id: FIELD_ID,
   label: 'X',
   display_context: 'OPTIONAL',
   field_type: FIELD_TYPE,
   value: VALUE
-};
+});
 
 const FORM_GROUP: FormGroup = new FormGroup({});
 const REGISTER_CONTROL = (control) => {

--- a/src/shared/components/palette/text/read-text-field.component.spec.ts
+++ b/src/shared/components/palette/text/read-text-field.component.spec.ts
@@ -11,13 +11,13 @@ describe('ReadTextFieldComponent', () => {
     type: 'Text'
   };
   const VALUE = 'Hello world';
-  const CASE_FIELD: CaseField = {
+  const CASE_FIELD: CaseField = <CaseField>({
     id: 'x',
     label: 'X',
     field_type: FIELD_TYPE,
     value: VALUE,
     display_context: 'READONLY'
-  };
+  });
 
   let fixture: ComponentFixture<ReadTextFieldComponent>;
   let component: ReadTextFieldComponent;

--- a/src/shared/components/palette/text/write-text-field.component.spec.ts
+++ b/src/shared/components/palette/text/write-text-field.component.spec.ts
@@ -14,13 +14,13 @@ const FIELD_TYPE: FieldType = {
   type: 'Text'
 };
 const VALUE = 'Hello world';
-const CASE_FIELD: CaseField = {
+const CASE_FIELD: CaseField = <CaseField>({
   id: FIELD_ID,
   label: 'X',
   field_type: FIELD_TYPE,
   value: VALUE,
   display_context: 'OPTIONAL'
-};
+});
 
 const FORM_GROUP: FormGroup = new FormGroup({});
 const REGISTER_CONTROL = (control) => {

--- a/src/shared/components/palette/yes-no/read-yes-no-field.component.spec.ts
+++ b/src/shared/components/palette/yes-no/read-yes-no-field.component.spec.ts
@@ -13,13 +13,13 @@ describe('ReadYesNoFieldComponent', () => {
     type: 'YesOrNo'
   };
   const VALUE = true;
-  const CASE_FIELD: CaseField = {
+  const CASE_FIELD: CaseField = <CaseField>({
     id: 'x',
     label: 'X',
     display_context: 'OPTIONAL',
     field_type: FIELD_TYPE,
     value: VALUE
-  };
+  });
   const FORMATTED_VALUE = 'Yes';
 
   let fixture: ComponentFixture<ReadYesNoFieldComponent>;

--- a/src/shared/components/palette/yes-no/write-yes-no-field.component.spec.ts
+++ b/src/shared/components/palette/yes-no/write-yes-no-field.component.spec.ts
@@ -17,13 +17,13 @@ const FIELD_TYPE: FieldType = {
 };
 const VALUE = 'yes';
 const FORMATTED_VALUE = 'Yes';
-const CASE_FIELD: CaseField = {
+const CASE_FIELD: CaseField = <CaseField>({
   id: FIELD_ID,
   label: 'X',
   display_context: 'OPTIONAL',
   field_type: FIELD_TYPE,
   value: VALUE
-};
+});
 
 const FORM_GROUP: FormGroup = new FormGroup({});
 const REGISTER_CONTROL = (control) => {

--- a/src/shared/components/search-result/search-result.component.ts
+++ b/src/shared/components/search-result/search-result.component.ts
@@ -114,7 +114,7 @@ export class SearchResultComponent implements OnChanges {
 
         const field = result.case_fields[fieldId];
 
-        caseFields.push(plainToClass(CaseField, {
+        caseFields.push(Object.assign(new CaseField(), {
           id: fieldId,
           label: null,
           field_type: {},
@@ -147,7 +147,7 @@ export class SearchResultComponent implements OnChanges {
   }
 
   buildCaseField(col: SearchResultViewColumn, result: SearchResultViewItem): CaseField {
-    return plainToClass(CaseField, {
+    return Object.assign(new CaseField(), {
       id: col.case_field_id,
       label: col.label,
       field_type: col.case_field_type,

--- a/src/shared/components/search-result/search-result.component.ts
+++ b/src/shared/components/search-result/search-result.component.ts
@@ -6,6 +6,7 @@ import { FormGroup } from '@angular/forms';
 import { ActivityService, SearchResultViewItemComparatorFactory } from '../../services';
 import { CaseReferencePipe } from '../../pipes';
 import { AbstractAppConfig } from '../../../app.config';
+import { plainToClass } from 'class-transformer';
 
 @Component({
   selector: 'ccd-search-result',
@@ -113,13 +114,13 @@ export class SearchResultComponent implements OnChanges {
 
         const field = result.case_fields[fieldId];
 
-        caseFields.push({
+        caseFields.push(plainToClass(CaseField, {
           id: fieldId,
           label: null,
           field_type: {},
           value: field,
           display_context: null,
-        });
+        }));
       });
 
       result.hydrated_case_fields = caseFields;
@@ -146,13 +147,13 @@ export class SearchResultComponent implements OnChanges {
   }
 
   buildCaseField(col: SearchResultViewColumn, result: SearchResultViewItem): CaseField {
-    return {
+    return plainToClass(CaseField, {
       id: col.case_field_id,
       label: col.label,
       field_type: col.case_field_type,
       value: result.case_fields[col.case_field_id],
       display_context: null,
-    };
+    });
   }
 
   getColumnsWithPrefix(col: CaseField, result: SearchResultViewItem): CaseField {

--- a/src/shared/domain/case-view/case-tab.model.ts
+++ b/src/shared/domain/case-view/case-tab.model.ts
@@ -1,10 +1,13 @@
 import { Orderable } from '../order';
 import { CaseField } from '../definition';
+import { Type } from 'class-transformer';
 
+// @dynamic
 export class CaseTab implements Orderable {
   id: string;
   label: string;
   order?: number;
+  @Type(() => CaseField)
   fields: CaseField[];
   show_condition?: string;
 }

--- a/src/shared/domain/case-view/case-view.model.ts
+++ b/src/shared/domain/case-view/case-view.model.ts
@@ -2,7 +2,9 @@ import { CaseTab } from './case-tab.model';
 import { CaseViewEvent } from './case-view-event.model';
 import { CaseViewTrigger } from './case-view-trigger.model';
 import { CaseField } from '../definition';
+import { Type } from 'class-transformer';
 
+// @dynamic
 export class CaseView {
   case_id?: string;
   case_type: {
@@ -25,5 +27,6 @@ export class CaseView {
   tabs: CaseTab[];
   triggers: CaseViewTrigger[];
   events: CaseViewEvent[];
+  @Type(() => CaseField)
   metadataFields?: CaseField[];
 }

--- a/src/shared/domain/case-view/case-view.model.ts
+++ b/src/shared/domain/case-view/case-view.model.ts
@@ -24,6 +24,7 @@ export class CaseView {
     title_display?: string
   };
   channels: string[];
+  @Type(()=> CaseTab)
   tabs: CaseTab[];
   triggers: CaseViewTrigger[];
   events: CaseViewEvent[];

--- a/src/shared/domain/definition/case-field-model.spec.ts
+++ b/src/shared/domain/definition/case-field-model.spec.ts
@@ -37,4 +37,18 @@ describe('CaseFieldTest', () => {
     expect(component.value).toBe(VALUE);
     expect(component.list_items).toBeUndefined();
   });
+
+  it('should be able to test if the field is readonly', () => {
+    expect(component.isReadonly()).toBe(false);
+    component.display_context = null
+    expect(component.isReadonly()).toBe(false);
+    component.display_context = "Mandatory";
+    expect(component.isReadonly()).toBe(false);
+    component.display_context = "Optional";
+    expect(component.isReadonly()).toBe(false);
+    component.display_context = "REAdOnlY";
+    expect(component.isReadonly()).toBe(true);
+  });
+
+
 });

--- a/src/shared/domain/definition/case-field-model.spec.ts
+++ b/src/shared/domain/definition/case-field-model.spec.ts
@@ -1,0 +1,40 @@
+import { CaseField } from './case-field.model';
+import { async } from '@angular/core/testing';
+import { FieldType } from './field-type.model';
+
+describe('CaseFieldTest', () => {
+
+  let component: CaseField;
+  const VALUE: any = { value: {code: 'Code1', label:'Label 1'}, list_items: [{code: 'Code1', label:'Label 1'}, {code: 'Code2', label:'Label 2'}]};
+  beforeEach(async(() => {
+    component = new CaseField();
+  }));
+
+  it('should be able to retrive right values from the accessors menthods when FieldType is DynamicLists', () => {
+
+    let fieldType: FieldType = new FieldType();
+    fieldType.type = 'DynamicList'
+    component.field_type = fieldType;
+    expect(component.value).toBeUndefined();
+    expect(component.list_items).toEqual([]);
+    component.value = 'Ali'
+    expect(component.value).toBe('Ali');
+    component.value = VALUE;
+    expect(component.value).toBe('Code1');
+    expect(component.list_items).toEqual([{code: 'Code1', label:'Label 1'}, {code: 'Code2', label:'Label 2'}]);
+  });
+
+  it('should be able to retrive right values from the accessors menthods when FieldType is Text', () => {
+    let fieldType: FieldType = new FieldType();
+    fieldType.type = 'Text'
+    component.field_type = fieldType;
+    expect(component.value).toBeUndefined();
+    expect(component.list_items).toBeUndefined();
+    component.value = 'Ali'
+
+    expect(component.value).toBe('Ali');
+    component.value = VALUE;
+    expect(component.value).toBe(VALUE);
+    expect(component.list_items).toBeUndefined();
+  });
+});

--- a/src/shared/domain/definition/case-field.model.ts
+++ b/src/shared/domain/definition/case-field.model.ts
@@ -3,6 +3,7 @@ import { FieldType } from './field-type.model';
 import { WizardPageField } from '../../components/case-editor/domain';
 import { Expose, Type } from 'class-transformer';
 import { AccessControlList } from './access-control-list.model';
+import { _ } from 'underscore';
 
 // @dynamic
 export class CaseField implements Orderable {
@@ -57,8 +58,8 @@ export class CaseField implements Orderable {
 
   @Expose()
   public isReadonly() {
-    return  (!(typeof this.display_context === 'undefined' || this.display_context === null )
-      && this.display_context.toUpperCase() === 'READONLY');
+    return !_.isEmpty(this.display_context)
+      && this.display_context.toUpperCase() === 'READONLY';
   }
-  
+
 }

--- a/src/shared/domain/definition/case-field.model.ts
+++ b/src/shared/domain/definition/case-field.model.ts
@@ -55,4 +55,10 @@ export class CaseField implements Orderable {
     this._list_items = items;
   }
 
+  @Expose()
+  public isReadonly() {
+    return  (!(typeof this.display_context === 'undefined' || this.display_context === null )
+      && this.display_context.toUpperCase() === 'READONLY');
+  }
+  
 }

--- a/src/shared/domain/definition/case-field.model.ts
+++ b/src/shared/domain/definition/case-field.model.ts
@@ -1,7 +1,7 @@
 import { Orderable } from '../order';
 import { FieldType } from './field-type.model';
 import { WizardPageField } from '../../components/case-editor/domain';
-import { Type } from 'class-transformer';
+import { Expose, Type } from 'class-transformer';
 import { AccessControlList } from './access-control-list.model';
 
 // @dynamic
@@ -13,7 +13,7 @@ export class CaseField implements Orderable {
 
   @Type(() => FieldType)
   field_type: FieldType;
-  value?: any;
+
   hint_text?: string;
   security_label?: string;
   display_context: string;
@@ -26,20 +26,33 @@ export class CaseField implements Orderable {
   @Type(() => WizardPageField)
   wizardProps?: WizardPageField;
 
+  private _value: any;
+  private _items: any = [];
 
-  getValue?(): string {
-    if (this.field_type.type === 'DynamicList') {
-      return this.value ? this.value.value.code : '';
+  @Expose()
+  get value(): any {
+    if (this.field_type && this.field_type.type === 'DynamicList') {
+      return this._value && this._value.value ? this._value.value.code : this._value;
     } else {
-      return this.value;
+      return this._value;
     }
   }
 
-  getItems?(): any {
-    if (this.field_type.type === 'DynamicList') {
-      return this.value ? this.value.list_items : [];
+  set value(newValue: any) {
+    this._value = newValue;
+  }
+
+  @Expose()
+  get items(): any {
+    if (this.field_type && this.field_type.type === 'DynamicList') {
+      return this._value.list_items ? this._value.list_items : this._items;
     } else {
       return this.field_type.fixed_list_items;
     }
   }
+
+  set items(newItems: any) {
+    this._items = newItems;
+  }
+
 }

--- a/src/shared/domain/definition/case-field.model.ts
+++ b/src/shared/domain/definition/case-field.model.ts
@@ -27,7 +27,7 @@ export class CaseField implements Orderable {
   wizardProps?: WizardPageField;
 
   private _value: any;
-  private _items: any = [];
+  private _list_items: any = [];
 
   @Expose()
   get value(): any {
@@ -38,21 +38,21 @@ export class CaseField implements Orderable {
     }
   }
 
-  set value(newValue: any) {
-    this._value = newValue;
+  set value(value: any) {
+    this._value = value;
   }
 
   @Expose()
-  get items(): any {
+  get list_items(): any {
     if (this.field_type && this.field_type.type === 'DynamicList') {
-      return this._value.list_items ? this._value.list_items : this._items;
+      return this._value.list_items ? this._value.list_items : this._list_items;
     } else {
       return this.field_type.fixed_list_items;
     }
   }
 
-  set items(newItems: any) {
-    this._items = newItems;
+  set list_items(items: any) {
+    this._list_items = items;
   }
 
 }

--- a/src/shared/domain/definition/case-field.model.ts
+++ b/src/shared/domain/definition/case-field.model.ts
@@ -45,7 +45,7 @@ export class CaseField implements Orderable {
   @Expose()
   get list_items(): any {
     if (this.field_type && this.field_type.type === 'DynamicList') {
-      return this._value.list_items ? this._value.list_items : this._list_items;
+      return this._value && this._value.list_items ? this._value.list_items : this._list_items;
     } else {
       return this.field_type.fixed_list_items;
     }

--- a/src/shared/domain/definition/case-type.model.ts
+++ b/src/shared/domain/definition/case-type.model.ts
@@ -2,13 +2,18 @@ import { CaseEvent } from './case-event.model';
 import { CaseState } from './case-state.model';
 import { Jurisdiction } from './jurisdiction.model';
 import { CaseField } from './case-field.model';
+import { Type } from 'class-transformer';
 
+// @dynamics
 export class CaseType {
   id: string;
   name: string;
   events: CaseEvent[];
   states: CaseState[];
+
+  @Type(() => CaseField)
   case_fields: CaseField[];
+
   description: string;
   jurisdiction: Jurisdiction;
 }

--- a/src/shared/domain/search/search-result-view-item.model.ts
+++ b/src/shared/domain/search/search-result-view-item.model.ts
@@ -1,8 +1,11 @@
 import { CaseField } from '../definition';
+import { Type } from 'class-transformer';
 
+// @dynamic
 export class SearchResultViewItem {
   case_id: string;
   case_fields: object;
+  @Type(()=> CaseField)
   hydrated_case_fields?: CaseField[];
   columns?: object;
 }

--- a/src/shared/fixture/case-tab.test.fixture.ts
+++ b/src/shared/fixture/case-tab.test.fixture.ts
@@ -1,4 +1,5 @@
-import { CaseTab } from '../domain';
+import { CaseField, CaseTab } from '../domain';
+import { plainToClass } from 'class-transformer';
 
 export let createCaseTabArray = () => {
   const tab1 = new CaseTab();
@@ -15,7 +16,7 @@ export let createCaseTabArray = () => {
   tab2.label = 'Name';
   tab2.order = 1;
   tab2.fields = [
-    {
+    plainToClass(CaseField, {
       id: 'PersonFirstName',
       label: 'First name',
       display_context: 'OPTIONAL',
@@ -26,8 +27,8 @@ export let createCaseTabArray = () => {
       order: 2,
       value: 'Janet',
       show_condition: ''
-    },
-    {
+    }),
+    plainToClass(CaseField, {
       id: 'PersonLastName',
       label: 'Last name',
       display_context: 'OPTIONAL',
@@ -38,8 +39,8 @@ export let createCaseTabArray = () => {
       order: 1,
       value: 'Parker',
       show_condition: 'PersonFirstName="Jane*"'
-    },
-    {
+    }),
+    plainToClass(CaseField, {
       id: 'PersonComplex',
       label: 'Complex field',
       display_context: 'OPTIONAL',
@@ -50,7 +51,7 @@ export let createCaseTabArray = () => {
       },
       order: 3,
       show_condition: 'PersonFirstName="Park"'
-    }
+    })
   ];
   tab2.show_condition = 'PersonFirstName="Janet"';
 

--- a/src/shared/fixture/case-view.test.fixture.ts
+++ b/src/shared/fixture/case-view.test.fixture.ts
@@ -1,5 +1,5 @@
 import { createCaseTabArray } from './case-tab.test.fixture';
-import { CaseView } from '../domain';
+import { CaseField, CaseView } from '../domain';
 
 export let createCaseView = () => {
   const caseView = new CaseView();
@@ -19,7 +19,7 @@ export let createCaseView = () => {
 
   caseView.tabs = createCaseTabArray();
 
-  caseView.metadataFields = [{
+  caseView.metadataFields = [<CaseField>({
     id: '[STATE]',
     label: 'State',
     display_context: 'READONLY',
@@ -30,7 +30,7 @@ export let createCaseView = () => {
     order: 2,
     value: 'State1',
     show_condition: ''
-  }];
+  })];
 
   return caseView;
 };

--- a/src/shared/fixture/shared.test.fixture.ts
+++ b/src/shared/fixture/shared.test.fixture.ts
@@ -28,7 +28,7 @@ export let createCaseEventTrigger = (id: string,
 
 export let aCaseField = (id: string, label: string, type: FieldTypeEnum, display_context: string,
   show_summary_content_option: number, typeComplexFields: CaseField[] = []): CaseField => {
-  return {
+  return <CaseField>({
     id: id || 'personFirstName',
     field_type: {
       id: type.toString() || 'Text',
@@ -38,7 +38,7 @@ export let aCaseField = (id: string, label: string, type: FieldTypeEnum, display
     display_context: display_context || 'OPTIONAL',
     label: label || 'First name',
     show_summary_content_option: show_summary_content_option
-  };
+  });
 };
 
 export let createWizardPage = (id: string,
@@ -103,7 +103,7 @@ export let createCaseField = (id: string,
                               display_context: string,
                               order = undefined,
                               show_condition = undefined): CaseField => {
-  return {
+  return <CaseField>({
     id: id || 'personFirstName',
     field_type: fieldType || textFieldType(),
     display_context: display_context || 'OPTIONAL',
@@ -112,7 +112,7 @@ export let createCaseField = (id: string,
     show_summary_content_option: 0,
     order: order,
     show_condition: show_condition || undefined
-  };
+  });
 };
 
 export let createFieldType = (typeId: string,

--- a/src/shared/services/fields/fields.utils.ts
+++ b/src/shared/services/fields/fields.utils.ts
@@ -128,7 +128,11 @@ export class FieldsUtils {
     };
   }
 
-  public cloneObject(obj: any): CaseField {
+  public cloneObject(obj: any): any {
+    return Object.assign({}, obj);
+  }
+
+  public cloneCaseField(obj: any): CaseField {
     return Object.assign(new CaseField(), obj);
   }
 
@@ -141,7 +145,7 @@ export class FieldsUtils {
   }
 
   private mergeFields(caseFields: CaseField[], formFields: any, mergeFunction: (CaseField, any) => void) {
-    let result = Object.assign({}, formFields);
+    let result = this.cloneObject(formFields);
     caseFields.forEach(field => {
       mergeFunction(field, result);
       if (field.field_type && field.field_type.complex_fields && field.field_type.complex_fields.length > 0) {

--- a/src/shared/services/fields/fields.utils.ts
+++ b/src/shared/services/fields/fields.utils.ts
@@ -128,8 +128,8 @@ export class FieldsUtils {
     };
   }
 
-  public cloneObject(obj: any): any {
-    return Object.assign({}, obj);
+  public cloneObject(obj: any): CaseField {
+    return Object.assign(new CaseField(), obj);
   }
 
   mergeCaseFieldsAndFormFields(caseFields: CaseField[], formFields: any): any {
@@ -141,7 +141,7 @@ export class FieldsUtils {
   }
 
   private mergeFields(caseFields: CaseField[], formFields: any, mergeFunction: (CaseField, any) => void) {
-    let result = this.cloneObject(formFields);
+    let result = Object.assign({}, formFields);
     caseFields.forEach(field => {
       mergeFunction(field, result);
       if (field.field_type && field.field_type.complex_fields && field.field_type.complex_fields.length > 0) {

--- a/src/shared/services/form/field-type-sanitiser.spec.ts
+++ b/src/shared/services/form/field-type-sanitiser.spec.ts
@@ -115,9 +115,8 @@ describe('FieldTypeSanitiser', () => {
 
   it('should enrich dynamiclist casefields values with correct format ', () => {
     expect(editForm.data.dynamicList).toEqual('M');
-    FieldTypeSanitiser.sanitiseLists(caseFields, editForm);
+    new FieldTypeSanitiser().sanitiseLists(caseFields, editForm);
     expect(editForm.data.dynamicList).toEqual(EXPECTED_VALUE_DYNAMIC_LIST);
   });
-
 
 });

--- a/src/shared/services/form/field-type-sanitiser.spec.ts
+++ b/src/shared/services/form/field-type-sanitiser.spec.ts
@@ -1,0 +1,123 @@
+import { FieldTypeSanitiser } from './field-type-sanitiser';
+import { CaseField } from '../../domain/definition';
+
+describe('FieldTypeSanitiser', () => {
+
+  const VALUE_DYNAMIC_LIST = JSON.parse('{\n' +
+    '            "value": {\n' +
+    '              "code": "F",\n' +
+    '              "label": "Female"\n' +
+    '            },\n' +
+    '            "list_items": [\n' +
+    '              {\n' +
+    '                "code": "F",\n' +
+    '                "label": "Female"\n' +
+    '              },\n' +
+    '              {\n' +
+    '                "code": "M",\n' +
+    '                "label": "Male"\n' +
+    '              }' +
+    '            ]\n' +
+    '          }');
+
+  const EXPECTED_VALUE_DYNAMIC_LIST = JSON.parse('{\n' +
+    '            "value": {\n' +
+    '              "code": "M",\n' +
+    '              "label": "Male"\n' +
+    '            },\n' +
+    '            "list_items": [\n' +
+    '              {\n' +
+    '                "code": "F",\n' +
+    '                "label": "Female"\n' +
+    '              },\n' +
+    '              {\n' +
+    '                "code": "M",\n' +
+    '                "label": "Male"\n' +
+    '              }' +
+    '            ]\n' +
+    '          }');
+
+  const editForm = {
+    data: {
+      dynamicList: 'M'
+    }
+  }
+
+
+  const caseFields: CaseField[] = [
+    Object.assign(new CaseField(), {
+      id: '[CASE_REFERENCE]',
+      label: 'Case Reference',
+      value: 1533032330714079,
+      hint_text: null,
+      field_type: {
+        id: 'Number',
+        type: 'Number',
+        min: null,
+        max: null,
+        regular_expression: null,
+        fixed_list_items: [],
+        complex_fields: [],
+        collection_field_type: null
+      },
+      security_label: 'PUBLIC',
+      order: null,
+      display_context: null,
+      show_condition: null,
+      show_summary_change_option: null,
+      show_summary_content_option: null
+    }),
+    Object.assign(new CaseField(), {
+      id: '[CASE_TYPE]',
+      label: 'Case Type',
+      value: 'DIVORCE',
+      hint_text: null,
+      field_type: {
+        id: 'Text',
+        type: 'Text',
+        min: null,
+        max: null,
+        regular_expression: null,
+        fixed_list_items: [],
+        complex_fields: [],
+        collection_field_type: null
+      },
+      security_label: 'PUBLIC',
+      order: null,
+      display_context: null,
+      show_condition: null,
+      show_summary_change_option: null,
+      show_summary_content_option: null
+    }),
+    Object.assign(new CaseField(), {
+      id: 'dynamicList',
+      label: 'DynamicList',
+      value: VALUE_DYNAMIC_LIST,
+      hint_text: null,
+      field_type: {
+        id: 'dynamicList',
+        type: 'DynamicList',
+        min: null,
+        max: null,
+        regular_expression: null,
+        fixed_list_items: [],
+        complex_fields: [],
+        collection_field_type: null
+      },
+      security_label: 'PUBLIC',
+      order: null,
+      display_context: null,
+      show_condition: null,
+      show_summary_change_option: null,
+      show_summary_content_option: null
+    })
+  ];
+
+  it('should enrich dynamiclist casefields values with correct format ', () => {
+    expect(editForm.data.dynamicList).toEqual('M');
+    FieldTypeSanitiser.sanitiseLists(caseFields, editForm);
+    expect(editForm.data.dynamicList).toEqual(EXPECTED_VALUE_DYNAMIC_LIST);
+  });
+
+
+});

--- a/src/shared/services/form/field-type-sanitiser.ts
+++ b/src/shared/services/form/field-type-sanitiser.ts
@@ -5,7 +5,7 @@ import { Injectable } from '@angular/core';
 export class FieldTypeSanitiser {
 
   /**
-   * This method takes finds dynamiclists in a form and replaces its string value, with
+   * This method finds dynamiclists in a form and replaces its string value, with
    * following example JSON format
    * @return {value: {code:'xyz',label:'XYZ'}, list_items: [{code:'xyz',label:'XYZ'},{code:'abc',label:'ABC'}]}
    * @param caseFields

--- a/src/shared/services/form/field-type-sanitiser.ts
+++ b/src/shared/services/form/field-type-sanitiser.ts
@@ -1,7 +1,6 @@
 import { CaseField } from '../../domain/definition';
 import { Injectable } from '@angular/core';
 
-// @dynamic
 @Injectable()
 export class FieldTypeSanitiser {
 
@@ -12,7 +11,7 @@ export class FieldTypeSanitiser {
    * @param caseFields
    * @param editForm
    */
-  public static sanitiseLists(caseFields: CaseField[], editForm: any) {
+   sanitiseLists(caseFields: CaseField[], editForm: any) {
 
     this.getDynamicListsFromCaseFields(caseFields).forEach(dynamicField => {
       this.getListOfKeysFromEditForm(editForm).forEach((key) => {
@@ -21,26 +20,26 @@ export class FieldTypeSanitiser {
     });
   }
 
-  private static createValueCodePairAlongWithListIfKeyExistsInForm(dynamicField, key, editForm: any) {
+  private createValueCodePairAlongWithListIfKeyExistsInForm(dynamicField: CaseField, key, editForm: any) {
     if (dynamicField.id === key) {
       editForm['data'][key] =
         {
           value: this.getMatchingCodeFromListOfItems(dynamicField, editForm, key),
-          list_items: dynamicField.items
+          list_items: dynamicField.list_items
         };
     }
   }
 
-  private static getMatchingCodeFromListOfItems(dynamicField, editForm: any, key) {
-    let result = dynamicField.items.filter(value => value.code === editForm['data'][key]);
+  private getMatchingCodeFromListOfItems(dynamicField: CaseField, editForm: any, key) {
+    let result = dynamicField.list_items.filter(value => value.code === editForm['data'][key]);
     return result.length > 0? result[0] : {};
   }
 
-  private static getListOfKeysFromEditForm(editForm: any) {
+  private getListOfKeysFromEditForm(editForm: any) {
     return Object.keys(editForm['data']);
   }
 
-  private static getDynamicListsFromCaseFields(caseFields: CaseField[]): CaseField[] {
+  private getDynamicListsFromCaseFields(caseFields: CaseField[]): CaseField[] {
     return caseFields
       .filter(caseField => caseField.field_type.type === 'DynamicList');
   }

--- a/src/shared/services/form/field-type-sanitiser.ts
+++ b/src/shared/services/form/field-type-sanitiser.ts
@@ -32,9 +32,8 @@ export class FieldTypeSanitiser {
   }
 
   private static getMatchingCodeFromListOfItems(dynamicField, editForm: any, key) {
-    return dynamicField.items.filter(function (value) {
-      return value.code === editForm['data'][key];
-    })[0];
+    let result = dynamicField.items.filter(value => value.code === editForm['data'][key]);
+    return result.length > 0? result[0] : {};
   }
 
   private static getListOfKeysFromEditForm(editForm: any) {

--- a/src/shared/services/form/field-type-sanitiser.ts
+++ b/src/shared/services/form/field-type-sanitiser.ts
@@ -12,7 +12,7 @@ export class FieldTypeSanitiser {
    * @param caseFields
    * @param editForm
    */
-  public static sanitiseLists(caseFields: CaseField[], editForm: any): any {
+  public static sanitiseLists(caseFields: CaseField[], editForm: any) {
 
     this.getDynamicListsFromCaseFields(caseFields).forEach(dynamicField => {
       this.getListOfKeysFromEditForm(editForm).forEach((key) => {

--- a/src/shared/services/form/field-type-sanitiser.ts
+++ b/src/shared/services/form/field-type-sanitiser.ts
@@ -1,0 +1,48 @@
+import { CaseField } from '../../domain/definition';
+import { Injectable } from '@angular/core';
+
+// @dynamic
+@Injectable()
+export class FieldTypeSanitiser {
+
+  /**
+   * This method takes finds dynamiclists in a form and replaces its string value, with
+   * following example JSON format
+   * @return {value: {code:'xyz',label:'XYZ'}, list_items: [{code:'xyz',label:'XYZ'},{code:'abc',label:'ABC'}]}
+   * @param caseFields
+   * @param editForm
+   */
+  public static sanitiseLists(caseFields: CaseField[], editForm: any): any {
+
+    this.getDynamicListsFromCaseFields(caseFields).forEach(dynamicField => {
+      this.getListOfKeysFromEditForm(editForm).forEach((key) => {
+        this.createValueCodePairAlongWithListIfKeyExistsInForm(dynamicField, key, editForm);
+      });
+    });
+  }
+
+  private static createValueCodePairAlongWithListIfKeyExistsInForm(dynamicField, key, editForm: any) {
+    if (dynamicField.id === key) {
+      editForm['data'][key] =
+        {
+          value: this.getMatchingCodeFromListOfItems(dynamicField, editForm, key),
+          list_items: dynamicField.items
+        };
+    }
+  }
+
+  private static getMatchingCodeFromListOfItems(dynamicField, editForm: any, key) {
+    return dynamicField.items.filter(function (value) {
+      return value.code === editForm['data'][key];
+    })[0];
+  }
+
+  private static getListOfKeysFromEditForm(editForm: any) {
+    return Object.keys(editForm['data']);
+  }
+
+  private static getDynamicListsFromCaseFields(caseFields: CaseField[]): CaseField[] {
+    return caseFields
+      .filter(caseField => caseField.field_type.type === 'DynamicList');
+  }
+}

--- a/src/shared/services/form/form-value.service.spec.ts
+++ b/src/shared/services/form/form-value.service.spec.ts
@@ -1,12 +1,13 @@
 import { FormValueService } from './form-value.service';
 import { CaseField, FieldType } from '../../domain/definition';
+import {FieldTypeSanitiser} from './field-type-sanitiser';
 
 describe('FormValueService', () => {
 
   let formValueService: FormValueService;
 
   beforeEach(() => {
-    formValueService = new FormValueService();
+    formValueService = new FormValueService(new FieldTypeSanitiser());
   });
 
   it('should return null when given null', () => {

--- a/src/shared/services/form/form-value.service.ts
+++ b/src/shared/services/form/form-value.service.ts
@@ -5,6 +5,8 @@ import { FieldTypeSanitiser } from './field-type-sanitiser';
 @Injectable()
 export class FormValueService {
 
+  constructor(private fieldTypeSanitiser: FieldTypeSanitiser){}
+
   public sanitise(rawValue: object): object {
     return this.sanitiseObject(rawValue);
   }
@@ -76,7 +78,7 @@ export class FormValueService {
   }
 
   sanitiseDynamicLists(caseFields: CaseField[], editForm: any): any {
-    return FieldTypeSanitiser.sanitiseLists(caseFields, editForm);
+    return this.fieldTypeSanitiser.sanitiseLists(caseFields, editForm);
   }
 
 }

--- a/src/shared/services/form/form-value.service.ts
+++ b/src/shared/services/form/form-value.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { CaseField } from '../../domain/definition/case-field.model';
+import { FieldTypeSanitiser } from './field-type-sanitiser';
 
 @Injectable()
 export class FormValueService {
@@ -75,25 +76,7 @@ export class FormValueService {
   }
 
   sanitiseDynamicLists(caseFields: CaseField[], editForm: any): any {
-    // loop thorught dynamic fields in caseFields
-    caseFields
-      .filter(caseField => caseField.field_type.type === 'DynamicList')
-      .forEach(dynamicField => {
-        // for each dynamic field find the field in editForm, if field exists in the editForm
-        // get the code (selected value from user)
-        // replace code in editForm with whole JSON for dynamic list
-        Object.keys(editForm['data']).forEach((key) => {
-          if (dynamicField.id === key) {
-            editForm['data'][key] =
-              {
-                value: dynamicField.value.list_items.filter(value => value.code === editForm['data'][key])[0],
-                list_items: dynamicField.value.list_items
-              };
-          }
-        });
-      });
-
-
+    return FieldTypeSanitiser.sanitiseLists(caseFields, editForm);
   }
 
 }

--- a/src/shared/services/form/index.ts
+++ b/src/shared/services/form/index.ts
@@ -1,3 +1,4 @@
 export * from './form-error.service';
 export * from './form-validators.service';
 export * from './form-value.service';
+export * from './field-type-sanitiser';

--- a/yarn.lock
+++ b/yarn.lock
@@ -10512,6 +10512,11 @@ unc-path-regex@^0.1.2:
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
   integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
 
+underscore@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
+  integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
+
 underscore@~1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-4704

Add accessor methods in CaseField and related changes across application.
Ie : Fix compatiblity issues across application

CaseField in the toolkit has an optional 'value' property.
We need to implement the optional 'value' as a mandatory property with accessor methods. And move the implementation of getValue() method into the getter method for value. i.e.
_value: any;
get value() { move here current content of getValue() method }
set value() {
getValue() { .... } remove this
This is needed because getValue() currently has logic to fetch the value from dynamic lists. And we want this logic to be used everywhere we currently use field.value
Doing this will break our test code in multiple places so we are tackling this in this ticket. 
Other things to do:
1) remove method instantiate() in  write-fixed-list-field.component.ts 
2) introduce a 'FieldTypeSanitiser' as per comment in https://github.com/hmcts/ccd-case-ui-toolkit/pull/327/files

**Does this PR introduce a breaking change?** (check one with "x")

```
[X] Yes
[ ] No
```
