### PR TITLE
Revert "Build on master and tagged releases" - Allowing prereleases 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ matrix:
   # Allow node 12.x to fail until dependencies start working
   allow_failures:
     - node_js: "node"
-branches:
-  only:
-    - master
-    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
 cache: yarn
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s --


### PR DESCRIPTION
In order todo a prerelease there needs to be a build from the branch. we are reverting this pr to bring back branch builds for this reason 