### PR TITLE
RDM-3782: Previous Case Reference data is displayed until new data is…

### DIFF
--- a/src/shared/components/search-result/search-result.component.html
+++ b/src/shared/components/search-result/search-result.component.html
@@ -29,7 +29,7 @@
 
       <a *ngIf="colIndex == 0" routerLink="/case/{{jurisdiction.id}}/{{caseType.id}}/{{result.case_id}}"
          attr.aria-label="go to case with Case reference:{{ result.case_id | ccdCaseReference }}">
-        <ng-container class="text-16" [style.visibility]="hideRows ? 'hidden' : 'visible'">
+        <ng-container class="text-16" *ngIf="!hideRows">
           <ccd-field-read *ngIf="draftPrefixOrGet(col, result); else case_reference"
                           ccdLabelSubstitutor [caseField]="getColumnsWithPrefix(result.columns[col.case_field_id], result)"
                           [contextFields]="result.hydrated_case_fields"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-3782

### Change description ###
Previous Case Reference data is displayed until new data is loaded

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
