### PR TITLE
RDM-4525 Remove unused id as breaking external tests.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,8 @@
 ## RELEASE NOTES
 
+### Version 2.58.1 - July 1 2019
+**RDM-4525** Remove unused id on write fixed list field template as breaking external tests.
+
 ### Version 2.58.0 - June 27 2019
 **RDM-4890** Integrate New Postcode Lookup into CCD
 **RDM-3782** Previous Case Reference data is displayed until new data is loaded

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.58.0",
+  "version": "2.58.1",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/components/palette/fixed-list/write-fixed-list-field.html
+++ b/src/shared/components/palette/fixed-list/write-fixed-list-field.html
@@ -1,4 +1,4 @@
-<div class="form-group" [ngClass]="{'form-group-error': !fixedListControl.valid && fixedListControl.touched}" [id]="id()">
+<div class="form-group" [ngClass]="{'form-group-error': !fixedListControl.valid && fixedListControl.touched}">
 
   <label [for]="id()">
     <span class="form-label" *ngIf="caseField.label">{{caseField | ccdFieldLabel}}</span>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-4525


### Change description ###
Remove superfluous id from write-fixed-list-field template. Not needed by FE func tests as there is already same id present on select tag.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
