### PR TITLE
RDM-4692 ccd-write-address-field id fix

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,8 @@
 ## RELEASE NOTES
 
+### Version 2.58.11 - July 29 2019
+**RDM-4692** ccd-write-address-field id fix
+
 ### Version 2.58.10 - July 26 2019
 **RDM-5053**  Dynamic list: Page Show condition fix
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "v2.58.14-RDM-4692-prerelease",
+  "version": "2.58.11",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "v2.58.9",
+  "version": "v2.58.14-RDM-4692-prerelease",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/components/palette/address/write-address-field.component.ts
+++ b/src/shared/components/palette/address/write-address-field.component.ts
@@ -125,10 +125,6 @@ export class WriteAddressFieldComponent extends AbstractFieldWriteComponent impl
     }
   }
 
-  buildIdPrefix(field: CaseField): string {
-    return this.isCompoundPipe.transform(field) ? `${this.idPrefix}_` : `${this.idPrefix}`;
-  }
-
   createId(elementId: string): string {
     return this.id() + '_' + elementId ;
   }

--- a/src/shared/components/palette/address/write-address-field.html
+++ b/src/shared/components/palette/address/write-address-field.html
@@ -34,7 +34,7 @@
     [formGroup]="formGroup"
     [registerControl]="registerControl"
     [ignoreMandatory]="true"
-    [idPrefix]="buildIdPrefix(caseField)"
+    [idPrefix]="idPrefix"
     #writeComplexFieldComponent>
   </ccd-write-complex-type-field>
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-4692


### Change description ###
ccd-write-address-field is composing ccd-write-complex-type-field, so we do not need to alter the prefix. ccd-write-complex-type-field will do it.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
