### PR TITLE
RDM-5310 Fix for Proceed button does not render correctly

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,8 @@
 ## RELEASE NOTES
 
+### Version 2.58.14 - August 7 2019
+**RDM-4068** CRUD permissions on elements within complex types
+
 ### Version 2.58.13 - July 30 2019
 **RDM-5318** Changes to make Workbasket tolerant of missing defaults
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.58.15",
+  "version": "2.58.16",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.58.13",
+  "version": "2.58.14",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.58.11",
+  "version": "2.58.12-RDM-5310-prerelease",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/components/case-editor/services/wizard-page-field-to-case-field.mapper.ts
+++ b/src/shared/components/case-editor/services/wizard-page-field-to-case-field.mapper.ts
@@ -67,6 +67,7 @@ export class WizardPageFieldToCaseFieldMapper {
       }
     } else {
       case_field_leaf.hidden = true;
+      case_field_leaf.display_context = override.display_context;
     }
   }
 

--- a/src/shared/components/palette/base-field/field-read-label.html
+++ b/src/shared/components/palette/base-field/field-read-label.html
@@ -1,7 +1,11 @@
-<dl class="case-field" *ngIf="withLabel && !isLabel() && !isComplex(); else caseFieldValue">
-  <dt class="case-field__label">{{caseField.label}}</dt>
-  <dd class="case-field__value">
-    <ng-container *ngTemplateOutlet="caseFieldValue"></ng-container>
-  </dd>
-</dl>
-<ng-template #caseFieldValue><ng-content></ng-content></ng-template>
+<div [hidden]="caseField.hidden">
+  <dl class="case-field" *ngIf="withLabel && !isLabel() && !isComplex(); else caseFieldValue">
+    <dt class="case-field__label">{{caseField.label}}</dt>
+    <dd class="case-field__value">
+      <ng-container *ngTemplateOutlet="caseFieldValue"></ng-container>
+    </dd>
+  </dl>
+  <ng-template #caseFieldValue>
+    <ng-content></ng-content>
+  </ng-template>
+</div>

--- a/src/shared/components/palette/base-field/field-read.html
+++ b/src/shared/components/palette/base-field/field-read.html
@@ -1,3 +1,5 @@
-<ccd-field-read-label [caseField]="caseField" [withLabel]="withLabel">
-  <ng-container #fieldContainer></ng-container>
-</ccd-field-read-label>
+<div [hidden]="caseField.hidden">
+  <ccd-field-read-label [caseField]="caseField" [withLabel]="withLabel">
+    <ng-container #fieldContainer></ng-container>
+  </ccd-field-read-label>
+</div>

--- a/src/shared/components/palette/collection/collection-create-checker.service.spec.ts
+++ b/src/shared/components/palette/collection/collection-create-checker.service.spec.ts
@@ -16,7 +16,16 @@ describe('CollectionCreateCheckerService', () => {
   const DATE_TEXT_FIELD = createCaseField('date', 'Date', '', textFieldType(), 'READONLY', undefined, undefined, [acl1, acl2]);
   const DESCRIPTION_TEXT_FIELD = createCaseField('description', 'Description', '', textFieldType(), 'READONLY',
     undefined, undefined, [acl3]);
-  const TIMELINE_EVENT_COMPLEX = createFieldType('TimelineEvent', 'Complex', [DATE_TEXT_FIELD, DESCRIPTION_TEXT_FIELD]);
+  const CATEGORY_TEXT_FIELD = createCaseField('categoryText', 'Category name', '', textFieldType(),
+    'READONLY', undefined, undefined, [acl1, acl2]);
+  const COLOR_TEXT_FIELD = createCaseField('colorText', 'Category', '', textFieldType(), 'READONLY', undefined, undefined, [acl1, acl2]);
+  const CATEGORY_COMPLEX_TYPE = createFieldType('TimelineEvent', 'Complex', [CATEGORY_TEXT_FIELD, COLOR_TEXT_FIELD]);
+  const CATEGORY = createCaseField('categoy', 'Category', '', CATEGORY_COMPLEX_TYPE, 'READONLY', undefined, undefined, [acl1]);
+  const TAGS_COLLECTION = createCaseField('tags', 'Tags', '',
+    createFieldType('tagss-bbcd64b3a', 'Collection', [], textFieldType()), 'READONLY',
+    undefined, undefined, [acl1]);
+  const TIMELINE_EVENT_COMPLEX = createFieldType('TimelineEvent', 'Complex',
+    [DATE_TEXT_FIELD, DESCRIPTION_TEXT_FIELD, CATEGORY, TAGS_COLLECTION]);
   const TIMELINE_EVENTS_COLLECTION = createCaseField('defendantTimeLineEvents', 'Timeline Events', '',
     createFieldType('defendantTimeLineEvents-acd64b3a', 'Collection', [], TIMELINE_EVENT_COMPLEX), 'OPTIONAL',
     undefined, undefined, [acl2]);
@@ -55,8 +64,14 @@ describe('CollectionCreateCheckerService', () => {
   });
 
   it('should be created with all the dependencies', () => {
-    collectionCreateCheckerService.setDisplayContextForChildren(TIMELINE_EVENTS_COLLECTION, [TIMELINE_EVENTS_COLLECTION], profile);
+    collectionCreateCheckerService.setDisplayContextForChildren(TIMELINE_EVENTS_COLLECTION, profile);
     expect(TIMELINE_EVENTS_COLLECTION.field_type.collection_field_type.complex_fields[0].display_context).toEqual('OPTIONAL');
     expect(TIMELINE_EVENTS_COLLECTION.field_type.collection_field_type.complex_fields[1].display_context).toEqual('READONLY');
+    expect(TIMELINE_EVENTS_COLLECTION.field_type.collection_field_type.complex_fields[2].display_context).toEqual('OPTIONAL');
+    expect(TIMELINE_EVENTS_COLLECTION.field_type.collection_field_type.complex_fields[2].field_type.complex_fields[0].display_context)
+      .toEqual('OPTIONAL');
+    expect(TIMELINE_EVENTS_COLLECTION.field_type.collection_field_type.complex_fields[2].field_type.complex_fields[1].display_context)
+      .toEqual('OPTIONAL');
+    expect(TIMELINE_EVENTS_COLLECTION.field_type.collection_field_type.complex_fields[3].display_context).toEqual('OPTIONAL');
   });
 });

--- a/src/shared/components/palette/collection/collection-create-checker.service.spec.ts
+++ b/src/shared/components/palette/collection/collection-create-checker.service.spec.ts
@@ -1,0 +1,62 @@
+import { TestBed } from '@angular/core/testing';
+import { CollectionCreateCheckerService } from './collection-create-checker.service';
+import { Profile } from '../../../domain/profile';
+import { createACL, createCaseField, createFieldType, textFieldType } from '../../../fixture';
+import { AccessControlList } from '../../../domain/definition/access-control-list.model';
+
+describe('CollectionCreateCheckerService', () => {
+  const ROLE1 = 'role1';
+  const ROLE2 = 'role2';
+  const ROLE3 = 'role3';
+  let acl1: AccessControlList = createACL(ROLE1, true, true, true, false);
+  let acl2: AccessControlList = createACL(ROLE2, true, true, false, false);
+  let acl3: AccessControlList = createACL(ROLE3, false, true, false, false);
+
+  let collectionCreateCheckerService: CollectionCreateCheckerService = new CollectionCreateCheckerService();
+  const DATE_TEXT_FIELD = createCaseField('date', 'Date', '', textFieldType(), 'READONLY', undefined, undefined, [acl1, acl2]);
+  const DESCRIPTION_TEXT_FIELD = createCaseField('description', 'Description', '', textFieldType(), 'READONLY',
+    undefined, undefined, [acl3]);
+  const TIMELINE_EVENT_COMPLEX = createFieldType('TimelineEvent', 'Complex', [DATE_TEXT_FIELD, DESCRIPTION_TEXT_FIELD]);
+  const TIMELINE_EVENTS_COLLECTION = createCaseField('defendantTimeLineEvents', 'Timeline Events', '',
+    createFieldType('defendantTimeLineEvents-acd64b3a', 'Collection', [], TIMELINE_EVENT_COMPLEX), 'OPTIONAL',
+    undefined, undefined, [acl2]);
+  let rolesArray: Array<string> = [ROLE1, ROLE2, ROLE3];
+  let profile: Profile = {
+    user: {
+      idam: {
+        id: '21',
+        email: 'a@b.com',
+        forename: 'Jon',
+        surname: 'Snow',
+        roles: rolesArray
+      }
+    },
+    channels: [],
+    jurisdictions: [],
+    default: {
+      workbasket: {
+        jurisdiction_id: '',
+        case_type_id: '',
+        state_id: ''
+      }
+    },
+    isSolicitor(): boolean {
+      return false;
+    },
+    isCourtAdmin(): boolean {
+      return false;
+    }
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [{provide: CollectionCreateCheckerService, useValue: collectionCreateCheckerService}]
+    });
+  });
+
+  it('should be created with all the dependencies', () => {
+    collectionCreateCheckerService.setDisplayContextForChildren(TIMELINE_EVENTS_COLLECTION, [TIMELINE_EVENTS_COLLECTION], profile);
+    expect(TIMELINE_EVENTS_COLLECTION.field_type.collection_field_type.complex_fields[0].display_context).toEqual('OPTIONAL');
+    expect(TIMELINE_EVENTS_COLLECTION.field_type.collection_field_type.complex_fields[1].display_context).toEqual('READONLY');
+  });
+});

--- a/src/shared/components/palette/collection/collection-create-checker.service.ts
+++ b/src/shared/components/palette/collection/collection-create-checker.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@angular/core';
+import { CaseField } from '../../../domain/definition';
+import { Profile } from '../../../domain/profile';
+
+@Injectable()
+export class CollectionCreateCheckerService {
+
+  public setDisplayContextForChildren(caseField: CaseField, caseFields: CaseField[], profile: Profile) {
+    let children = this.getCaseFieldChildren(caseField);
+
+    if (children && children.length > 0) {
+      children.forEach(child => {
+        if (!!profile.user.idam.roles.find(role => this.hasCreateAccess(child, role))) {
+          child.display_context = caseField.display_context;
+        }
+      });
+    }
+  }
+
+  private getCaseFieldChildren(caseField: CaseField): CaseField[] {
+    let childrenCaseFields = [];
+    if (this.isCollection(caseField)) {
+      childrenCaseFields = caseField.field_type.collection_field_type.complex_fields || [];
+    } else if (this.isComplex(caseField)) {
+      childrenCaseFields = caseField.field_type.complex_fields || [];
+    }
+    return childrenCaseFields;
+  }
+
+  private isComplex(case_field: CaseField) {
+    return case_field.field_type.type === 'Complex';
+  }
+
+  private isCollection(case_field: CaseField) {
+    return case_field.field_type.type === 'Collection';
+  }
+
+  private hasCreateAccess(caseField: CaseField, role: any) {
+    return !!caseField.acls.find( acl => acl.role === role && acl.create === true);
+  }
+}

--- a/src/shared/components/palette/collection/collection-create-checker.service.ts
+++ b/src/shared/components/palette/collection/collection-create-checker.service.ts
@@ -5,13 +5,16 @@ import { Profile } from '../../../domain/profile';
 @Injectable()
 export class CollectionCreateCheckerService {
 
-  public setDisplayContextForChildren(caseField: CaseField, caseFields: CaseField[], profile: Profile) {
+  public setDisplayContextForChildren(caseField: CaseField, profile: Profile) {
     let children = this.getCaseFieldChildren(caseField);
 
     if (children && children.length > 0) {
       children.forEach(child => {
         if (!!profile.user.idam.roles.find(role => this.hasCreateAccess(child, role))) {
           child.display_context = caseField.display_context;
+        }
+        if (this.isCollection(child) || this.isComplex(child)) {
+          this.setDisplayContextForChildren(child, profile)
         }
       });
     }

--- a/src/shared/components/palette/collection/write-collection-field.component.spec.ts
+++ b/src/shared/components/palette/collection/write-collection-field.component.spec.ts
@@ -15,6 +15,7 @@ import { ProfileNotifier } from '../../../services';
 import { createAProfile } from '../../../domain/profile/profile.test.fixture';
 import createSpyObj = jasmine.createSpyObj;
 import any = jasmine.any;
+import { CollectionCreateCheckerService } from './collection-create-checker.service';
 
 const FIELD_ID = 'Values';
 const SIMPLE_FIELD_TYPE: FieldType = {
@@ -75,6 +76,7 @@ describe('WriteCollectionFieldComponent', () => {
   let profileNotifier: any;
   let caseField: CaseField;
   let formGroup: FormGroup;
+  let collectionCreateCheckerService: CollectionCreateCheckerService;
 
   beforeEach(async(() => {
     formValidatorService = createSpyObj<FormValidatorsService>('formValidatorService', ['addValidators']);
@@ -107,6 +109,8 @@ describe('WriteCollectionFieldComponent', () => {
     profileNotifier = new ProfileNotifier();
     profileNotifier.profile = new BehaviorSubject(createAProfile()).asObservable();
 
+    collectionCreateCheckerService = new CollectionCreateCheckerService();
+
     TestBed
       .configureTestingModule({
         imports: [
@@ -124,6 +128,7 @@ describe('WriteCollectionFieldComponent', () => {
           { provide: MatDialog, useValue: dialog },
           { provide: ScrollToService, useValue: scrollToService },
           { provide: ProfileNotifier, useValue: profileNotifier },
+          { provide: CollectionCreateCheckerService, useValue: collectionCreateCheckerService },
           RemoveDialogComponent
         ]
       })
@@ -325,6 +330,7 @@ describe('WriteCollectionFieldComponent CRUD impact', () => {
   let profileNotifier: any;
   let caseField: CaseField;
   let formGroup: FormGroup;
+  let collectionCreateCheckerService: CollectionCreateCheckerService;
 
   beforeEach(async(() => {
     formValidatorService = createSpyObj<FormValidatorsService>('formValidatorService', ['addValidators']);
@@ -357,6 +363,8 @@ describe('WriteCollectionFieldComponent CRUD impact', () => {
     profileNotifier = new ProfileNotifier();
     profileNotifier.profile = new BehaviorSubject(createAProfile()).asObservable();
 
+    collectionCreateCheckerService = new CollectionCreateCheckerService();
+
     TestBed
       .configureTestingModule({
         imports: [
@@ -374,6 +382,7 @@ describe('WriteCollectionFieldComponent CRUD impact', () => {
           { provide: MatDialog, useValue: dialog },
           { provide: ScrollToService, useValue: scrollToService },
           { provide: ProfileNotifier, useValue: profileNotifier },
+          { provide: CollectionCreateCheckerService, useValue: collectionCreateCheckerService },
           RemoveDialogComponent
         ]
       })
@@ -442,6 +451,7 @@ describe('WriteCollectionFieldComponent CRUD impact - Update False', () => {
   let profileNotifier: any;
   let caseField: CaseField;
   let formGroup: FormGroup;
+  let collectionCreateCheckerService: CollectionCreateCheckerService;
 
   beforeEach(async(() => {
     formValidatorService = createSpyObj<FormValidatorsService>('formValidatorService', ['addValidators']);
@@ -474,6 +484,8 @@ describe('WriteCollectionFieldComponent CRUD impact - Update False', () => {
     profileNotifier = new ProfileNotifier();
     profileNotifier.profile = new BehaviorSubject(createAProfile()).asObservable();
 
+    collectionCreateCheckerService = new CollectionCreateCheckerService();
+
     TestBed
       .configureTestingModule({
         imports: [
@@ -491,6 +503,7 @@ describe('WriteCollectionFieldComponent CRUD impact - Update False', () => {
           { provide: MatDialog, useValue: dialog },
           { provide: ScrollToService, useValue: scrollToService },
           { provide: ProfileNotifier, useValue: profileNotifier },
+          { provide: CollectionCreateCheckerService, useValue: collectionCreateCheckerService },
           RemoveDialogComponent
         ]
       })

--- a/src/shared/components/palette/collection/write-collection-field.component.ts
+++ b/src/shared/components/palette/collection/write-collection-field.component.ts
@@ -92,7 +92,7 @@ export class WriteCollectionFieldComponent extends AbstractFieldWriteComponent i
     // Manually resetting errors is required to prevent `ExpressionChangedAfterItHasBeenCheckedError`
     this.formArray.setErrors(null);
     this.caseField.value.push({ value: null });
-    this.createChecker.setDisplayContextForChildren(this.caseField, this.caseFields, this.profile);
+    this.createChecker.setDisplayContextForChildren(this.caseField, this.profile);
 
     let lastIndex = this.caseField.value.length - 1;
 

--- a/src/shared/components/palette/collection/write-collection-field.component.ts
+++ b/src/shared/components/palette/collection/write-collection-field.component.ts
@@ -8,8 +8,8 @@ import { RemoveDialogComponent } from '../../dialogs/remove-dialog/remove-dialog
 import { ScrollToService } from '@nicky-lenaers/ngx-scroll-to';
 import { finalize } from 'rxjs/operators';
 import { Profile } from '../../../domain/profile';
-import { ActivatedRoute } from '@angular/router';
 import { ProfileNotifier } from '../../../services';
+import { CollectionCreateCheckerService } from './collection-create-checker.service';
 
 @Component({
   selector: 'ccd-write-collection-field',
@@ -34,6 +34,7 @@ export class WriteCollectionFieldComponent extends AbstractFieldWriteComponent i
               private dialog: MatDialog,
               private scrollToService: ScrollToService,
               private profileNotifier: ProfileNotifier,
+              private createChecker: CollectionCreateCheckerService
   ) {
     super();
   }
@@ -91,6 +92,7 @@ export class WriteCollectionFieldComponent extends AbstractFieldWriteComponent i
     // Manually resetting errors is required to prevent `ExpressionChangedAfterItHasBeenCheckedError`
     this.formArray.setErrors(null);
     this.caseField.value.push({ value: null });
+    this.createChecker.setDisplayContextForChildren(this.caseField, this.caseFields, this.profile);
 
     let lastIndex = this.caseField.value.length - 1;
 

--- a/src/shared/components/palette/complex/read-complex-field-collection-table.html
+++ b/src/shared/components/palette/complex/read-complex-field-collection-table.html
@@ -1,4 +1,4 @@
- <div class="complex-panel">
+ <div class="complex-panel" [hidden]="caseField.hidden">
       <dl class="complex-panel-title"><dt><span class="text-16">{{caseField.label}}</span></dt><dd></dd></dl>
       <table class="complex-panel-table">
         <tbody>

--- a/src/shared/components/palette/complex/read-complex-field-table.component.ts
+++ b/src/shared/components/palette/complex/read-complex-field-table.component.ts
@@ -1,9 +1,13 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { AbstractFieldReadComponent } from '../base-field/abstract-field-read.component';
+import { CaseField } from '../../../domain/definition';
 
 @Component({
   selector: 'ccd-read-complex-field-table',
   templateUrl: './read-complex-field-table.html',
   styleUrls: ['./read-complex-field-table.scss']
 })
-export class ReadComplexFieldTableComponent extends AbstractFieldReadComponent {}
+export class ReadComplexFieldTableComponent extends AbstractFieldReadComponent {
+  @Input()
+  caseFields: CaseField[] = [];
+}

--- a/src/shared/components/palette/complex/read-complex-field-table.html
+++ b/src/shared/components/palette/complex/read-complex-field-table.html
@@ -4,14 +4,14 @@
     <tbody>
       <ng-container *ngFor="let field of caseField | ccdFieldsFilter">
         <ng-container *ngIf="(field | ccdIsCompound); else SimpleRow">
-          <tr class="complex-panel-compound-field" ccdConditionalShow ccdLabelSubstitutor [caseField]="field" [contextFields]="caseField | ccdFieldsFilter">
+          <tr class="complex-panel-compound-field" ccdConditionalShow ccdLabelSubstitutor [caseField]="field" [contextFields]="caseFields">
             <td colspan="2">
               <span class="text-16"><ccd-field-read [caseField]="field" [context]="context"></ccd-field-read></span>
             </td>
           </tr>
         </ng-container>
         <ng-template #SimpleRow>
-          <tr class="complex-panel-simple-field" ccdConditionalShow ccdLabelSubstitutor [caseField]="field" [contextFields]="caseField | ccdFieldsFilter">
+          <tr class="complex-panel-simple-field" ccdConditionalShow ccdLabelSubstitutor [caseField]="field" [contextFields]="caseFields">
             <th><span class="text-16">{{field.label}}</span></th>
             <td>
                 <span class="text-16"><ccd-field-read [caseField]="field" [context]="context"></ccd-field-read></span>

--- a/src/shared/components/palette/complex/read-complex-field.component.spec.ts
+++ b/src/shared/components/palette/complex/read-complex-field.component.spec.ts
@@ -60,7 +60,7 @@ describe('ReadComplexFieldComponent', () => {
 
         ReadComplexFieldTableComponent = MockComponent({
           selector: 'ccd-read-complex-field-table',
-          inputs: ['caseField', 'context']
+          inputs: ['caseField', 'caseFields', 'context']
         });
 
         ReadComplexFieldNewTableComponent = MockComponent({
@@ -158,7 +158,7 @@ describe('ReadComplexFieldComponent', () => {
 
         ReadComplexFieldTableComponent = MockComponent({
           selector: 'ccd-read-complex-field-table',
-          inputs: ['caseField', 'context']
+          inputs: ['caseField', 'caseFields', 'context']
         });
 
         ReadComplexFieldNewTableComponent = MockComponent({
@@ -260,7 +260,7 @@ describe('ReadComplexFieldComponent', () => {
 
       ReadComplexFieldTableComponent = MockComponent({
         selector: 'ccd-read-complex-field-table',
-        inputs: ['caseField', 'context']
+        inputs: ['caseField', 'caseFields', 'context']
       });
 
       ReadComplexFieldNewTableComponent = MockComponent({

--- a/src/shared/components/palette/complex/read-complex-field.component.ts
+++ b/src/shared/components/palette/complex/read-complex-field.component.ts
@@ -1,12 +1,15 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { AbstractFieldReadComponent } from '../base-field/abstract-field-read.component';
 import { PaletteContext } from '../base-field/palette-context.enum';
+import { CaseField } from '../../../domain/definition';
 
 @Component({
   selector: 'ccd-read-complex-field',
   templateUrl: './read-complex-field.html',
 })
 export class ReadComplexFieldComponent extends AbstractFieldReadComponent implements OnInit {
+  @Input()
+  caseFields: CaseField[] = [];
 
   public paletteContext = PaletteContext;
 

--- a/src/shared/components/palette/complex/read-complex-field.html
+++ b/src/shared/components/palette/complex/read-complex-field.html
@@ -12,6 +12,7 @@
   <ccd-read-complex-field-table
     *ngSwitchDefault
     [caseField]="caseField"
+    [caseFields]="caseFields"
     [context]="context"
   ></ccd-read-complex-field-table>
 </ng-container>

--- a/src/shared/components/palette/palette.module.ts
+++ b/src/shared/components/palette/palette.module.ts
@@ -43,6 +43,7 @@ import { ReadCaseLinkFieldComponent } from './case-link/read-case-link-field.com
 import { WriteCaseLinkFieldComponent } from './case-link/write-case-link-field.component';
 import { FixedRadioListModule } from './fixed-radio-list';
 import { CaseHistoryViewerModule } from './history';
+import { CollectionCreateCheckerService } from './collection/collection-create-checker.service';
 
 @NgModule({
   imports: [
@@ -144,6 +145,7 @@ import { CaseHistoryViewerModule } from './history';
     WriteDateFieldComponent,
   ],
   providers: [
+    CollectionCreateCheckerService,
     PaletteService,
     FormValidatorsService,
   ]

--- a/src/shared/fixture/shared.test.fixture.ts
+++ b/src/shared/fixture/shared.test.fixture.ts
@@ -5,6 +5,8 @@ import { ComplexFieldOverride } from '../components/case-editor/domain/wizard-pa
 import { WizardPage, WizardPageField } from '../components/case-editor/domain';
 import { ShowCondition } from '../directives/conditional-show/domain';
 import { FixedListItem } from '../domain/definition';
+import { AccessControlList } from '../domain/definition/access-control-list.model';
+import { isBoolean } from 'util';
 
 export let createCaseEventTrigger = (id: string,
                                       name: string,
@@ -102,7 +104,8 @@ export let createCaseField = (id: string,
                               fieldType: FieldType,
                               display_context: string,
                               order = undefined,
-                              show_condition = undefined): CaseField => {
+                              show_condition = undefined,
+                              ACLs: AccessControlList[] = undefined): CaseField => {
   return <CaseField>({
     id: id || 'personFirstName',
     field_type: fieldType || textFieldType(),
@@ -111,7 +114,8 @@ export let createCaseField = (id: string,
     hint_text: hint || 'First name hint text',
     show_summary_content_option: 0,
     order: order,
-    show_condition: show_condition || undefined
+    show_condition: show_condition || undefined,
+    acls: ACLs
   });
 };
 
@@ -142,4 +146,14 @@ export let textFieldType = (): FieldType => {
     type: 'Text',
     complex_fields: []
   };
+};
+
+export let createACL = (role: string, create: boolean, read: boolean, update: boolean, _delete: boolean): AccessControlList => {
+  return <AccessControlList> ({
+    role: role || 'roleX',
+    create: create,
+    read: read,
+    update: update,
+    delete: _delete
+  });
 };

--- a/src/shared/fixture/shared.test.fixture.ts
+++ b/src/shared/fixture/shared.test.fixture.ts
@@ -6,17 +6,15 @@ import { WizardPage, WizardPageField } from '../components/case-editor/domain';
 import { ShowCondition } from '../directives/conditional-show/domain';
 import { FixedListItem } from '../domain/definition';
 import { AccessControlList } from '../domain/definition/access-control-list.model';
-import { isBoolean } from 'util';
-import { plainToClass } from 'class-transformer';
 import { CaseFieldBuilder } from './case-field-builder';
 
 export let createCaseEventTrigger = (id: string,
-                                      name: string,
-                                      case_id: string,
-                                      show_summary: boolean,
-                                      case_fields: CaseField[],
-                                      wizard_pages = [],
-                                      can_save_draft = false) => {
+                                     name: string,
+                                     case_id: string,
+                                     show_summary: boolean,
+                                     case_fields: CaseField[],
+                                     wizard_pages = [],
+                                     can_save_draft = false) => {
   const eventTrigger = new CaseEventTrigger();
 
   eventTrigger.id = id;
@@ -31,7 +29,7 @@ export let createCaseEventTrigger = (id: string,
 };
 
 export let aCaseField = (id: string, label: string, type: FieldTypeEnum, display_context: string,
-  show_summary_content_option: number, typeComplexFields: CaseField[] = []): CaseField => {
+                         show_summary_content_option: number, typeComplexFields: CaseField[] = []): CaseField => {
   return <CaseField>({
     id: id || 'personFirstName',
     field_type: {
@@ -108,17 +106,17 @@ export let createCaseField = (id: string,
                               order = undefined,
                               show_condition = undefined,
                               ACLs: AccessControlList[] = undefined): CaseField => {
-  return <CaseField>({
-    id: id || 'personFirstName',
-    field_type: fieldType || textFieldType(),
-    display_context: display_context || 'OPTIONAL',
-    label: label || 'First name',
-    hint_text: hint || 'First name hint text',
-    show_summary_content_option: 0,
-    order: order,
-    show_condition: show_condition || undefined,
-    acls: ACLs
-  });
+  return CaseFieldBuilder.create()
+    .withId(id || 'personFirstName')
+    .withFieldType(fieldType || textFieldType())
+    .withDisplayContext(display_context || 'OPTIONAL')
+    .withLabel(label || 'First name')
+    .withHintText(hint || 'First name hint text')
+    .withShowSummaryContentOption(0)
+    .withOrder(order)
+    .withShowCondition(show_condition || undefined)
+    .withACLs(ACLs)
+    .build();
 };
 
 export let newCaseField = (id: string,
@@ -167,7 +165,7 @@ export let textFieldType = (): FieldType => {
 };
 
 export let createACL = (role: string, create: boolean, read: boolean, update: boolean, _delete: boolean): AccessControlList => {
-  return <AccessControlList> ({
+  return <AccessControlList>({
     role: role || 'roleX',
     create: create,
     read: read,


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-5310

This PR fixes two things, 
- Firstly the `contextFields` for the read type complex field renderers (like read-complex-field-table) were reduced to the child field but as dot notation has been introduced the context fields must include all fields so that directives like conditional Hide  and show od legal field substitutor could evaluate correctly
- Fixing this introduced another issue, even though some of the fields were marked as `HIDDEN` they were still being shown in the page. For this `hidden` is honoured for read type complex field renderers.
- Finally since the fields are marked as `READONLY` by the `ccd-data-store-api` when the user has no update write, while adding new collection item the fields weren't rendering correctly. That has been fixed by adding a CollectionCreateCheckerService


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```