### PR TITLE
RDM-5604 Fix {} instantiations for read-collection-XX components

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,8 @@
 ## RELEASE NOTES
 
+### Version 2.58.15 - August 12 2019
+**RDM-5604** Object instantiation with curly braces breaks read-label-field component
+
 ### Version 2.58.14 - August 07 2019
 **RDM-4073** Ui refactoring: Introduce utility methods on CaseField isCollection and isCollectionOfComplex
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.58.14",
+  "version": "2.58.15",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/components/palette/base-field/field-read.component.ts
+++ b/src/shared/components/palette/base-field/field-read.component.ts
@@ -28,6 +28,10 @@ export class FieldReadComponent extends AbstractFieldReadComponent implements On
   }
 
   ngOnInit(): void {
+    // Ensure this.caseField is actually a CaseField instance even if instantiated with {}
+    if (!(this.caseField instanceof CaseField)) {
+      this.caseField = plainToClassFromExist(new CaseField(), this.caseField);
+    }
     // Ensure all field values are resolved by label interpolation before the component is fully initialised.
     Promise.resolve(null).then(() => {
       let componentClass = this.paletteService.getFieldComponentClass(this.caseField, false);


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-5604

CaseField Instantiation with Curly braces causes an issue since curly brace instantiation creates a plain object with no isComplex or isCollection methods. Added a fix for making sure caseField of component is an instance of CaseField by explicit casting...

These are the components using "{}" instantiation
- read-collection-field
- read-complex-field-collection-table

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```