### PR TITLE
Rdm 4617 fix

### DIFF
--- a/src/shared/components/palette/collection/write-collection-field.component.ts
+++ b/src/shared/components/palette/collection/write-collection-field.component.ts
@@ -53,7 +53,6 @@ export class WriteCollectionFieldComponent extends AbstractFieldWriteComponent i
 
   ngOnDestroy() {
     if (typeof this.profileSubscription !== 'undefined') {
-      console.log('unsubscribing from collection write field subscription')
       this.profileSubscription.unsubscribe();
     }
   }

--- a/src/shared/components/palette/collection/write-collection-field.component.ts
+++ b/src/shared/components/palette/collection/write-collection-field.component.ts
@@ -52,7 +52,10 @@ export class WriteCollectionFieldComponent extends AbstractFieldWriteComponent i
   }
 
   ngOnDestroy() {
-    this.profileSubscription.unsubscribe();
+    if (typeof this.profileSubscription !== 'undefined') {
+      console.log('unsubscribing from collection write field subscription')
+      this.profileSubscription.unsubscribe();
+    }
   }
 
   buildCaseField(item, index: number): CaseField {


### PR DESCRIPTION
having a collection in the dynamic workbasket filters causes an error and grey screen when clicking 'create case' button. as the ngOnDestroy us trying to unsubscribe to a subscription that has never been initialised, this hot fix seems to resolve the problem and has unblocked testing 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
