### PR TITLE
RDM-5883 Consume external GET Printable Documents endpoint in API v2

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,8 @@
 ## RELEASE NOTES
 
+### Version 2.62.20-RDM-5883-prerelease - November 11 2019
+Revert 5883 - Implement and consume external GET Printable Documents endpoint in API v2
+
 ### Version 2.59.4 - August 19 2019
 Revert 5398 - Document in collections
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.60.0-development-2",
+  "version": "2.62.20-RDM-5883-prerelease",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/components/case-editor/services/cases.service.spec.ts
+++ b/src/shared/components/case-editor/services/cases.service.spec.ts
@@ -472,12 +472,16 @@ describe('CasesService', () => {
         name: 'Doc1',
         type: 'application/pdf',
         url: 'https://test.service.reform.hmcts.net/doc1'
-      }
-    ];
+      }]
+
+    const DOCUMENT_RESOURCES = {
+      documentResources: DOCUMENTS,
+        _links: 'http://data-store-api/cases/123456789012345/documents'
+      };
 
     beforeEach(() => {
       httpService.get.and.returnValue(Observable.of(new Response(new ResponseOptions({
-        body: JSON.stringify(DOCUMENTS)
+        body: JSON.stringify(DOCUMENT_RESOURCES)
       }))));
     });
 

--- a/src/shared/components/case-editor/services/cases.service.spec.ts
+++ b/src/shared/components/case-editor/services/cases.service.spec.ts
@@ -27,7 +27,7 @@ describe('CasesService', () => {
   const EVENT_TRIGGER_DRAFT_URL = API_URL + `/internal/drafts/${DRAFT_ID}/event-trigger?ignore-warning=true`;
   const CREATE_EVENT_URL = API_URL + `/cases/${CASE_ID}/events`;
   const VALIDATE_CASE_URL = API_URL + `/case-types/${CTID}/validate?pageId=${PAGE_ID}`;
-  const PRINT_DOCUMENTS_URL = API_URL + `/caseworkers/:uid/jurisdictions/${JID}/case-types/${CTID}/cases/${CASE_ID}/documents`;
+  const PRINT_DOCUMENTS_URL = API_URL + `/cases/${CASE_ID}/documents`;
   const CREATE_CASE_URL = API_URL + `/caseworkers/:uid/jurisdictions/${JID}/case-types/${CTID}/cases?ignore-warning=false`;
   const CASE_VIEW: CaseView = {
     case_id: '1',
@@ -482,16 +482,21 @@ describe('CasesService', () => {
     });
 
     it('should use HttpService::get with correct url', () => {
+      const headers = new Headers({
+        'experimental': 'true',
+        'Accept': CasesService.V2_MEDIATYPE_CASE_DOCUMENTS
+      });
+
       casesService
-        .getPrintDocuments(JID, CTID, CASE_ID)
+        .getPrintDocuments(CASE_ID)
         .subscribe();
 
-      expect(httpService.get).toHaveBeenCalledWith(PRINT_DOCUMENTS_URL);
+      expect(httpService.get).toHaveBeenCalledWith(PRINT_DOCUMENTS_URL, {headers});
     });
 
     it('should retrieve document list from server', () => {
       casesService
-        .getPrintDocuments(JID, CTID, CASE_ID)
+        .getPrintDocuments(CASE_ID)
         .subscribe(
           eventTrigger => expect(eventTrigger).toEqual(DOCUMENTS)
         );
@@ -501,7 +506,7 @@ describe('CasesService', () => {
       httpService.get.and.returnValue(throwError(ERROR));
 
       casesService
-        .getPrintDocuments(JID, CTID, CASE_ID)
+        .getPrintDocuments(CASE_ID)
         .subscribe(data => {
           expect(data).toEqual(DOCUMENTS);
         }, err => {

--- a/src/shared/components/case-editor/services/cases.service.ts
+++ b/src/shared/components/case-editor/services/cases.service.ts
@@ -12,7 +12,7 @@ import { WizardPageFieldToCaseFieldMapper } from './wizard-page-field-to-case-fi
 
 @Injectable()
 export class CasesService {
-
+  // Internal (UI) API
   public static readonly V2_MEDIATYPE_CASE_VIEW = 'application/vnd.uk.gov.hmcts.ccd-data-store-api.ui-case-view.v2+json';
   public static readonly V2_MEDIATYPE_START_CASE_TRIGGER =
     'application/vnd.uk.gov.hmcts.ccd-data-store-api.ui-start-case-trigger.v2+json;charset=UTF-8';
@@ -20,6 +20,9 @@ export class CasesService {
     'application/vnd.uk.gov.hmcts.ccd-data-store-api.ui-start-event-trigger.v2+json;charset=UTF-8';
   public static readonly V2_MEDIATYPE_START_DRAFT_TRIGGER =
     'application/vnd.uk.gov.hmcts.ccd-data-store-api.ui-start-draft-trigger.v2+json;charset=UTF-8';
+
+  // External (Data Store) API
+  public static readonly V2_MEDIATYPE_CASE_DOCUMENTS = 'application/vnd.uk.gov.hmcts.ccd-data-store-api.case-documents.v2+json';
   public static readonly V2_MEDIATYPE_CASE_DATA_VALIDATE =
     'application/vnd.uk.gov.hmcts.ccd-data-store-api.case-data-validate.v2+json;charset=UTF-8';
   public static readonly V2_MEDIATYPE_CREATE_EVENT =
@@ -172,16 +175,18 @@ export class CasesService {
       );
   }
 
-  getPrintDocuments(jurisdictionId: string, caseTypeId: string, caseId: string): Observable<CasePrintDocument[]> {
+  getPrintDocuments(caseId: string): Observable<CasePrintDocument[]> {
     const url = this.appConfig.getCaseDataUrl()
-      + `/caseworkers/:uid`
-      + `/jurisdictions/${jurisdictionId}`
-      + `/case-types/${caseTypeId}`
       + `/cases/${caseId}`
       + `/documents`;
 
+    let headers = new Headers({
+      'experimental': 'true',
+      'Accept': CasesService.V2_MEDIATYPE_CASE_DOCUMENTS
+    });
+
     return this.http
-      .get(url)
+      .get(url, {headers})
       .pipe(
         map(response => response.json()),
         catchError(error => {

--- a/src/shared/components/case-editor/services/cases.service.ts
+++ b/src/shared/components/case-editor/services/cases.service.ts
@@ -188,7 +188,7 @@ export class CasesService {
     return this.http
       .get(url, {headers})
       .pipe(
-        map(response => response.json()),
+        map(response => response.json().documentResources),
         catchError(error => {
           this.errorService.setError(error);
           return throwError(error);

--- a/src/shared/components/case-viewer/printer/case-printer.component.spec.ts
+++ b/src/shared/components/case-viewer/printer/case-printer.component.spec.ts
@@ -113,6 +113,10 @@ describe('CasePrinterComponent', () => {
     expect(header.componentInstance.caseDetails).toEqual(CASE_VIEW);
   });
 
+  it('should call get print documents on init', () => {
+    expect(casesService.getPrintDocuments).toHaveBeenCalledWith(CASE_VIEW.case_id);
+  });
+
   it('should retrieve documents from route data', () => {
     caseService.announceCase(CASE_VIEW);
     expect(component.documents).toEqual(DOCUMENTS);

--- a/src/shared/components/case-viewer/printer/case-printer.component.ts
+++ b/src/shared/components/case-viewer/printer/case-printer.component.ts
@@ -26,9 +26,7 @@ export class CasePrinterComponent implements OnInit, OnDestroy {
     this.caseSubscription = this.caseNotifier.caseView.subscribe(caseDetails => {
       this.caseDetails = caseDetails;
       this.casesService
-        .getPrintDocuments(this.caseDetails.case_type.jurisdiction.id,
-                           this.caseDetails.case_type.id,
-                           this.caseDetails.case_id)
+        .getPrintDocuments(this.caseDetails.case_id)
         .pipe(
           map(documents => {
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-5883


### Change description ###
Consume external GET Printable Documents endpoint in API v2


**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
