### PR TITLE
RDM-1280: Wizard page should only allow Continue when all documents have been uploaded

### DIFF
--- a/src/shared/components/palette/document/write-document-field.component.spec.ts
+++ b/src/shared/components/palette/document/write-document-field.component.spec.ts
@@ -381,7 +381,7 @@ describe('WriteDocumentFieldComponent with Mandatory casefield', () => {
       }
     });
     expect(component.valid).toBeFalsy();
-    expect(component.uploadError).toEqual('File required');
+    expect(component.fileUploadMessages).toEqual('File required');
   });
 
   it('should be valid if no document specified for upload for not read only. Empty file.', () => {

--- a/src/shared/components/palette/document/write-document-field.component.ts
+++ b/src/shared/components/palette/document/write-document-field.component.ts
@@ -17,13 +17,15 @@ export class WriteDocumentFieldComponent extends AbstractFieldWriteComponent imp
   static readonly DOCUMENT_FILENAME = 'document_filename';
   static readonly UPLOAD_ERROR_FILE_REQUIRED = 'File required';
   static readonly UPLOAD_ERROR_NOT_AVAILABLE = 'Document upload facility is not available at the moment';
+  static readonly UPLOAD_WAITING_FILE_STATUS = 'Uploading...';
+
   private uploadedDocument: FormGroup;
   private selectedFile: File;
   private dialogConfig: MatDialogConfig;
   @ViewChild('fileInput') fileInput: ElementRef;
 
   valid = true;
-  uploadError: string;
+  fileUploadMessages: string;
   confirmReplaceResult: string;
   clickInsideTheDocument: boolean;
 
@@ -63,7 +65,7 @@ export class WriteDocumentFieldComponent extends AbstractFieldWriteComponent imp
 
     if (this.isAMandatoryComponent()) {
       if ( this.clickInsideTheDocument && this.validateFormUploadedDocument() ) {
-        this.displayFileErrors();
+        this.displayFileUploadMessages(WriteDocumentFieldComponent.UPLOAD_ERROR_FILE_REQUIRED);
       }
     }
   }
@@ -72,7 +74,7 @@ export class WriteDocumentFieldComponent extends AbstractFieldWriteComponent imp
 
     if (this.isAMandatoryComponent()) {
       if ( this.validateFormUploadedDocument() ) {
-        this.displayFileErrors();
+        this.displayFileUploadMessages(WriteDocumentFieldComponent.UPLOAD_ERROR_FILE_REQUIRED);
       }
     }
   }
@@ -81,7 +83,7 @@ export class WriteDocumentFieldComponent extends AbstractFieldWriteComponent imp
 
     if (fileInput.target.files[0]) {
       this.selectedFile = fileInput.target.files[0];
-
+      this.displayFileUploadMessages(WriteDocumentFieldComponent.UPLOAD_WAITING_FILE_STATUS);
       // Perform the file upload immediately on file selection
       let documentUpload: FormData = new FormData();
       documentUpload.append('files', this.selectedFile, this.selectedFile.name);
@@ -99,14 +101,14 @@ export class WriteDocumentFieldComponent extends AbstractFieldWriteComponent imp
 
         this.valid = true;
       }, (error: HttpError) => {
-        this.uploadError = this.getErrorMessage(error);
+        this.fileUploadMessages = this.getErrorMessage(error);
         this.valid = false;
       });
     } else {
       if (this.isAMandatoryComponent()) {
         this.selectedFile = null;
         this.updateDocumentForm(null, null, null);
-        this.displayFileErrors();
+        this.displayFileUploadMessages(WriteDocumentFieldComponent.UPLOAD_ERROR_FILE_REQUIRED);
       }
     }
   }
@@ -164,9 +166,9 @@ export class WriteDocumentFieldComponent extends AbstractFieldWriteComponent imp
     return this.caseField.display_context && this.caseField.display_context === Constants.MANDATORY;
   }
 
-  private displayFileErrors () {
+  private displayFileUploadMessages ( fileUploadMessage: string ) {
     this.valid = false;
-    this.uploadError = WriteDocumentFieldComponent.UPLOAD_ERROR_FILE_REQUIRED;
+    this.fileUploadMessages = fileUploadMessage;
   }
 
   private validateFormUploadedDocument():  boolean {
@@ -207,7 +209,6 @@ export class WriteDocumentFieldComponent extends AbstractFieldWriteComponent imp
     if (0 === error.status || 502 === error.status) {
       return WriteDocumentFieldComponent.UPLOAD_ERROR_NOT_AVAILABLE;
     }
-
     return error.error;
   }
 }

--- a/src/shared/components/palette/document/write-document-field.html
+++ b/src/shared/components/palette/document/write-document-field.html
@@ -2,7 +2,7 @@
   <label [for]="id()">
     <span class="form-label" attr.aria-label="{{caseField | ccdFieldLabel}}">{{caseField | ccdFieldLabel}}</span>
     <span class="form-hint" *ngIf="caseField.hint_text">{{caseField.hint_text}}</span>
-    <span class="error-message" *ngIf="uploadError && !valid">{{uploadError}}</span>
+    <span class="error-message" *ngIf="fileUploadMessages && !valid">{{fileUploadMessages}}</span>
   </label>
 
   <div>

--- a/src/shared/services/document-management/document-management.service.ts
+++ b/src/shared/services/document-management/document-management.service.ts
@@ -5,6 +5,7 @@ import { HttpService } from '../http';
 import { Headers } from '@angular/http';
 import { AbstractAppConfig } from '../../../app.config';
 import { map } from 'rxjs/operators';
+import { delay } from 'rxjs/internal/operators';
 
 @Injectable()
 export class DocumentManagementService {
@@ -12,6 +13,8 @@ export class DocumentManagementService {
   private static readonly HEADER_CONTENT_TYPE = 'Content-Type';
   private static readonly PDF = 'pdf';
   private static readonly IMAGE = 'image';
+  // This delay has been added in order to be able to display any temporally status messages in the GUI component that uses this service.
+  private static readonly RESPONSE_DELAY = 2000;
 
   imagesList: string[] = ['JPEG', 'GIF', 'PNG', 'TIF', 'JPG'];
 
@@ -26,8 +29,11 @@ export class DocumentManagementService {
     headers.append(DocumentManagementService.HEADER_CONTENT_TYPE, null);
     return this.http
       .post(url, formData, { headers })
+      .pipe(delay( DocumentManagementService.RESPONSE_DELAY ))
       .pipe(
-        map(response => response.json())
+        map(response => {
+          return response.json();
+        })
       );
   }
 

--- a/src/shared/services/document-management/document-management.service.ts
+++ b/src/shared/services/document-management/document-management.service.ts
@@ -13,7 +13,8 @@ export class DocumentManagementService {
   private static readonly HEADER_CONTENT_TYPE = 'Content-Type';
   private static readonly PDF = 'pdf';
   private static readonly IMAGE = 'image';
-  // This delay has been added in order to be able to display any temporally status messages in the GUI component that uses this service.
+  // This delay has been added to give enough time to the user on the UI to see the info messages on the document upload
+  // field for cases when uploads are very fast.
   private static readonly RESPONSE_DELAY = 2000;
 
   imagesList: string[] = ['JPEG', 'GIF', 'PNG', 'TIF', 'JPG'];


### PR DESCRIPTION
RDM-1280: Wizard page should only allow Continue when all documents have been uploaded

    [RDM-1280](https://tools.hmcts.net/jira/browse/RDM-1280).

Notes: This tickets depends on  [RDM-5709](https://tools.hmcts.net/jira/browse/RDM-5709).
It can not be merged until RDM-5709 is merged.

The same regressions test of RDM-5709 should be done.