### PR TITLE
RDM-6084 Fix for a caseLink to open the case in new tab.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,8 @@
 ## RELEASE NOTES
 
+### Version 2.62.19-RDM-6084-prerelease November 8 2019
+**RDM-6084** - Unable to open case in new tab from filter/search results pages
+
 ### Version 2.60.5-RDM-6350-RC1-prerelease
 **RDM-6350** - Fix for AboutToStart callback not showing errors correctly in UI
 

--- a/demo/src/app/search-result-consumer.component.html
+++ b/demo/src/app/search-result-consumer.component.html
@@ -74,8 +74,8 @@
                 [resultView]="resultView"
                 [paginationMetadata]="paginationMetadata"
                 [metadataFields]="metadataFields"
+                [caseLinkUrlTemplate]="'/v2/case/case_id'"
                 (changePage)="apply($event)"
-                (clickCase)="gotoCase($event)"
             ></ccd-search-result>
         </div>
     </main>

--- a/demo/src/app/search-result-consumer.component.ts
+++ b/demo/src/app/search-result-consumer.component.ts
@@ -30,8 +30,8 @@ export class SearchResultConsumerComponent implements OnInit {
         [resultView]="resultView"
         [paginationMetadata]="paginationMetadata"
         [metadataFields]="metadataFields"
+        [caseLinkUrlTemplate]="'/v2/case/case_id'"
         (changePage)="apply($event)"
-        (clickCase)="gotoCase($event)"
     ></ccd-search-result>`;
 
     constructor(
@@ -159,9 +159,5 @@ export class SearchResultConsumerComponent implements OnInit {
         console.log(selected);
 
     }
-
-  gotoCase(data) {
-    console.log('data: ', data);
-  }
 
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.60.5-RDM-6350-RC1-prerelease",
+  "version": "2.62.19-RDM-6084-prerelease",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/components/search-result/search-result.component.html
+++ b/src/shared/components/search-result/search-result.component.html
@@ -27,7 +27,7 @@
 
     <td class="search-result-column-cell" *ngFor="let col of resultView.columns; let colIndex = index">
 
-      <a *ngIf="colIndex == 0" (click)="goToCase(result.case_id)" href="javascript:void(0)"
+      <a *ngIf="colIndex == 0" routerLink="{{prepareCaseLinkUrl(result.case_id)}}" target="_blank"
          attr.aria-label="go to case with Case reference:{{ result.case_id | ccdCaseReference }}">
         <ng-container class="text-16" *ngIf="!hideRows">
           <ccd-field-read *ngIf="draftPrefixOrGet(col, result); else case_reference"

--- a/src/shared/components/search-result/search-result.component.html
+++ b/src/shared/components/search-result/search-result.component.html
@@ -27,7 +27,7 @@
 
     <td class="search-result-column-cell" *ngFor="let col of resultView.columns; let colIndex = index">
 
-      <a *ngIf="colIndex == 0" routerLink="{{prepareCaseLinkUrl(result.case_id)}}" target="_blank"
+      <a *ngIf="colIndex == 0" [routerLink]="prepareCaseLinkUrl(result.case_id)" target="_blank"
          attr.aria-label="go to case with Case reference:{{ result.case_id | ccdCaseReference }}">
         <ng-container class="text-16" *ngIf="!hideRows">
           <ccd-field-read *ngIf="draftPrefixOrGet(col, result); else case_reference"

--- a/src/shared/components/search-result/search-result.component.html
+++ b/src/shared/components/search-result/search-result.component.html
@@ -27,7 +27,7 @@
 
     <td class="search-result-column-cell" *ngFor="let col of resultView.columns; let colIndex = index">
 
-      <a *ngIf="colIndex == 0" [routerLink]="prepareCaseLinkUrl(result.case_id)" target="_blank"
+      <a *ngIf="colIndex == 0" [routerLink]="prepareCaseLinkUrl(result.case_id)"
          attr.aria-label="go to case with Case reference:{{ result.case_id | ccdCaseReference }}">
         <ng-container class="text-16" *ngIf="!hideRows">
           <ccd-field-read *ngIf="draftPrefixOrGet(col, result); else case_reference"

--- a/src/shared/components/search-result/search-result.component.spec.ts
+++ b/src/shared/components/search-result/search-result.component.spec.ts
@@ -142,7 +142,7 @@ describe('SearchResultComponent', () => {
       activityService.postActivity.and.returnValue(switchMap);
       activityService.isEnabled = true;
 
-      searchHandler = createSpyObj('searchHandler', ['applyFilters', 'navigateToCase']);
+      searchHandler = createSpyObj('searchHandler', ['applyFilters']);
 
       appConfig = createSpyObj('appConfig', ['getPaginationPageSize']);
       appConfig.getPaginationPageSize.and.returnValue(25);
@@ -178,7 +178,7 @@ describe('SearchResultComponent', () => {
       component = fixture.componentInstance;
 
       component.changePage.subscribe(searchHandler.applyFilters);
-      component.clickCase.subscribe(searchHandler.navigateToCase);
+      component.caseLinkUrlTemplate = '/case/jurisdiction_id/caseType_id/case_id';
       component.jurisdiction = JURISDICTION;
       component.caseType = CASE_TYPE;
       component.resultView = RESULT_VIEW;
@@ -338,13 +338,10 @@ describe('SearchResultComponent', () => {
       });
     });
 
-    it('should emit correct ID when go to case is triggered', () => {
-      let id = 'ID001'
-      component.goToCase(id);
-      expect(searchHandler.navigateToCase).toHaveBeenCalledWith({
-        caseId: id
-      });
-
+    it('should replace the caseLink url placeholders with a valid data', () => {
+      let id = 'ID001';
+      let url = component.prepareCaseLinkUrl(id);
+      expect(url).toBe('/case/' + JURISDICTION.id + '/' + CASE_TYPE.id + '/' + id);
     });
 
     it('should select correct page if new page triggered from outside', () => {

--- a/src/shared/components/search-result/search-result.component.ts
+++ b/src/shared/components/search-result/search-result.component.ts
@@ -22,6 +22,9 @@ export class SearchResultComponent implements OnChanges {
   ICON = DisplayMode.ICON;
 
   @Input()
+  caseLinkUrlTemplate: string;
+
+  @Input()
   jurisdiction: Jurisdiction;
 
   @Input()
@@ -47,9 +50,6 @@ export class SearchResultComponent implements OnChanges {
 
   @Output()
   changePage: EventEmitter<any> = new EventEmitter();
-
-  @Output()
-  clickCase: EventEmitter<any> = new EventEmitter();
 
   paginationPageSize: number;
 
@@ -262,16 +262,20 @@ export class SearchResultComponent implements OnChanges {
     return this.paginationMetadata.total_results_count + this.draftsCount;
   }
 
+  prepareCaseLinkUrl(caseId: string): string {
+    let url = this.caseLinkUrlTemplate;
+    url = url.replace('jurisdiction_id', this.jurisdiction.id);
+    url = url.replace('caseType_id', this.caseType.id);
+    url = url.replace('case_id', caseId);
+
+    return url;
+  }
+
   private getDraftsCountIfNotPageOne(currentPage): number {
     return currentPage > 1 ? this.draftsCount : 0;
   }
+
   private numberOfDrafts(): number {
     return this.resultView.results.filter(_ => _.case_id.startsWith(DRAFT_PREFIX)).length;
-  }
-
-  goToCase(caseId: string) {
-    this.clickCase.emit({
-      caseId: caseId
-    });
   }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-6084


### Change description ###
Removed the clickCase EventEmitter from the search-result component and introduced caseLinkUrlTemplate Input for passing the url template.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
