### PR TITLE
Rdm 6350 non ccd use

### DIFF
--- a/demo/server.js
+++ b/demo/server.js
@@ -28,6 +28,18 @@ app.use(function (req, res) {
         response = db.get('event-trigger_EnterCaseIntoLegacy').value();
       } else if (req.url.indexOf('event-triggers/stopCase') !== -1) {
         response = db.get('event-trigger_StopCase').value();
+      } else if (req.url.indexOf('event-triggers/failCallback') !== -1) {
+        res.status(422).send({
+          message: 'Unable to proceed because there are one or more callback Errors or Warnings',
+          callbackWarnings : [
+            "warning1",
+            "warning2"
+          ],
+          callbackErrors: [
+            "error1",
+            "error2"
+          ]
+       });;
       } else if (req.url.indexOf('internal/cases/1111222233334444/events') !== -1) {
         response = db.get('history').value();
       } else if (req.url.indexOf('internal/cases/1111222233334444') !== -1) {

--- a/demo/src/app/case-view-consumer.component.html
+++ b/demo/src/app/case-view-consumer.component.html
@@ -10,6 +10,12 @@
                         <li>case - an id of a case (e.g. 1111222233334444)</li>
                         <li>hasPrint - optionally display/hide print button (true by default)</li>
                         <li>hasEventSelector - optionally display/hide event selector dropdown (true by default)</li>
+                        <li>error - http error as a result of failed navigation (e.g. callback warnings or errors)</li>
+                    </ul>
+                </li>
+                <li>Output fields:
+                    <ul class="list list-bullet text">
+                        <li>navigationTriggered - notification about triggered navigation</li>
                     </ul>
                 </li>
             </ul>
@@ -21,7 +27,8 @@
         </pre>
 
         <div class="example">
-            <ccd-case-view [case]="caseId" [hasPrint]="false" [hasEventSelector]="false"></ccd-case-view>
+            <ccd-case-view [case]="caseId" [hasPrint]="false" [hasEventSelector]="true" [error]="error"
+                (navigationTriggered)="navigationTriggered($event)"></ccd-case-view>
         </div>
     </main>
 </div>

--- a/demo/src/app/case-view-consumer.component.html
+++ b/demo/src/app/case-view-consumer.component.html
@@ -10,12 +10,19 @@
                         <li>case - an id of a case (e.g. 1111222233334444)</li>
                         <li>hasPrint - optionally display/hide print button (true by default)</li>
                         <li>hasEventSelector - optionally display/hide event selector dropdown (true by default)</li>
-                        <li>error - http error as a result of failed navigation (e.g. callback warnings or errors)</li>
+                        <li>error - http error as a result of failed navigation (e.g. callback warnings or errors); it is required to display errors correctly inside case viewer</li>
                     </ul>
                 </li>
                 <li>Output fields:
                     <ul class="list list-bullet text">
-                        <li>navigationTriggered - notification about triggered navigation</li>
+                        <li>navigationTriggered - notification about triggered navigation (current possible navigations below)</li>
+                        <ul class="list list-bullet text">
+                            <li>DRAFT_DELETED - navigation after a sucessful deletion of a draft</li>
+                            <li>ERROR_DELETING_DRAFT - navigation after an error occurs on trying to delete draft</li>
+                            <li>DRAFT_RESUMED - navigation after a draft is resumed</li>
+                            <li>EVENT_TRIGGERED - navigation after event is triggered</li>
+                            <li>NO_READ_ACCESS_REDIRECTION - navigation after user has no READ access when redirected to case view after a case created</li>
+                        </ul>
                     </ul>
                 </li>
             </ul>

--- a/demo/src/app/case-view-consumer.component.ts
+++ b/demo/src/app/case-view-consumer.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
+import { NavigationOrigin, AlertService, HttpError } from '@hmcts/ccd-case-ui-toolkit';
 
 @Component({
   selector: 'case-create-consumer',
@@ -7,15 +8,65 @@ import { ActivatedRoute } from '@angular/router';
   styleUrls: ['./elements-documentation.scss']
 })
 export class CaseViewConsumerComponent implements OnInit {
+    public static readonly CASE_CREATED_MSG = 'The case has been created successfully';
+    public static readonly DRAFT_DELETED_MSG = `The draft has been successfully deleted`;
+
+    error: HttpError;
     caseId: string;
     code = `
-    <ccd-case-view [case]="caseId" [hasPrint]="false" [hasEventSelector]="false"></ccd-case-view>`;
+    <ccd-case-view [case]="caseId" [hasPrint]="false" [hasEventSelector]="true" [error]="error"
+        (navigationTriggered)="navigationTriggered($event)"></ccd-case-view>`;
 
     constructor(
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
+        private router: Router,
+        private alertService: AlertService
     ) {}
 
     ngOnInit() {
         this.caseId = this.route.snapshot.params['cid'];
     }
+
+    navigationTriggered(navigation: any) {
+        if (navigation) {
+            switch (navigation.action) {
+                case NavigationOrigin.DRAFT_DELETED:
+                return this.router.navigate(['list/case'])
+                    .then(() => {
+                    this.alertService.setPreserveAlerts(true);
+                    this.alertService.success(CaseViewConsumerComponent.DRAFT_DELETED_MSG);
+                    });
+                case NavigationOrigin.ERROR_DELETING_DRAFT:
+                return this.router.navigate(['list/case']);
+                case NavigationOrigin.DRAFT_RESUMED:
+                return this.router.navigate(
+                    ['create/case',
+                    navigation.jid,
+                    navigation.ctid,
+                    navigation.etid], { queryParams: navigation.queryParams }).catch(error => {
+                    this.handleError(error, navigation.etid);
+                });
+                case NavigationOrigin.EVENT_TRIGGERED:
+                return this.router.navigate(['trigger', navigation.etid], {
+                    queryParams: navigation.queryParams,
+                    relativeTo: navigation.relativeTo
+                }).catch(error => {
+                    this.handleError(error, navigation.etid);
+                });
+                case NavigationOrigin.NO_READ_ACCESS_REDIRECTION:
+                return this.router.navigate((['/list/case']))
+                    .then(() => {
+                    this.alertService.success(CaseViewConsumerComponent.CASE_CREATED_MSG);
+                    });
+            }
+        }
+    }
+
+    private handleError(error: HttpError, triggerId: string) {
+        if (error.status !== 401 && error.status !== 403) {
+          console.log('error during triggering event:', triggerId);
+          console.log(error);
+          this.error = error;
+        }
+      }
 }

--- a/demo/src/app/case-view-consumer.component.ts
+++ b/demo/src/app/case-view-consumer.component.ts
@@ -31,33 +31,21 @@ export class CaseViewConsumerComponent implements OnInit {
         if (navigation) {
             switch (navigation.action) {
                 case NavigationOrigin.DRAFT_DELETED:
-                return this.router.navigate(['list/case'])
-                    .then(() => {
-                    this.alertService.setPreserveAlerts(true);
-                    this.alertService.success(CaseViewConsumerComponent.DRAFT_DELETED_MSG);
-                    });
+                    // navigation after a sucessful deletion of a draft
                 case NavigationOrigin.ERROR_DELETING_DRAFT:
-                return this.router.navigate(['list/case']);
+                    // navigation after an error occurs on trying to delete draft
                 case NavigationOrigin.DRAFT_RESUMED:
-                return this.router.navigate(
-                    ['create/case',
-                    navigation.jid,
-                    navigation.ctid,
-                    navigation.etid], { queryParams: navigation.queryParams }).catch(error => {
-                    this.handleError(error, navigation.etid);
-                });
+                    // navigation after a draft is resumed
                 case NavigationOrigin.EVENT_TRIGGERED:
-                return this.router.navigate(['trigger', navigation.etid], {
-                    queryParams: navigation.queryParams,
-                    relativeTo: navigation.relativeTo
-                }).catch(error => {
-                    this.handleError(error, navigation.etid);
-                });
-                case NavigationOrigin.NO_READ_ACCESS_REDIRECTION:
-                return this.router.navigate((['/list/case']))
-                    .then(() => {
-                    this.alertService.success(CaseViewConsumerComponent.CASE_CREATED_MSG);
+                    // navigation after event is triggered
+                    return this.router.navigate(['trigger', navigation.etid], {
+                        queryParams: navigation.queryParams,
+                        relativeTo: navigation.relativeTo
+                    }).catch(error => {
+                        this.handleError(error, navigation.etid);
                     });
+                case NavigationOrigin.NO_READ_ACCESS_REDIRECTION:
+                    // navigation after user has no READ access when redirected to case view after a case created
             }
         }
     }

--- a/demo/stubs/api.json
+++ b/demo/stubs/api.json
@@ -2447,6 +2447,12 @@
         "name": "Put the case on hold",
         "description": "This is to put a case on hold",
         "order": 3
+      },
+      {
+        "id": "failCallback",
+        "name": "Fail callback",
+        "description": "This is to fail callback",
+        "order": 4
       }
     ],
     "events": [

--- a/src/shared/components/case-viewer/case-view/case-view.component.html
+++ b/src/shared/components/case-viewer/case-view/case-view.component.html
@@ -1,4 +1,5 @@
 <div *ngIf="isDataLoaded()">
     <ccd-case-viewer [hasPrint]="hasPrint"
-                     [hasEventSelector]="hasEventSelector"></ccd-case-viewer>
+                     [hasEventSelector]="hasEventSelector"
+                     [error]="error"></ccd-case-viewer>
 </div>

--- a/src/shared/components/case-viewer/case-view/case-view.component.spec.ts
+++ b/src/shared/components/case-viewer/case-view/case-view.component.spec.ts
@@ -47,7 +47,7 @@ describe('CaseViewComponent', () => {
 
   let CaseViewerComponent: any = MockComponent({
     selector: 'ccd-case-viewer',
-    inputs: ['hasPrint', 'hasEventSelector']
+    inputs: ['hasPrint', 'hasEventSelector', 'error']
   });
 
   describe('Case', () => {

--- a/src/shared/components/case-viewer/case-view/case-view.component.ts
+++ b/src/shared/components/case-viewer/case-view/case-view.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit, Output, EventEmitter, OnDestroy } from '@angular/core';
 import { AlertService } from '../../../services/alert';
-import { CaseView, Draft } from '../../../domain';
+import { CaseView, Draft, HttpError } from '../../../domain';
 import { CasesService, CaseNotifier } from '../../case-editor';
 import { DraftService } from '../../../services';
 import { Observable, throwError, Subscription } from 'rxjs';
@@ -20,6 +20,8 @@ export class CaseViewComponent implements OnInit, OnDestroy {
   hasPrint = true;
   @Input()
   hasEventSelector = true;
+  @Input()
+  error: HttpError;
 
   @Output()
   navigationTriggered: EventEmitter<any> = new EventEmitter();

--- a/src/shared/components/case-viewer/case-viewer.component.ts
+++ b/src/shared/components/case-viewer/case-viewer.component.ts
@@ -81,6 +81,7 @@ export class CaseViewerComponent implements OnInit, OnDestroy, OnChanges {
     this.callbackErrorsSubject.subscribe(errorEvent => {
       this.error = errorEvent;
     });
+    // This is designed to be used by CCD UI that will use CaseViewerComponent directly via app.routing root path.
     this.errorSubscription = this.errorNotifierService.error.subscribe(error => {
       if (error && error.status !== 401 && error.status !== 403) {
         this.error = error;
@@ -89,6 +90,7 @@ export class CaseViewerComponent implements OnInit, OnDestroy, OnChanges {
     });
   }
 
+  // This is designed to be used by external UI like ExUI that will import and use CaseViewComponent to use case view functionality.
   ngOnChanges(changes: SimpleChanges) {
     if (changes.error && changes.error.currentValue) {
       this.error = changes.error.currentValue;

--- a/src/shared/components/case-viewer/case-viewer.component.ts
+++ b/src/shared/components/case-viewer/case-viewer.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, NgZone, OnDestroy, OnInit } from '@angular/core';
+import { Component, Input, NgZone, OnDestroy, OnInit, OnChanges, SimpleChanges } from '@angular/core';
 import { ActivatedRoute, Params } from '@angular/router';
 import { CaseTab } from '../../domain/case-view/case-tab.model';
 import { Subject } from 'rxjs/Subject';
@@ -25,7 +25,7 @@ import { ErrorNotifierService } from '../../services/error';
   templateUrl: './case-viewer.component.html',
   styleUrls: ['./case-viewer.scss']
 })
-export class CaseViewerComponent implements OnInit, OnDestroy {
+export class CaseViewerComponent implements OnInit, OnDestroy, OnChanges {
   public static readonly ORIGIN_QUERY_PARAM = 'origin';
   static readonly TRIGGER_TEXT_START = 'Go';
   static readonly TRIGGER_TEXT_CONTINUE = 'Ignore Warning and Go';
@@ -34,13 +34,14 @@ export class CaseViewerComponent implements OnInit, OnDestroy {
   hasPrint = true;
   @Input()
   hasEventSelector = true;
+  @Input()
+  error;
 
   BANNER = DisplayMode.BANNER;
 
   caseDetails: CaseView;
   sortedTabs: CaseTab[];
   caseFields: CaseField[];
-  error: any;
   triggerTextStart = CaseViewerComponent.TRIGGER_TEXT_START;
   triggerTextIgnoreWarnings = CaseViewerComponent.TRIGGER_TEXT_CONTINUE;
   triggerText: string = CaseViewerComponent.TRIGGER_TEXT_START;
@@ -86,6 +87,13 @@ export class CaseViewerComponent implements OnInit, OnDestroy {
         this.callbackErrorsSubject.next(this.error);
       }
     });
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.error && changes.error.currentValue) {
+      this.error = changes.error.currentValue;
+      this.callbackErrorsSubject.next(this.error);
+    }
   }
 
   isPrintEnabled(): boolean {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-6350


### Change description ###
Changes required to properly consume CaseViewerComponent by external UI like ExUI.

The changes would require the consuming component (see encapsulated inside CaseViewConsumerComponent in demo app) to implement navigation listening logic on the following navigation events:
- DRAFT_DELETED,
- ERROR_DELETING_DRAFT,
- DRAFT_RESUMED,
- EVENT_TRIGGERED,
- NO_READ_ACCESS_REDIRECTION,
as well as handle and pass down any errors resulting from the navigation.

Note: A new failCallback event has been added to showcase the error handling mechanism when navigation fails with 422 and there are callback errors and warnings returned which results in the error being passed down to the CaseViewerComponent and displayed on the template as banners.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
