### PR TITLE
RDM-5007 Stop using wizardPageField.display_context

### DIFF
--- a/src/shared/components/case-editor/services/wizard-page-field-to-case-field.mapper.spec.ts
+++ b/src/shared/components/case-editor/services/wizard-page-field-to-case-field.mapper.spec.ts
@@ -19,7 +19,7 @@ describe('WizardPageFieldToCaseFieldMapper', () => {
   const INCOMPLETE_SHOW_CONDITION = INCOMPLETE_SHOW_CONDITION_ONE + ' AND ' + INCOMPLETE_SHOW_CONDITION_TWO;
 
   const CASE_FIELDS = [
-    createCaseField('debtorName', 'Debtor name', '', textFieldType(), null),
+    createCaseField('debtorName', 'Debtor name', '', textFieldType(), 'MANDATORY'),
     createCaseField('finalReturn', 'Final return', '',
       createFieldType('Return', 'Complex', [
         createCaseField('addressAttended',
@@ -186,7 +186,7 @@ describe('WizardPageFieldToCaseFieldMapper - nested Collection of Collection typ
     [PARTY_NAME_TEXT_FIELD, RESPONSE_SUBJECT_LIST_ITEM, TIMELINE_EVENTS_COLLECTION]);
 
   const CASE_FIELDS = [
-    createCaseField('reason', 'Reason', '', textFieldType(), null),
+    createCaseField('reason', 'Reason', '', textFieldType(), 'MANDATORY'),
     createCaseField('respondents', 'Defendants', '',
       createFieldType('respondents-33e0ff77', 'Collection', [], RESPONDENT_COMPLEX_FIELD_TYPE), 'COMPLEX')];
 

--- a/src/shared/components/case-editor/services/wizard-page-field-to-case-field.mapper.ts
+++ b/src/shared/components/case-editor/services/wizard-page-field-to-case-field.mapper.ts
@@ -19,7 +19,6 @@ export class WizardPageFieldToCaseFieldMapper {
 
     let caseField: CaseField = caseFields.find(e => e.id === wizardPageField.case_field_id);
     caseField.wizardProps = wizardPageField;
-    caseField.display_context = wizardPageField.display_context;
     caseField.order = wizardPageField.order;
 
     this.initializeNaturalOrder(caseField);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-5007


### Change description ###
Use caseField displayContext instead using the override from wizardPageField.display_context. Final goal is to remove the wizardPageField.display_context from wizardPages.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
