### PR TITLE
EUI-2344: Hide generic callback error message

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,7 @@
 ## RELEASE NOTES
+### Version 2.64.36-hide-generic-callback-error-message
+**EUI-2344** - Hide generic callback error message when there is a custom configured message provided by a Service
+
 ### Version 2.64.35-organisation-complex-field-type
 **EUI-2086** - Search organisation
 **EUI-2087** - Select organisation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.64.35-organisation-complex-field-type",
+  "version": "2.64.36-hide-generic-callback-error-message",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/components/case-editor/case-edit-page/case-edit-page.component.spec.ts
+++ b/src/shared/components/case-editor/case-edit-page/case-edit-page.component.spec.ts
@@ -20,14 +20,29 @@ import { CaseFieldService } from '../../../services/case-fields/case-field.servi
 import { Draft } from '../../../domain/draft.model';
 import { CaseEventData } from '../../../domain/case-event-data.model';
 import { CaseEventTrigger } from '../../../domain/case-view/case-event-trigger.model';
+import { HttpError } from '../../../domain/http/http-error.model';
 import { CallbackErrorsContext } from '../../error/domain/error-context';
 import { FieldTypeSanitiser } from '../../../services/form/field-type-sanitiser';
+import { text } from '../../../test/helpers';
 import createSpyObj = jasmine.createSpyObj;
 
 describe('CaseEditPageComponent', () => {
 
   let de: DebugElement;
   const $SELECT_SUBMIT_BUTTON = By.css('button[type=submit]');
+  const $SELECT_ERROR_SUMMARY = By.css('.error-summary');
+  const $SELECT_ERROR_HEADING_GENERIC = By.css('.error-summary>h1:first-child');
+  const $SELECT_ERROR_MESSAGE_GENERIC = By.css('.govuk-error-summary__body>p:first-child');
+  const $SELECT_ERROR_HEADING_SPECIFIC = By.css('.error-summary>h3:first-child');
+  const $SELECT_ERROR_MESSAGE_SPECIFIC = By.css('.error-summary>p:nth-child(2)');
+  const $SELECT_CALLBACK_DATA_FIELD_ERROR_LIST = By.css('.error-summary-list');
+  const $SELECT_FIRST_FIELD_ERROR = By.css('li:first-child');
+  const $SELECT_SECOND_FIELD_ERROR = By.css('li:nth-child(2)');
+
+  const ERROR_HEADING_GENERIC = 'Something went wrong';
+  const ERROR_MESSAGE_GENERIC = 'We\'re working to fix the problem. Try again shortly.';
+  const ERROR_HEADING_SPECIFIC = 'The event could not be created'
+  const ERROR_MESSAGE_SPECIFIC = 'There are field validation errors'
 
   let comp: CaseEditPageComponent;
   let fixture: ComponentFixture<CaseEditPageComponent>;
@@ -575,6 +590,95 @@ describe('CaseEditPageComponent', () => {
         expect(eventData.event_token).toEqual(comp.eventTrigger.event_token);
         expect(formValueService.sanitiseDynamicLists).toHaveBeenCalled();
       });
+    });
+
+    it('should display generic error heading and message when form error is set but no callback errors, warnings, or error details', () => {
+      comp.error = {
+        status: 200,
+        callbackErrors: null,
+        callbackWarnings: null,
+        details: null
+      } as HttpError;
+
+      fixture.detectChanges();
+
+      fixture.whenStable().then(() => {
+        const error = de.query($SELECT_ERROR_SUMMARY);
+        expect(error).toBeTruthy();
+
+        const errorHeading = error.query($SELECT_ERROR_HEADING_GENERIC);
+        expect(text(errorHeading)).toBe(ERROR_HEADING_GENERIC);
+
+        const errorMessage = error.query($SELECT_ERROR_MESSAGE_GENERIC);
+        expect(text(errorMessage)).toBe(ERROR_MESSAGE_GENERIC);
+      });
+    });
+
+    it('should display specific error heading and message, and callback data field validation errors (if any)', () => {
+      comp.error = {
+        status: 422,
+        callbackErrors: null,
+        callbackWarnings: null,
+        details: {
+          field_errors: [
+            {
+              message: 'First field error'
+            },
+            {
+              message: 'Second field error'
+            }
+          ]
+        },
+        message: 'There are field validation errors'
+      } as HttpError;
+
+      fixture.detectChanges();
+
+      fixture.whenStable().then(() => {
+        const error = de.query($SELECT_ERROR_SUMMARY);
+        expect(error).toBeTruthy();
+
+        const errorHeading = error.query($SELECT_ERROR_HEADING_SPECIFIC);
+        expect(text(errorHeading)).toBe(ERROR_HEADING_SPECIFIC);
+
+        const errorMessage = error.query($SELECT_ERROR_MESSAGE_SPECIFIC);
+        expect(text(errorMessage)).toBe(ERROR_MESSAGE_SPECIFIC);
+
+        const fieldErrorList = de.query($SELECT_CALLBACK_DATA_FIELD_ERROR_LIST);
+        expect(fieldErrorList).toBeTruthy();
+        const firstFieldError = fieldErrorList.query($SELECT_FIRST_FIELD_ERROR);
+        expect(text(firstFieldError)).toBe('First field error');
+        const secondFieldError = fieldErrorList.query($SELECT_SECOND_FIELD_ERROR);
+        expect(text(secondFieldError)).toBe('Second field error');
+      });
+    });
+
+    it('should not display generic error heading and message when there are specific callback errors', () => {
+      comp.error = {
+        status: 422,
+        callbackErrors: ['First error', 'Second error'],
+        callbackWarnings: null,
+        details: null
+      } as HttpError;
+
+      fixture.detectChanges();
+
+      const error = de.query($SELECT_ERROR_SUMMARY);
+      expect(error).toBeFalsy();
+    });
+
+    it('should not display generic error heading and message when there are specific callback warnings', () => {
+      comp.error = {
+        status: 422,
+        callbackErrors: null,
+        callbackWarnings: ['First warning', 'Second warning'],
+        details: null
+      } as HttpError;
+
+      fixture.detectChanges();
+
+      const error = de.query($SELECT_ERROR_SUMMARY);
+      expect(error).toBeFalsy();
     });
 
     it('should change button label when callback warnings notified ', () => {

--- a/src/shared/components/case-editor/case-edit-page/case-edit-page.html
+++ b/src/shared/components/case-editor/case-edit-page/case-edit-page.html
@@ -6,13 +6,24 @@
   #{{ getCaseId() | ccdCaseReference}}
 </h2>
 
-<div *ngIf="error" class="error-summary" role="group" aria-labelledby="edit-case-event_error-summary-heading" tabindex="-1">
+<!-- Generic error heading and error message to be displayed only if there are no specific callback errors or warnings, or no error details -->
+<div *ngIf="error && !(error.callbackErrors || error.callbackWarnings || error.details)" class="error-summary" role="group" aria-labelledby="edit-case-event_error-summary-heading" tabindex="-1">
+  <h1 class="heading-h1 error-summary-heading" id="edit-case-event_error-summary-heading">
+    Something went wrong
+  </h1>
+  <div class="govuk-error-summary__body" id="edit-case-event_error-summary-body">
+    <p>We're working to fix the problem. Try again shortly.</p>
+    <p><a href="get-help" target="_blank">Contact us</a> if you're still having problems.</p>
+  </div>
+</div>
+<!-- Event error heading and error message to be displayed if there are specific error details -->
+<div *ngIf="error && error.details" class="error-summary" role="group" aria-labelledby="edit-case-event_error-summary-heading" tabindex="-1">
   <h3 class="heading-h3 error-summary-heading" id="edit-case-event_error-summary-heading">
     The event could not be created
   </h3>
   <p>{{error.message}}</p>
   <ul *ngIf="error.details?.field_errors" class="error-summary-list">
-    <li *ngFor="let fieldError of error.details.field_errors" class=" ccd-error-summary-li">{{fieldError.message}}</li>
+    <li *ngFor="let fieldError of error.details.field_errors" class="ccd-error-summary-li">{{fieldError.message}}</li>
   </ul>
 </div>
 <ccd-callback-errors

--- a/src/shared/components/case-editor/case-edit-submit/case-edit-submit.html
+++ b/src/shared/components/case-editor/case-edit-submit/case-edit-submit.html
@@ -6,8 +6,18 @@
   #{{ getCaseId() | ccdCaseReference}}
 </h2>
 
-<div *ngIf="error" class="error-summary" role="group" aria-labelledby="edit-case-event_error-summary-heading"
-     tabindex="-1">
+<!-- Generic error heading and error message to be displayed only if there are no specific callback errors or warnings, or no error details -->
+<div *ngIf="error && !(error.callbackErrors || error.callbackWarnings || error.details)" class="error-summary" role="group" aria-labelledby="edit-case-event_error-summary-heading" tabindex="-1">
+  <h1 class="heading-h1 error-summary-heading" id="edit-case-event_error-summary-heading">
+    Something went wrong
+  </h1>
+  <div class="govuk-error-summary__body" id="edit-case-event_error-summary-body">
+    <p>We're working to fix the problem. Try again shortly.</p>
+    <p><a href="get-help" target="_blank">Contact us</a> if you're still having problems.</p>
+  </div>
+</div>
+<!-- Event error heading and error message to be displayed if there are specific error details -->
+<div *ngIf="error && error.details" class="error-summary" role="group" aria-labelledby="edit-case-event_error-summary-heading" tabindex="-1">
   <h3 class="heading-h3 error-summary-heading" id="edit-case-event_error-summary-heading">
     The event could not be created
   </h3>

--- a/src/shared/components/case-viewer/case-viewer.component.html
+++ b/src/shared/components/case-viewer/case-viewer.component.html
@@ -1,5 +1,16 @@
 <div *ngIf="isDataLoaded()">
-  <div *ngIf="error" class="error-summary" role="group" aria-labelledby="edit-case-event_error-summary-heading" tabindex="-1">
+  <!-- Generic error heading and error message to be displayed only if there are no specific callback errors or warnings, or no error details -->
+  <div *ngIf="error && !(error.callbackErrors || error.callbackWarnings || error.details)" class="error-summary" role="group" aria-labelledby="edit-case-event_error-summary-heading" tabindex="-1">
+    <h1 class="heading-h1 error-summary-heading" id="edit-case-event_error-summary-heading">
+      Something went wrong
+    </h1>
+    <div class="govuk-error-summary__body" id="edit-case-event_error-summary-body">
+      <p>We're working to fix the problem. Try again shortly.</p>
+      <p><a href="get-help" target="_blank">Contact us</a> if you're still having problems.</p>
+    </div>
+  </div>
+  <!-- Callback error heading and error message to be displayed if there are specific error details -->
+  <div *ngIf="error && error.details" class="error-summary" role="group" aria-labelledby="edit-case-event_error-summary-heading" tabindex="-1">
     <h2 class="heading-h2 error-summary-heading" id="edit-case-event_error-summary-heading">
       The callback data failed validation
     </h2>

--- a/src/shared/components/error/callback-errors.html
+++ b/src/shared/components/error/callback-errors.html
@@ -10,6 +10,8 @@
       </li>
     </ul>
   </ng-container>
+  <!-- Add a break for spacing if there are both errors and warnings -->
+  <br *ngIf="hasErrors() && hasWarnings()">
   <ng-container *ngIf="hasWarnings()">
     <h3 class="heading-h3 error-summary-heading">
       Warnings


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-2344

### Change description ###
Hide the generic callback error message if a custom configured one has been provided by a Service. Applies to the Case Edit page, Case Edit Submit page, and Case Viewer component.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
