### PR TITLE
EUI-2649: Revert EUI-2575 temporarily

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,7 @@
 ## RELEASE NOTES
+### Version 2.64.38-revert-EUI-2575
+**EUI-2649** - Revert EUI-2575 (which changed `usecase` query param to `use_case`), due to reversion in CCD Demo environment
+
 ### Version 2.64.37-organisation-complex-field-type
 **EUI-2087** - Search organisation support full UK address fields
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.64.37-organisation-complex-field-type",
+  "version": "2.64.38-revert-EUI-2575",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/services/search/search.service.spec.ts
+++ b/src/shared/services/search/search.service.spec.ts
@@ -16,7 +16,7 @@ describe('SearchService', () => {
   const DATA_URL = 'http://data.ccd.reform';
   const SEARCH_URL = API_URL + `/caseworkers/:uid/jurisdictions/${JID}/case-types/${CTID}/cases`;
   const VIEW = `WORKBASKET`;
-  const SEARCH_CASES_URL = DATA_URL + `/internal/searchCases?ctid=${CTID}&use_case=${VIEW}`;
+  const SEARCH_CASES_URL = DATA_URL + `/internal/searchCases?ctid=${CTID}&usecase=${VIEW}`;
   const SEARCH_INPUT_URL = DATA_URL + '/internal/case-types/0/search-inputs';
 
   const SEARCH_VIEW = {

--- a/src/shared/services/search/search.service.ts
+++ b/src/shared/services/search/search.service.ts
@@ -41,7 +41,7 @@ export class SearchService {
 
   public searchCases(caseTypeId: string,
                 metaCriteria: object, caseCriteria: object, view?: SearchView, sort?: {column: string, order: number}): Observable<{}> {
-    const url = this.appConfig.getCaseDataUrl() + `/internal/searchCases?ctid=${caseTypeId}&use_case=${view}`;
+    const url = this.appConfig.getCaseDataUrl() + `/internal/searchCases?ctid=${caseTypeId}&usecase=${view}`;
 
     let options: RequestOptionsArgs = this.requestOptionsBuilder.buildOptions(metaCriteria, caseCriteria, view);
     const body: {} = {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-2649

### Change description ###
Change `use_case` query parameter back to `usecase`, due to reversion on CCD Demo environment.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
