### PR TITLE
EUI-2657: Reinstate EUI-2575

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,8 @@
 ## RELEASE NOTES
-### Version EUI-2649-case-detail-is-broken
+### Version 2.64.40-reinstate-EUI-2575
+**EUI-2657** - Reinstate EUI-2575 (`use_case` query param), in line with the reversion in CCD Demo environment being undone
+
+### Version 2.64.39-fix-datepipe-error
 **EUI-2649** - EUI-2649-case-detail-is-broken
 
 ### Version 2.64.38-revert-EUI-2575

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.64.39-fix-datepipe-error",
+  "version": "2.64.40-reinstate-EUI-2575",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/services/search/search.service.spec.ts
+++ b/src/shared/services/search/search.service.spec.ts
@@ -16,7 +16,7 @@ describe('SearchService', () => {
   const DATA_URL = 'http://data.ccd.reform';
   const SEARCH_URL = API_URL + `/caseworkers/:uid/jurisdictions/${JID}/case-types/${CTID}/cases`;
   const VIEW = `WORKBASKET`;
-  const SEARCH_CASES_URL = DATA_URL + `/internal/searchCases?ctid=${CTID}&usecase=${VIEW}`;
+  const SEARCH_CASES_URL = DATA_URL + `/internal/searchCases?ctid=${CTID}&use_case=${VIEW}`;
   const SEARCH_INPUT_URL = DATA_URL + '/internal/case-types/0/search-inputs';
 
   const SEARCH_VIEW = {

--- a/src/shared/services/search/search.service.ts
+++ b/src/shared/services/search/search.service.ts
@@ -41,7 +41,7 @@ export class SearchService {
 
   public searchCases(caseTypeId: string,
                 metaCriteria: object, caseCriteria: object, view?: SearchView, sort?: {column: string, order: number}): Observable<{}> {
-    const url = this.appConfig.getCaseDataUrl() + `/internal/searchCases?ctid=${caseTypeId}&usecase=${view}`;
+    const url = this.appConfig.getCaseDataUrl() + `/internal/searchCases?ctid=${caseTypeId}&use_case=${view}`;
 
     let options: RequestOptionsArgs = this.requestOptionsBuilder.buildOptions(metaCriteria, caseCriteria, view);
     const body: {} = {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-2657

### Change description ###
Revert `usecase` query parameter to `use_case`, in line with reversion on CCD Demo environment being undone.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
