### PR TITLE
EUI-1783: Support for deleting hidden field values

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,7 @@
 ## RELEASE NOTES
+### Version 2.64.42-retain-hidden-value-support
+**EUI-1783** Delete hidden field value except if `retain_hidden_value` flag is true
+
 ### Version 2.64.41-reinstate-EUI-2575
 **EUI-2657** - Reinstate EUI-2575 (`use_case` query param), in line with the reversion in CCD Demo environment being undone
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.64.41-reinstate-EUI-2575",
+  "version": "2.64.42-retain-hidden-value-support",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/components/case-editor/case-edit-submit/case-edit-submit.component.ts
+++ b/src/shared/components/case-editor/case-edit-submit/case-edit-submit.component.ts
@@ -118,25 +118,25 @@ export class CaseEditSubmitComponent implements OnInit, OnDestroy {
    * = `true`). This is necessary to allow hidden fields whose values are **not** to be retained, to be passed to the
    * backend to be updated.
    *
-   * @param fg The `FormGroup` instance whose raw values are to be filtered
-   * @returns `fg` with the filtered raw form value data (as key-value pairs) in place of the original value data
+   * @param formGroup The `FormGroup` instance whose raw values are to be filtered
+   * @returns `formGroup` with the filtered raw form value data (as key-value pairs) in place of the original value data
    */
-  private filterRawFormValues(fg: FormGroup): any {
+  private filterRawFormValues(formGroup: FormGroup): any {
     // Get the raw form value data, which includes the values of any disabled controls, as key-value pairs
-    const rawFormValueData = fg.getRawValue().data;
+    const rawFormValueData = formGroup.getRawValue().data;
 
     // Discard any value whose FormControl is hidden (status = DISABLED) AND corresponds to a case_field with the
     // retain_hidden_value flag set to true (these fields should not be updated in the backend)
     Object.keys(rawFormValueData).forEach((key) => {
       const case_field = this.eventTrigger.case_fields[key];
-      if ((fg.get('data') as FormGroup).get(key).status === 'DISABLED' && case_field && case_field.retain_hidden_value) {
+      if ((formGroup.get('data') as FormGroup).get(key).status === 'DISABLED' && case_field && case_field.retain_hidden_value) {
         delete rawFormValueData[key];
       }
     });
 
     // Set the filtered raw form value data back on the FormGroup
-    fg.value.data = rawFormValueData;
-    return fg;
+    formGroup.value.data = rawFormValueData;
+    return formGroup;
   }
 
   isDisabled(): boolean {

--- a/src/shared/components/case-editor/case-edit-submit/case-edit-submit.component.ts
+++ b/src/shared/components/case-editor/case-edit-submit/case-edit-submit.component.ts
@@ -87,7 +87,7 @@ export class CaseEditSubmitComponent implements OnInit, OnDestroy {
 
   submit(): void {
     this.isSubmitting = true;
-    let caseEventData: CaseEventData = this.formValueService.sanitise(this.editForm.value) as CaseEventData;
+    let caseEventData: CaseEventData = this.formValueService.sanitise(this.filterRawFormValues(this.editForm).value) as CaseEventData;
     caseEventData.event_token = this.eventTrigger.event_token;
     caseEventData.ignore_warning = this.ignoreWarning;
     this.caseEdit.submit(caseEventData)
@@ -110,6 +110,33 @@ export class CaseEditSubmitComponent implements OnInit, OnDestroy {
           this.isSubmitting = false;
         }
       );
+  }
+
+  /**
+   * Filter *all* the values of a {@link FormGroup}, including those for disabled fields (i.e. hidden ones), removing
+   * any whose {@link FormControl} is hidden (disabled) AND whose value is to be retained (i.e. `retain_hidden_value`
+   * = `true`). This is necessary to allow hidden fields whose values are **not** to be retained, to be passed to the
+   * backend to be updated.
+   *
+   * @param fg The `FormGroup` instance whose raw values are to be filtered
+   * @returns `fg` with the filtered raw form value data (as key-value pairs) in place of the original value data
+   */
+  private filterRawFormValues(fg: FormGroup): any {
+    // Get the raw form value data, which includes the values of any disabled controls, as key-value pairs
+    const rawFormValueData = fg.getRawValue().data;
+
+    // Discard any value whose FormControl is hidden (status = DISABLED) AND corresponds to a case_field with the
+    // retain_hidden_value flag set to true (these fields should not be updated in the backend)
+    Object.keys(rawFormValueData).forEach((key) => {
+      const case_field = this.eventTrigger.case_fields[key];
+      if ((fg.get('data') as FormGroup).get(key).status === 'DISABLED' && case_field && case_field.retain_hidden_value) {
+        delete rawFormValueData[key];
+      }
+    });
+
+    // Set the filtered raw form value data back on the FormGroup
+    fg.value.data = rawFormValueData;
+    return fg;
   }
 
   isDisabled(): boolean {

--- a/src/shared/components/case-editor/case-edit/case-edit.component.spec.ts
+++ b/src/shared/components/case-editor/case-edit/case-edit.component.spec.ts
@@ -77,7 +77,7 @@ describe('CaseEditComponent', () => {
 
   const CASE_FIELD_2: CaseField = <CaseField>({
     id: 'PersonLastName',
-    label: 'First name',
+    label: 'Last name',
     field_type: null,
     display_context: 'READONLY'
   });
@@ -538,7 +538,7 @@ describe('CaseEditComponent', () => {
           expect(component.form.get('data').get(CASE_FIELD_3.id)).not.toBeNull();
         });
 
-        it('should navigate to next page when next is called and clear hidden simple form field', () => {
+        it('should navigate to next page when next is called and clear hidden simple form fields with retain_hidden_value true', () => {
           component.wizard = wizard;
           let currentPage = new WizardPage();
           currentPage.wizard_page_fields = [WIZARD_PAGE_1];
@@ -546,6 +546,10 @@ describe('CaseEditComponent', () => {
           wizard.getPage.and.returnValue(currentPage);
           let nextPage = new WizardPage();
           nextPage.show_condition = 'PersonFirstName=\"John\"';
+          // Ensure retain_hidden_value is true for fields that will be cleared but whose value is to be retained in
+          // the backend (i.e. form control removed to prevent backend update)
+          CASE_FIELD_2.retain_hidden_value = true;
+          CASE_FIELD_3.retain_hidden_value = true;
           nextPage.case_fields = [CASE_FIELD_2, CASE_FIELD_3]
           nextPage.wizard_page_fields = [WIZARD_PAGE_2, WIZARD_PAGE_3];
           wizard.nextPage.and.returnValue(nextPage);

--- a/src/shared/domain/definition/case-field.model.ts
+++ b/src/shared/domain/definition/case-field.model.ts
@@ -24,6 +24,7 @@ export class CaseField implements Orderable {
   show_summary_content_option?: number;
   acls?: AccessControlList[];
   metadata?: boolean;
+  retain_hidden_value: boolean;
 
   @Type(() => WizardPageField)
   wizardProps?: WizardPageField;

--- a/src/shared/fixture/shared.test.fixture.ts
+++ b/src/shared/fixture/shared.test.fixture.ts
@@ -29,7 +29,8 @@ export let createCaseEventTrigger = (id: string,
 };
 
 export let aCaseField = (id: string, label: string, type: FieldTypeEnum, display_context: string,
-                         show_summary_content_option: number, typeComplexFields: CaseField[] = []): CaseField => {
+                         show_summary_content_option: number, typeComplexFields: CaseField[] = [],
+                         retain_hidden_value?: boolean): CaseField => {
   return <CaseField>({
     id: id || 'personFirstName',
     field_type: {
@@ -39,7 +40,8 @@ export let aCaseField = (id: string, label: string, type: FieldTypeEnum, display
     },
     display_context: display_context || 'OPTIONAL',
     label: label || 'First name',
-    show_summary_content_option: show_summary_content_option
+    show_summary_content_option: show_summary_content_option,
+    retain_hidden_value: retain_hidden_value || false
   });
 };
 

--- a/src/shared/services/fields/fields.purger.ts
+++ b/src/shared/services/fields/fields.purger.ts
@@ -2,8 +2,9 @@ import { Injectable } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { FieldsUtils } from './fields.utils';
 import { ShowCondition } from '../../directives/conditional-show/domain/conditional-show.model';
-import { WizardPage } from '../../components';
+import { Wizard, WizardPage, WizardPageField } from '../../components';
 import { CaseField } from '../../domain/definition';
+import { CaseEventTrigger } from '../../domain/case-view/case-event-trigger.model';
 
 // @dynamic
 @Injectable()
@@ -13,12 +14,12 @@ export class FieldsPurger {
     private fieldsUtils: FieldsUtils,
   ) {}
 
-  clearHiddenFields(form, wizard, eventTrigger, currentPageId) {
+  clearHiddenFields(form: FormGroup, wizard: Wizard, eventTrigger: CaseEventTrigger, currentPageId: string) {
     this.clearHiddenFieldForFieldShowCondition(currentPageId, form, wizard, eventTrigger);
     this.clearHiddenFieldForPageShowCondition(form, wizard, eventTrigger);
   }
 
-  private clearHiddenFieldForPageShowCondition(form, wizard, eventTrigger) {
+  private clearHiddenFieldForPageShowCondition(form: FormGroup, wizard: Wizard, eventTrigger: CaseEventTrigger) {
     let currentEventState = this.fieldsUtils.getCurrentEventState(eventTrigger, form);
     wizard.pages.forEach(wp => {
       if (this.hasShowConditionPage(wp, currentEventState)) {
@@ -30,7 +31,7 @@ export class FieldsPurger {
     });
   }
 
-  private clearHiddenFieldForFieldShowCondition(currentPageId, form, wizard, eventTrigger) {
+  private clearHiddenFieldForFieldShowCondition(currentPageId: string, form: FormGroup, wizard: Wizard, eventTrigger: CaseEventTrigger) {
     let formFields = form.getRawValue();
     let currentPage: WizardPage = wizard.getPage(currentPageId, this.fieldsUtils.buildCanShowPredicate(eventTrigger, form));
     currentPage.wizard_page_fields.forEach(wpf => {
@@ -44,54 +45,66 @@ export class FieldsPurger {
     });
   }
 
-  private isHidden(condition, formFields) {
+  private isHidden(condition: ShowCondition, formFields: any): boolean {
     return !condition.match(formFields);
   }
 
-  private findCaseFieldByWizardPageFieldId(currentPage, wizardPageField) {
+  private findCaseFieldByWizardPageFieldId(currentPage: WizardPage, wizardPageField: WizardPageField): CaseField {
     return currentPage.case_fields.find(cf => cf.id === wizardPageField.case_field_id);
   }
 
-  private hasShowConditionPage(wizardPage, formFields): boolean {
+  private hasShowConditionPage(wizardPage: WizardPage, formFields: any): boolean {
     return wizardPage.show_condition && formFields[this.getShowConditionKey(wizardPage.show_condition)];
   }
 
-  private hasShowConditionField(case_field, formFields): boolean {
+  private hasShowConditionField(case_field: CaseField, formFields: any): boolean {
     return case_field.show_condition && formFields.data[this.getShowConditionKey(case_field.show_condition)];
   }
 
-  private getShowConditionKey(show_condition) {
-    return show_condition.split('=')[0];
+  private getShowConditionKey(show_condition: string): string {
+    // Need to allow for negated conditions, i.e. !=, as well as regular ones (=)
+    return show_condition.split(/!=|=/)[0];
   }
 
-  private resetField(form, field) {
-    if (Array.isArray(field.value)) {
-      field.value.splice(0, field.value.length);
-    } else if (this.isObject(field.value)) {
-      field.value = {};
+  private resetField(form: FormGroup, field: CaseField) {
+    // Removing the field means that it is *NOT* sent to the CCD backend, which means no changes are made in the data.
+    // This is OK *if* the hidden value needs to be retained, i.e. field.retain_hidden_value = true, but the default
+    // should be to set it to null and allow it to be sent as such.
+    if (field.retain_hidden_value) {
+      // Reset the field value and remove its control. This does NOT update it in the CCD backend, since it is just
+      // removed from the JSON structure
+      if (Array.isArray(field.value)) {
+        field.value.splice(0, field.value.length);
+      } else if (this.isObject(field.value)) {
+        field.value = {};
+      } else {
+        field.value = '';
+      }
+      (form.get('data') as FormGroup).removeControl(field.id);
     } else {
-      field.value = '';
+      // Set the value of the field's control to null. This DOES update the value in the CCD backend
+      const fieldControl = (form.get('data') as FormGroup).get(field.id);
+      fieldControl.setValue(null);
     }
-    (form.get('data') as FormGroup).removeControl(field.id);
   }
 
-  private resetPage(form, wizardPage: WizardPage) {
+  private resetPage(form: FormGroup, wizardPage: WizardPage) {
     wizardPage.wizard_page_fields.forEach(wpf => {
       let case_field = this.findCaseFieldByWizardPageFieldId(wizardPage, wpf);
       this.resetField(form, case_field);
     });
   }
 
-  private getType(elem): string {
+  private getType(elem: any): string {
     return Object.prototype.toString.call(elem).slice(8, -1);
   }
 
-  private isObject(elem) {
+  private isObject(elem: any): boolean {
     return this.getType(elem) === 'Object';
   };
 
   // TODO: call isReadOnly on CaseFields once we make it available
-  private isReadonly(case_field: CaseField) {
+  private isReadonly(case_field: CaseField): boolean {
     return case_field.display_context.toUpperCase() === 'READONLY'
   }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-1783

### Change description ###
Ensure any existing value of a hidden field is deleted in the CCD backend, unless the field has the `retain_hidden_value` flag set to `true` (see RDM-9024), in which case the existing value will remain untouched.

**Note:** This is a _breaking change_; for hidden fields, the default behaviour will change from the value being retained to the value being **deleted** in the CCD backend, _unless_ the field has the `retain_hidden_value` flag set to `true`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
