### PR TITLE
EUI-2681: Fix another bug with check for complex field types

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,7 @@
 ## RELEASE NOTES
+### Version 2.64.44-retain-hidden-value-fix-for-complex-types
+**EUI-2681** Fix bug with check for complex field types
+
 ### Version 2.64.43-retain-hidden-value-fix-for-complex-types
 **EUI-2681** Fix: Do not set a field control's value to `null` if it corresponds to a complex `CaseField` type
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.64.43-retain-hidden-value-fix-for-complex-types",
+  "version": "2.64.44-retain-hidden-value-fix-for-complex-types",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/services/fields/fields.purger.ts
+++ b/src/shared/services/fields/fields.purger.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { FormGroup } from '@angular/forms';
+import { FormControl, FormGroup } from '@angular/forms';
 import { FieldsUtils } from './fields.utils';
 import { ShowCondition } from '../../directives/conditional-show/domain/conditional-show.model';
 import { Wizard, WizardPage, WizardPageField } from '../../components';
@@ -76,8 +76,8 @@ export class FieldsPurger {
     // alone.
     //
     // The only reliable check if a field is a complex type or not is to obtain its corresponding control and check
-    // whether it's a `FormControl` (simple field) or `FormGroup` (complex field) instance.
-    if (field.retain_hidden_value || (form.get('data') as FormGroup).get(field.id) instanceof FormGroup) {
+    // whether it's a `FormControl` (simple field) or something else.
+    if (field.retain_hidden_value || !((form.get('data') as FormGroup).get(field.id) instanceof FormControl)) {
       // Reset the field value and remove its control. This does NOT update it in the CCD backend, since it is just
       // removed from the JSON structure
       if (Array.isArray(field.value)) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-2681

### Change description ###
Change the check to see if the form control is a `FormControl` instance (simple field) _or something else_. This caters for other types of form controls, such as `FormArray` (and not just `FormGroup`).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
