### PR TITLE
EUI-2667 - Fix for collection fields that include date fields

### DIFF
--- a/src/shared/components/palette/history/event-log/event-log-table.component.spec.ts
+++ b/src/shared/components/palette/history/event-log/event-log-table.component.spec.ts
@@ -108,7 +108,8 @@ describe('EventLogTableComponent', () => {
       expect(firstRowCells.length).toBe(3);
       let firstEvent = EVENTS[0];
 
-      const timeZoneOffset = -(new Date().getTimezoneOffset());
+      const date = new Date(2017, 4, 10); // 10th May, 2017
+      const timeZoneOffset = - (new Date(date).getTimezoneOffset());
 
       expect(firstRowCells[COL_EVENT].nativeElement.textContent).toBe(firstEvent.event_name + firstEvent.significant_item.description);
       expect(firstRowCells[COL_DATE].nativeElement.textContent)

--- a/src/shared/directives/substitutor/label-substitutor.directive.spec.ts
+++ b/src/shared/directives/substitutor/label-substitutor.directive.spec.ts
@@ -451,16 +451,20 @@ describe('LabelSubstitutorDirective', () => {
     it('should pass form field value with invalid date when both form and case field values present', () => {
       let label = 'someLabel';
       comp.caseField = textField('LabelB', '', label);
-      comp.caseFields = [comp.caseField, field('LabelA', '2018-03', {
+      comp.caseFields = [comp.caseField, field('LabelA', 'bob', {
         id: 'LabelA',
         type: 'Date'
       }, '')];
       comp.formGroup = new FormGroup({
-        LabelA: new FormControl('2018-03')
+        LabelA: new FormControl('bob')
       });
       fixture.detectChanges();
 
-      expect(placeholderService.resolvePlaceholders).toHaveBeenCalledWith({LabelB: '', LabelA: '{ Invalid Date: 2018-03 }'}, label);
+      // EUI-2667. Changing this to expect a null as the DatePipe will no
+      // longer simply throw an exception for an invalid date and will
+      // attempt to parse what's passed in as a date. This is to overcome
+      // collections of dates being passed through twice.
+      expect(placeholderService.resolvePlaceholders).toHaveBeenCalledWith({LabelB: '', LabelA: null}, label);
     });
   });
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-2667


### Change description ###
The DatePipe was throwing exceptions for dates that didn't fit the ISO format. This resulted in console errors and a failure to display dates when they are in a collection - the date is basically formatted twice, except the second time it throws an exception because it receives the already-formatted date.

This will now attempt to parse dates it receives that don't correspond to the ISO format and, when it encounters one, format it appropriately.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
