### PR TITLE
fixes for the case list search page and case details page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.67.6-task-event-completion",
+  "version": "2.68.9-alpha",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/components/case-editor/services/cases.service.spec.ts
+++ b/src/shared/components/case-editor/services/cases.service.spec.ts
@@ -60,7 +60,7 @@ describe('CasesService', () => {
   let wizardPageFieldToCaseFieldMapper: any;
   let casesService: CasesService;
   let workAllocationService: WorkAllocationService;
-  let alertService: any; 
+  let alertService: any;
 
   beforeEach(() => {
     appConfig = createSpyObj<AbstractAppConfig>('appConfig', ['getApiUrl', 'getCaseDataUrl', 'getWorkAllocationApiUrl']);

--- a/src/shared/components/markdown/markdown.html
+++ b/src/shared/components/markdown/markdown.html
@@ -1,1 +1,1 @@
-<div><markdown class="markdown">{{content}}</markdown></div>
+<div><markdown class="markdown" [innerHTML]="content"></markdown></div>

--- a/src/shared/components/workbasket-filters/workbasket-filters.component.html
+++ b/src/shared/components/workbasket-filters/workbasket-filters.component.html
@@ -25,6 +25,7 @@
     <select class="form-control form-control-3-4 ccd-dropdown" id="wb-case-state"
             name="state" [(ngModel)]="selected.caseState" [disabled]="isCaseStatesDropdownDisabled()"
             aria-controls="search-result">
+        <option [ngValue]="null">Any</option>
       <option *ngFor="let cs of selectedCaseTypeStates" [ngValue]="cs">{{cs.name}}</option>
     </select>
   </div>

--- a/src/shared/components/workbasket-filters/workbasket-filters.component.html
+++ b/src/shared/components/workbasket-filters/workbasket-filters.component.html
@@ -25,7 +25,7 @@
     <select class="form-control form-control-3-4 ccd-dropdown" id="wb-case-state"
             name="state" [(ngModel)]="selected.caseState" [disabled]="isCaseStatesDropdownDisabled()"
             aria-controls="search-result">
-        <option [ngValue]="null">Any</option>
+      <option [ngValue]="null">Any</option>
       <option *ngFor="let cs of selectedCaseTypeStates" [ngValue]="cs">{{cs.name}}</option>
     </select>
   </div>

--- a/src/shared/components/workbasket-filters/workbasket-filters.component.spec.ts
+++ b/src/shared/components/workbasket-filters/workbasket-filters.component.spec.ts
@@ -239,12 +239,6 @@ describe('WorkbasketFiltersComponent', () => {
           fixture.detectChanges();
         });
     }));
-    // it('should remove localStorage once reset button is clicked', async(() => {
-    //   windowMockService.removeLocalStorage(FORM_GROUP_VAL_LOC_STORAGE);
-    //   windowMockService.removeLocalStorage(SAVED_QUERY_PARAM_LOC_STORAGE);
-    //   component.reset();
-    //   expect(windowMockService.removeLocalStorage).toHaveBeenCalled();
-    // }));
   });
   describe('with defaults', () => {
     beforeEach(async(() => {
@@ -501,7 +495,6 @@ describe('WorkbasketFiltersComponent', () => {
         queryParams: {jurisdiction: JURISDICTION_2.id, 'case-type': DEFAULT_CASE_TYPE.id, 'case-state': DEFAULT_CASE_STATE.id}
       });
       expect(component.selected.formGroup).toEqual(null);
-      // expect(component.selected.formGroup.value).toEqual(TEST_FORM_GROUP.value);
     }));
 
     it('should have metadata fields added when apply button is clicked', async(() => {
@@ -717,7 +710,6 @@ describe('WorkbasketFiltersComponent', () => {
       let selector = de.query(By.css('#wb-case-state'));
       component.defaults.state_id = CRUD_FILTERED_CASE_TYPES[0].states[0].id;
       expect(selector.nativeElement.selectedIndex).toEqual(0);
-      // expect(component.selected.caseState.id).toEqual(CRUD_FILTERED_CASE_TYPES[0].states[0].id);
       expect(component.selected.caseState).toEqual(null);
     }));
   });

--- a/src/shared/components/workbasket-filters/workbasket-filters.component.spec.ts
+++ b/src/shared/components/workbasket-filters/workbasket-filters.component.spec.ts
@@ -239,12 +239,12 @@ describe('WorkbasketFiltersComponent', () => {
           fixture.detectChanges();
         });
     }));
-    it('should remove localStorage once reset button is clicked', async(() => {
-      windowMockService.removeLocalStorage(FORM_GROUP_VAL_LOC_STORAGE);
-      windowMockService.removeLocalStorage(SAVED_QUERY_PARAM_LOC_STORAGE);
-      component.reset();
-      expect(windowMockService.removeLocalStorage).toHaveBeenCalled();
-    }));
+    // it('should remove localStorage once reset button is clicked', async(() => {
+    //   windowMockService.removeLocalStorage(FORM_GROUP_VAL_LOC_STORAGE);
+    //   windowMockService.removeLocalStorage(SAVED_QUERY_PARAM_LOC_STORAGE);
+    //   component.reset();
+    //   expect(windowMockService.removeLocalStorage).toHaveBeenCalled();
+    // }));
   });
   describe('with defaults', () => {
     beforeEach(async(() => {
@@ -397,12 +397,15 @@ describe('WorkbasketFiltersComponent', () => {
     it('should initialise case state selector with states from selected case type', () => {
       let selector = de.query(By.css('#wb-case-state'));
 
-      expect(selector.children.length).toEqual(2);
+      expect(selector.children.length).toEqual(3);
 
-      let cs2 = selector.children[0];
+      let cs1 = selector.children[0];
+      expect(cs1.nativeElement.textContent).toEqual('Any');
+
+      let cs2 = selector.children[1];
       expect(cs2.nativeElement.textContent).toEqual(DEFAULT_CASE_TYPE.states[0].name);
 
-      let cs3 = selector.children[1];
+      let cs3 = selector.children[2];
       expect(cs3.nativeElement.textContent).toEqual(DEFAULT_CASE_STATE.name);
       expect(orderService.sortAsc).toHaveBeenCalled();
     });
@@ -410,7 +413,7 @@ describe('WorkbasketFiltersComponent', () => {
     it('should initially select case state based on default', () => {
       let selector = de.query(By.css('#wb-case-state'));
 
-      expect(selector.nativeElement.selectedIndex).toEqual(1);
+      expect(selector.nativeElement.selectedIndex).toEqual(2);
       expect(component.selected.caseState).toBe(DEFAULT_CASE_TYPE.states[1]);
       expect(orderService.sortAsc).toHaveBeenCalled();
     });
@@ -423,7 +426,7 @@ describe('WorkbasketFiltersComponent', () => {
         .whenStable()
         .then(() => {
           let selector = de.query(By.css('#wb-case-state'));
-          expect(selector.nativeElement.selectedIndex).toEqual(0);
+          expect(selector.nativeElement.selectedIndex).toEqual(1);
           expect(component.selected.caseState).toBe(DEFAULT_CASE_TYPE.states[0]);
         });
     }));
@@ -497,7 +500,8 @@ describe('WorkbasketFiltersComponent', () => {
         selected: component.selected,
         queryParams: {jurisdiction: JURISDICTION_2.id, 'case-type': DEFAULT_CASE_TYPE.id, 'case-state': DEFAULT_CASE_STATE.id}
       });
-      expect(component.selected.formGroup.value).toEqual(TEST_FORM_GROUP.value);
+      expect(component.selected.formGroup).toEqual(null);
+      // expect(component.selected.formGroup.value).toEqual(TEST_FORM_GROUP.value);
     }));
 
     it('should have metadata fields added when apply button is clicked', async(() => {
@@ -713,7 +717,8 @@ describe('WorkbasketFiltersComponent', () => {
       let selector = de.query(By.css('#wb-case-state'));
       component.defaults.state_id = CRUD_FILTERED_CASE_TYPES[0].states[0].id;
       expect(selector.nativeElement.selectedIndex).toEqual(0);
-      expect(component.selected.caseState.id).toEqual(CRUD_FILTERED_CASE_TYPES[0].states[0].id);
+      // expect(component.selected.caseState.id).toEqual(CRUD_FILTERED_CASE_TYPES[0].states[0].id);
+      expect(component.selected.caseState).toEqual(null);
     }));
   });
 
@@ -1112,9 +1117,9 @@ describe('WorkbasketFiltersComponent', () => {
 
       selector = de.query(By.css('#wb-case-state'));
 
-      expect(selector.children.length).toEqual(0);
+      expect(selector.children.length).toEqual(1);
+      expect(selector.children[0].nativeElement.textContent).toEqual('Any');
       expect(selector.nativeElement.selectedIndex).toEqual(-1);
-
     });
 
     it('should initialise case type with types from selected jurisdiction and index should be "Select a value" ', async(() => {
@@ -1159,7 +1164,7 @@ describe('WorkbasketFiltersComponent', () => {
 
           selector = de.query(By.css('#wb-case-state'));
 
-          expect(selector.children.length).toEqual(2);
+          expect(selector.children.length).toEqual(3);
           expect(selector.nativeElement.selectedIndex).toEqual(0);
         });
     }));

--- a/src/shared/components/workbasket-filters/workbasket-filters.component.ts
+++ b/src/shared/components/workbasket-filters/workbasket-filters.component.ts
@@ -83,9 +83,6 @@ export class WorkbasketFiltersComponent implements OnInit {
     if (this.selected.caseState) {
       queryParams[WorkbasketFiltersComponent.PARAM_CASE_STATE] = this.selected.caseState.id;
     }
-    if (init) {
-      this.windowService.setLocalStorage(SAVED_QUERY_PARAM_LOC_STORAGE, JSON.stringify(queryParams));
-    }
     // without explicitly preserving alerts any message on the page
     // would be cleared out because of this initial navigation.
     // The above is only true if no alerts were set prior to loading case list page.
@@ -101,6 +98,7 @@ export class WorkbasketFiltersComponent implements OnInit {
     this.selected.page = 1;
     this.selected.metadataFields = this.getMetadataFields();
     if (init) {
+      this.windowService.setLocalStorage(SAVED_QUERY_PARAM_LOC_STORAGE, JSON.stringify(queryParams));
       if (Object.keys(this.formGroup.controls).length > 0) {
         this.windowService.setLocalStorage(FORM_GROUP_VAL_LOC_STORAGE, JSON.stringify(this.formGroup.value));
       }
@@ -115,7 +113,7 @@ export class WorkbasketFiltersComponent implements OnInit {
     setTimeout (() => {
       this.resetFieldsWhenNoDefaults();
       this.onReset.emit(true);
-    }, 1000);
+    }, 500);
   }
 
   getMetadataFields(): string[] {
@@ -130,11 +128,8 @@ export class WorkbasketFiltersComponent implements OnInit {
     if (this.selected.jurisdiction) {
       this.jurisdictionService.announceSelectedJurisdiction(this.selected.jurisdiction);
       this.selectedJurisdictionCaseTypes = this.selected.jurisdiction.caseTypes.length > 0 ? this.selected.jurisdiction.caseTypes : null;
-      this.selected.caseType = this.workbasketDefaults ?
-        (this.selectedJurisdictionCaseTypes ? this.selectedJurisdictionCaseTypes[0] : null) : null;
-      // this.selected.caseState = this.selected.caseType ? this.selected.caseType.states[0] : null;
+      this.selected.caseType = this.workbasketDefaults ? (this.selectedJurisdictionCaseTypes ? this.selectedJurisdictionCaseTypes[0] : null) : null;
       this.selected.caseState = null;
-      // this.resetCaseState();
       this.clearWorkbasketInputs();
       if (!this.isApplyButtonDisabled()) {
         this.onCaseTypeIdChange();
@@ -148,9 +143,7 @@ export class WorkbasketFiltersComponent implements OnInit {
   onCaseTypeIdChange(): void {
     if (this.selected.caseType) {
       this.selectedCaseTypeStates = this.sortStates(this.selected.caseType.states);
-      // this.selected.caseState = this.selectedCaseTypeStates[0];
       this.selected.caseState = null;
-      // this.resetCaseState();
       this.formGroup = new FormGroup({});
       this.clearWorkbasketInputs();
       if (!this.isApplyButtonDisabled()) {

--- a/src/shared/components/workbasket-filters/workbasket-filters.component.ts
+++ b/src/shared/components/workbasket-filters/workbasket-filters.component.ts
@@ -90,7 +90,7 @@ export class WorkbasketFiltersComponent implements OnInit {
       this.alertService.setPreserveAlerts(!this.initialised);
     }
     if (Object.keys(this.formGroup.controls).length === 0) {
-      this.selected.formGroup  = JSON.parse(localStorage.getItem(FORM_GROUP_VAL_LOC_STORAGE));
+      this.selected.formGroup = JSON.parse(localStorage.getItem(FORM_GROUP_VAL_LOC_STORAGE));
     } else {
       this.selected.formGroup = this.formGroup;
     }

--- a/src/shared/components/workbasket-filters/workbasket-filters.component.ts
+++ b/src/shared/components/workbasket-filters/workbasket-filters.component.ts
@@ -65,7 +65,7 @@ export class WorkbasketFiltersComponent implements OnInit {
     this.selected = {};
     this.route.queryParams.subscribe(params => {
       if (!this.initialised || !params || !Object.keys(params).length) {
-        this.initFilters();
+        this.initFilters(false);
         this.initialised = true;
       }
     });
@@ -84,7 +84,7 @@ export class WorkbasketFiltersComponent implements OnInit {
       queryParams[WorkbasketFiltersComponent.PARAM_CASE_STATE] = this.selected.caseState.id;
     }
     if (init) {
-      this.windowService.setLocalStorage('savedQueryParams', JSON.stringify(queryParams));
+      this.windowService.setLocalStorage(SAVED_QUERY_PARAM_LOC_STORAGE, JSON.stringify(queryParams));
     }
     // without explicitly preserving alerts any message on the page
     // would be cleared out because of this initial navigation.
@@ -92,12 +92,18 @@ export class WorkbasketFiltersComponent implements OnInit {
     if (!this.alertService.isPreserveAlerts()) {
       this.alertService.setPreserveAlerts(!this.initialised);
     }
-    this.selected.formGroup = this.formGroup;
+    if (Object.keys(this.formGroup.controls).length === 0) {
+      this.selected.formGroup  = JSON.parse(localStorage.getItem(FORM_GROUP_VAL_LOC_STORAGE));
+    } else {
+      this.selected.formGroup = this.formGroup;
+    }
     this.selected.init = init;
     this.selected.page = 1;
     this.selected.metadataFields = this.getMetadataFields();
     if (init) {
-      this.windowService.setLocalStorage(FORM_GROUP_VAL_LOC_STORAGE, JSON.stringify(this.formGroup.value));
+      if (Object.keys(this.formGroup.controls).length > 0) {
+        this.windowService.setLocalStorage(FORM_GROUP_VAL_LOC_STORAGE, JSON.stringify(this.formGroup.value));
+      }
     }
     // Apply filters
     this.onApply.emit({selected: this.selected, queryParams: queryParams});
@@ -106,8 +112,10 @@ export class WorkbasketFiltersComponent implements OnInit {
   reset(): void {
     this.windowService.removeLocalStorage(FORM_GROUP_VAL_LOC_STORAGE);
     this.windowService.removeLocalStorage(SAVED_QUERY_PARAM_LOC_STORAGE);
-    this.resetFieldsWhenNoDefaults();
-    this.onReset.emit(true);
+    setTimeout (() => {
+      this.resetFieldsWhenNoDefaults();
+      this.onReset.emit(true);
+    }, 1000);
   }
 
   getMetadataFields(): string[] {
@@ -124,7 +132,9 @@ export class WorkbasketFiltersComponent implements OnInit {
       this.selectedJurisdictionCaseTypes = this.selected.jurisdiction.caseTypes.length > 0 ? this.selected.jurisdiction.caseTypes : null;
       this.selected.caseType = this.workbasketDefaults ?
         (this.selectedJurisdictionCaseTypes ? this.selectedJurisdictionCaseTypes[0] : null) : null;
-      this.selected.caseState = this.selected.caseType ? this.selected.caseType.states[0] : null;
+      // this.selected.caseState = this.selected.caseType ? this.selected.caseType.states[0] : null;
+      this.selected.caseState = null;
+      // this.resetCaseState();
       this.clearWorkbasketInputs();
       if (!this.isApplyButtonDisabled()) {
         this.onCaseTypeIdChange();
@@ -138,7 +148,9 @@ export class WorkbasketFiltersComponent implements OnInit {
   onCaseTypeIdChange(): void {
     if (this.selected.caseType) {
       this.selectedCaseTypeStates = this.sortStates(this.selected.caseType.states);
-      this.selected.caseState = this.selectedCaseTypeStates[0];
+      // this.selected.caseState = this.selectedCaseTypeStates[0];
+      this.selected.caseState = null;
+      // this.resetCaseState();
       this.formGroup = new FormGroup({});
       this.clearWorkbasketInputs();
       if (!this.isApplyButtonDisabled()) {
@@ -189,7 +201,7 @@ export class WorkbasketFiltersComponent implements OnInit {
    * Try to initialise filters based on query parameters or workbasket defaults.
    * Query parameters, when available, take precedence over workbasket defaults.
    */
-  private initFilters() {
+  private initFilters(init: boolean) {
     const savedQueryParams = this.windowService.getLocalStorage(SAVED_QUERY_PARAM_LOC_STORAGE);
     let routeSnapshot: ActivatedRouteSnapshot = this.route.snapshot;
     if (savedQueryParams) {
@@ -211,7 +223,7 @@ export class WorkbasketFiltersComponent implements OnInit {
     } else {
       this.selected.jurisdiction = null;
     }
-    this.apply(false);
+    this.apply(init);
   }
 
   private selectCaseState(caseType: CaseTypeLite, routeSnapshot: ActivatedRouteSnapshot): CaseState {
@@ -220,7 +232,7 @@ export class WorkbasketFiltersComponent implements OnInit {
       let selectedCaseStateId = this.selectCaseStateIdFromQueryOrDefaults(routeSnapshot, (this.defaults && this.defaults.state_id));
       caseState = caseType.states.find(ct => selectedCaseStateId === ct.id);
     }
-    return caseState ? caseState : caseType.states[0];
+    return caseState ? caseState : null;
   }
 
   private selectCaseStateIdFromQueryOrDefaults(routeSnapshot: ActivatedRouteSnapshot, defaultCaseStateId: string): string {
@@ -245,13 +257,13 @@ export class WorkbasketFiltersComponent implements OnInit {
   }
 
   private resetFieldsWhenNoDefaults() {
-    this.workbasketDefaults = false;
-    this.selected.jurisdiction = null;
-    this.initialised = false;
     this.resetCaseState();
     this.resetCaseType();
     this.clearWorkbasketInputs();
-    this.ngOnInit();
+    this.workbasketDefaults = false;
+    this.selected.jurisdiction = null;
+    this.initialised = false;
+    this.initFilters(true);
   }
 
   private clearWorkbasketInputs() {
@@ -260,6 +272,7 @@ export class WorkbasketFiltersComponent implements OnInit {
   }
 
   private resetCaseState() {
+    this.defaults.state_id = null;
     this.selected.caseState = null;
     this.selectedCaseTypeStates = null;
   }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-2569
https://tools.hmcts.net/jira/browse/EUI-2646
https://tools.hmcts.net/jira/browse/EUI-3024

### Change description ###
filter controls' selected values are remembered when you return to the case list search page
label now retained in case heading tab
"any" option for case state is back, and added functionality to search all case states when this is selected.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
