### PR TITLE
EUI-3375: Clear out labels nested within complex types within collections

### DIFF
--- a/src/shared/services/form/form-value.service.ts
+++ b/src/shared/services/form/form-value.service.ts
@@ -312,6 +312,7 @@ export class FormValueService {
    * @param data The object to be tidied up.
    * @param caseFields The CaseFields that need to be cleaned up.
    * @param clearEmpty Whether or not we should clear out empty, optional, complex objects.
+   * @param clearNonCase Whether or not we should clear out non-case fields at the top level.
    */
   public removeUnnecessaryFields(data: object, caseFields: CaseField[], clearEmpty = false, clearNonCase = false): void {
     if (data && caseFields && caseFields.length > 0) {
@@ -324,8 +325,9 @@ export class FormValueService {
           // Retain anything that is readonly and not a label.
           continue;
         }
-        if (field.hidden === true) {
-          // Delete anything that is hidden (that is NOT readonly).
+        if (field.hidden === true && field.display_context !== 'HIDDEN') {
+          // Delete anything that is hidden (that is NOT readonly), and that
+          // hasn't had its display_context overridden to make it hidden.
           delete data[field.id];
         } else if (field.field_type) {
           switch (field.field_type.type) {
@@ -337,6 +339,7 @@ export class FormValueService {
               // Recurse and remove anything unnecessary from within a complex field.
               this.removeUnnecessaryFields(data[field.id], field.field_type.complex_fields, clearEmpty);
               // Also remove any optional complex objects that are completely empty.
+              // Stop removing empty objects.
               if (FormValueService.clearOptionalEmpty(clearEmpty, data[field.id], field)) {
                 delete data[field.id];
               }
@@ -352,6 +355,7 @@ export class FormValueService {
                   // Iterate through the elements and remove any unnecessary fields within.
                   for (const item of collection) {
                     this.removeUnnecessaryFields(item, field.field_type.collection_field_type.complex_fields, clearEmpty);
+                    this.removeUnnecessaryFields(item.value, field.field_type.collection_field_type.complex_fields, false);
                   }
                 }
               }

--- a/src/shared/services/form/form-value.service.ts
+++ b/src/shared/services/form/form-value.service.ts
@@ -339,7 +339,6 @@ export class FormValueService {
               // Recurse and remove anything unnecessary from within a complex field.
               this.removeUnnecessaryFields(data[field.id], field.field_type.complex_fields, clearEmpty);
               // Also remove any optional complex objects that are completely empty.
-              // Stop removing empty objects.
               if (FormValueService.clearOptionalEmpty(clearEmpty, data[field.id], field)) {
                 delete data[field.id];
               }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-3375


### Change description ###
Reintroduced the recursion within collections to clear out unwanted fields within the `value` part of the item. This had been removed due to EUI-3284 but we still need to remove nested labels because the API doesn't like them.

EUI-3284 still failed with just that change so I've added in a check for the display_context being set to 'HIDDEN' when considering whether to delete a hidden field's data at the submission stage. When the display_context is set to 'HIDDEN', it means that it's been overridden by the page wizard to not be seen by the user, rather than having been hidden by the normal show/hide logic.

There are instances where sending hidden data causes the API to return an error - i.e., data has been submitted that shouldn't have been - and others where we need to send it because the API needs them. The distinguishing feature seems to be with `display_context = 'HIDDEN'`, hence this new check.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
