### PR TITLE
EUI-3381: Alerts not showing

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,8 @@
 ## RELEASE NOTES
 
+### Version 2.71.2-conditional-show-perf
+Fix EUI-3381 - fix for missing alert banner.
+
 ### Version 2.71.1-conditional-show-perf
 Fix EUI-3375 - more tweaks to collections on data submission
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.71.1-conditional-show-perf",
+  "version": "2.71.2-conditional-show-perf",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/services/alert/alert.service.ts
+++ b/src/shared/services/alert/alert.service.ts
@@ -76,30 +76,37 @@ export class AlertService {
     this.preservedError = '';
     this.preservedWarning = '';
     this.preservedSuccess = '';
+
+    // EUI-3381.
+    this.alertObserver.next(null);
+    this.message = '';
   }
 
   error(message: string): void {
     this.preservedError = this.preserveMessages(message);
-    this.errorObserver.next({
-      level: 'error',
-      message: message
-    });
+    const alert: Alert = { level: 'error', message };
+    this.errorObserver.next(alert);
+
+    // EUI-3381.
+    this.push(alert);
   }
 
   warning(message: string): void {
     this.preservedWarning = this.preserveMessages(message);
-    this.warningObserver.next({
-      level: 'warning',
-      message: message
-    });
+    const alert: Alert = { level: 'warning', message };
+    this.warningObserver.next(alert);
+
+    // EUI-3381.
+    this.push(alert);
   }
 
   success(message: string): void {
     this.preservedSuccess = this.preserveMessages(message);
-    this.successObserver.next({
-      level: 'success',
-      message: message
-    });
+    const alert: Alert = { level: 'success', message };
+    this.successObserver.next(alert);
+
+    // EUI-3381.
+    this.push(alert);
   }
 
   setPreserveAlerts(preserve: boolean, urlInfo?: string[]) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-3381


### Change description ###
Alerts weren't showing because MC still relies on the alertObserver, which wasn't being updated when error, warning, or success were called.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```