### PR TITLE
EUI-3403: Fix for optional top level documents

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,8 @@
 ## RELEASE NOTES
 
+### Version 2.71.4-optional-top-level-documents
+Fix EUI-3403 - fix for optional top-level documents incorrectly showing.
+
 ### Version 2.71.2-conditional-show-perf
 Fix EUI-3381 - fix for missing alert banner.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.71.2-conditional-show-perf",
+  "version": "2.71.4-optional-top-level-documents",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/components/palette/document/write-document-field.component.ts
+++ b/src/shared/components/palette/document/write-document-field.component.ts
@@ -56,18 +56,14 @@ export class WriteDocumentFieldComponent extends AbstractFieldWriteComponent imp
 
   ngOnInit() {
     this.initDialog();
-    let document = this.caseField.value;
-    if (document) {
-      if (this.isAMandatoryComponent()) {
-        this.createDocumentFormWithValidator(document.document_url, document.document_binary_url, document.document_filename);
-      } else {
-        this.createDocumentForm(document.document_url, document.document_binary_url, document.document_filename);
-      }
+    // EUI-3403. The field was not being registered when there was no value and the field
+    // itself was not mandatory, which meant that show_conditions would not be evaluated.
+    // I've cleaned up the logic and it's now always registered.
+    const document = this.caseField.value || { document_url: null, docment_binary_url: null, document_filename: null };
+    if (this.isAMandatoryComponent()) {
+      this.createDocumentFormWithValidator(document.document_url, document.document_binary_url, document.document_filename);
     } else {
-      if (this.isAMandatoryComponent()) {
-        this.createDocumentFormWithValidator(null, null, null);
-        this.selectedFile = null;
-      }
+      this.createDocumentForm(document.document_url, document.document_binary_url, document.document_filename);
     }
   }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-3403


### Change description ###
Document fields were not being registered when there was no value and the field itself was not mandatory, which meant that `show_conditions` would not be evaluated. Cleaned up the logic and the field is now always registered.

Also fixed a lint error in this PR.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```