### PR TITLE
EUI-3464: Remove setting of null HTTP headers

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,6 @@
 ## RELEASE NOTES
+### Version 2.72.5-remove-null-http-request-headers
+**EUI-3464** Fix Document field uploads by removing setting of null HTTP "Accept" and "Content-Type" headers
 
 ### Version 2.72.4-check-your-answers
 Fix EUI-3452 - fix for show/hide conditions on Check Your Answers page.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.72.4-check-your-answers",
+  "version": "2.72.5-remove-null-http-request-headers",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/services/document-management/document-management.service.ts
+++ b/src/shared/services/document-management/document-management.service.ts
@@ -9,28 +9,25 @@ import { HttpHeaders } from '@angular/common/http';
 
 @Injectable()
 export class DocumentManagementService {
-  private static readonly HEADER_ACCEPT = 'Accept';
-  private static readonly HEADER_CONTENT_TYPE = 'Content-Type';
   private static readonly PDF = 'pdf';
   private static readonly IMAGE = 'image';
   // This delay has been added to give enough time to the user on the UI to see the info messages on the document upload
   // field for cases when uploads are very fast.
   private static readonly RESPONSE_DELAY = 1000;
 
-  imagesList: string[] = [ 'GIF', 'JPG', 'JPEG', 'PNG'];
+  imagesList: string[] = ['GIF', 'JPG', 'JPEG', 'PNG'];
 
   constructor(private http: HttpService, private appConfig: AbstractAppConfig) {}
 
   uploadFile(formData: FormData): Observable<DocumentData> {
     const url = this.appConfig.getDocumentManagementUrl();
-    let headers = new HttpHeaders();
-    headers = headers.append(DocumentManagementService.HEADER_ACCEPT, null);
-    // Content-Type header value needs to be null; HttpService will delete it, so that Angular can set it automatically
-    // with the correct boundary
-    headers = headers.append(DocumentManagementService.HEADER_CONTENT_TYPE, null);
+    // Do not set any headers, such as "Accept" or "Content-Type", with null values; this is not permitted with the
+    // Angular HttpClient in @angular/common/http. Just create and pass a new HttpHeaders object. Angular will add the
+    // correct headers and values automatically
+    const headers = new HttpHeaders();
     return this.http
       .post(url, formData, {headers, observe: 'body'})
-      .pipe(delay( DocumentManagementService.RESPONSE_DELAY ))
+      .pipe(delay(DocumentManagementService.RESPONSE_DELAY))
       .pipe(
         map(response => {
           return response;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-3464

### Change description ###
Do not set `Accept` and `Content-Type` headers with `null` values; this is not permitted by the Angular HttpClient. Just pass a new HttpHeaders object in the request and Angular will do the rest.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
