### PR TITLE
EUI-3490: Case list filter broken

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,8 @@
 ## RELEASE NOTES
+
+### Version 2.72.6-fix-filter-any-state
+**EUI-3490** Fixed an issue with the Case list filter where "Any" state is selected.
+
 ### Version 2.72.5-remove-null-http-request-headers
 **EUI-3464** Fix Document field uploads by removing setting of null HTTP "Accept" and "Content-Type" headers
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.72.5-remove-null-http-request-headers",
+  "version": "2.72.6-fix-filter-any-state",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/services/request/request.options.builder.ts
+++ b/src/shared/services/request/request.options.builder.ts
@@ -1,5 +1,6 @@
 import { HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+
 import { OptionsType } from '..';
 
 @Injectable()
@@ -7,7 +8,25 @@ export class RequestOptionsBuilder {
 
     public static readonly FIELD_PREFIX = 'case.';
 
+    /**
+     * Assess the value to see if it should be included in the request options.
+     * If it's null or an "empty" string, it shouldn't be.
+     *
+     * @param value The value to be assessed.
+     */
+    private static includeParam(value: any): boolean {
+      if (value) {
+        if (typeof(value) === 'string') {
+          return value.trim().length > 0;
+        }
+        return true;
+      }
+      return false;
+    }
+
     buildOptions(metaCriteria: object, caseCriteria: object, view?: SearchView): OptionsType {
+      // TODO: This should probably be the now built-in URLSearchParams but it
+      // requires a bigger refactor and there are bigger fish to fry right now.
       let params = new HttpParams();
 
       if (view) {
@@ -16,13 +35,17 @@ export class RequestOptionsBuilder {
 
       if (metaCriteria) {
         for (let criterion of Object.keys(metaCriteria)) {
-          params = params.set(criterion, metaCriteria[criterion]);
+          // EUI-3490. Make sure the parameter should be included for adding it.
+          // This was already handled by the old URLSearchParams mechanism.
+          if (RequestOptionsBuilder.includeParam(metaCriteria[criterion])) {
+            params = params.set(criterion, metaCriteria[criterion]);
+          }
         }
       }
 
       if (caseCriteria) {
         for (let criterion of Object.keys(caseCriteria)) {
-          if (caseCriteria[criterion] && caseCriteria[criterion].trim().length > 0) {
+          if (RequestOptionsBuilder.includeParam(caseCriteria[criterion])) {
             params = params.set(RequestOptionsBuilder.FIELD_PREFIX + criterion, caseCriteria[criterion].trim());
           }
         }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-3490


### Change description ###
The previous implementation used `URLSearchParams`, which automatically ignored `null` properties. Switching to `HttpParams` introduced an issue where such `null`s are not ignored, which had the consequence of sending `"&state=null"` in the query string when the user selected "Any" in the State filter.

Rather than revert back to the deprecated `URLSearchParams` or refactor additional areas for the now built-in `URLSearchParams`, I'm just `null`-checking and making sure they don't get into the query string.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
