### PR TITLE
EUI-3494, EUI-3495: Case creation broken

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,6 @@
 ## RELEASE NOTES
 
-### Version 2.72.9-fix-case-submission
+### Version 2.72.9-prerelease-fix-case-submission
 **EUI-3494** Fixed the missing case ID on case creation.
 **EUI-3495** Fixed an issue where the user was return to Case list following case creation.
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 ## RELEASE NOTES
 
+### Version 2.72.9-fix-case-submission
+**EUI-3494** Fixed the missing case ID on case creation.
+**EUI-3495** Fixed an issue where the user was return to Case list following case creation.
+
 ### Version 2.72.6-fix-filter-any-state
 **EUI-3490** Fixed an issue with the Case list filter where "Any" state is selected.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.72.9-fix-case-submission",
+  "version": "2.72.9-prerelease-fix-case-submission",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.72.6-fix-filter-any-state",
+  "version": "2.72.9-fix-case-submission",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/components/case-editor/services/cases.service.spec.ts
+++ b/src/shared/components/case-editor/services/cases.service.spec.ts
@@ -303,16 +303,6 @@ describe('CasesService', () => {
         );
     });
 
-    it('should return body with empty id if no content-type response header', () => {
-      httpService.post.and.returnValue(Observable.of(EVENT_RESPONSE));
-
-      casesService
-        .createEvent(CASE_DETAILS, CASE_EVENT_DATA)
-        .subscribe(
-          data => expect(data).toEqual(EMPTY_RESPONSE)
-        );
-    });
-
     it('should set error when error is thrown', () => {
       httpService.post.and.returnValue(throwError(ERROR));
 
@@ -440,16 +430,6 @@ describe('CasesService', () => {
         .createCase(CTID, CASE_EVENT_DATA)
         .subscribe(
           data => expect((data as any).body).toEqual(CASE_RESPONSE)
-        );
-    });
-
-    it('should return body with empty id if no content-type response header', () => {
-      httpService.post.and.returnValue(Observable.of(CASE_RESPONSE));
-
-      casesService
-        .createCase(CTID, CASE_EVENT_DATA)
-        .subscribe(
-          data => expect(data).toEqual(EMPTY_RESPONSE)
         );
     });
 

--- a/src/shared/components/case-editor/services/cases.service.ts
+++ b/src/shared/components/case-editor/services/cases.service.ts
@@ -69,7 +69,6 @@ export class CasesService {
     return this.http
       .get(url)
       .pipe(
-        map(response => response),
         catchError(error => {
           this.errorService.setError(error);
           return throwError(error);

--- a/src/shared/components/case-editor/services/cases.service.ts
+++ b/src/shared/components/case-editor/services/cases.service.ts
@@ -87,7 +87,6 @@ export class CasesService {
     return this.http
       .get(url, {headers, observe: 'body'})
       .pipe(
-        map(response => response),
         catchError(error => {
           this.errorService.setError(error);
           return throwError(error);
@@ -103,19 +102,19 @@ export class CasesService {
    *
    * EUI-2530 Dynamic Lists for Elements in a Complex Type
    *
-   * @param jsonResponse - {}
+   * @param jsonBody - {}
    */
-  private handleNestedDynamicLists(jsonResponse) {
+  private handleNestedDynamicLists(jsonBody: any): any {
 
-    if (jsonResponse.case_fields) {
-      jsonResponse.case_fields.forEach(caseField => {
+    if (jsonBody.case_fields) {
+      jsonBody.case_fields.forEach(caseField => {
         if (caseField.field_type) {
           this.setDynamicListDefinition(caseField, caseField.field_type, caseField);
         }
       });
     }
 
-    return jsonResponse;
+    return jsonBody;
   }
 
   private setDynamicListDefinition(caseField, caseFieldType, rootCaseField) {
@@ -172,7 +171,7 @@ export class CasesService {
                   ignoreWarning?: string): Observable<CaseEventTrigger> {
     ignoreWarning = undefined !== ignoreWarning ? ignoreWarning : 'false';
 
-    let url = this.buildEventTriggerUrl(caseTypeId, eventTriggerId, caseId, ignoreWarning);
+    const url = this.buildEventTriggerUrl(caseTypeId, eventTriggerId, caseId, ignoreWarning);
 
     let headers = new HttpHeaders()
     headers = headers.set('experimental', 'true')
@@ -189,8 +188,8 @@ export class CasesService {
     return this.http
       .get(url, {headers, observe: 'body'})
       .pipe(
-        map(response => {
-          return this.handleNestedDynamicLists(response);
+        map(body => {
+          return this.handleNestedDynamicLists(body);
         }),
         catchError(error => {
           this.errorService.setError(error);
@@ -205,7 +204,7 @@ export class CasesService {
     const caseId = caseDetails.case_id;
     const url = this.appConfig.getCaseDataUrl() + `/cases/${caseId}/events`;
 
-    let headers = new HttpHeaders()
+    const headers = new HttpHeaders()
       .set('experimental', 'true')
       .set('Accept', CasesService.V2_MEDIATYPE_CREATE_EVENT)
       .set('Content-Type', 'application/json');
@@ -213,7 +212,7 @@ export class CasesService {
     return this.http
       .post(url, eventData, {headers, observe: 'body'})
       .pipe(
-        map(response => this.processResponse(response, eventData)),
+        map(body => this.processResponseBody(body, eventData)),
         catchError(error => {
           this.errorService.setError(error);
           return throwError(error);
@@ -226,7 +225,7 @@ export class CasesService {
     const url = this.appConfig.getCaseDataUrl()
       + `/case-types/${ctid}/validate${pageIdString}`;
 
-    let headers = new HttpHeaders()
+    const headers = new HttpHeaders()
       .set('experimental', 'true')
       .set('Accept', CasesService.V2_MEDIATYPE_CASE_DATA_VALIDATE)
       .set('Content-Type', 'application/json');
@@ -234,7 +233,6 @@ export class CasesService {
     return this.http
       .post(url, eventData, {headers, observe: 'body'})
       .pipe(
-        map(response => response),
         catchError(error => {
           this.errorService.setError(error);
           return throwError(error);
@@ -251,7 +249,7 @@ export class CasesService {
     const url = this.appConfig.getCaseDataUrl()
       + `/case-types/${ctid}/cases?ignore-warning=${ignoreWarning}`;
 
-    let headers = new HttpHeaders()
+    const headers = new HttpHeaders()
       .set('experimental', 'true')
       .set('Accept', CasesService.V2_MEDIATYPE_CREATE_CASE)
       .set('Content-Type', 'application/json');
@@ -259,7 +257,7 @@ export class CasesService {
     return this.http
       .post(url, eventData, {headers, observe: 'body'})
       .pipe(
-        map(response => this.processResponse(response, eventData)),
+        map(body => this.processResponseBody(body, eventData)),
         catchError(error => {
           this.errorService.setError(error);
           return throwError(error);
@@ -272,7 +270,7 @@ export class CasesService {
       + `/cases/${caseId}`
       + `/documents`;
 
-    let headers = new HttpHeaders()
+    const headers = new HttpHeaders()
       .set('experimental', 'true')
       .set('Accept', CasesService.V2_MEDIATYPE_CASE_DOCUMENTS)
       .set('Content-Type', 'application/json');
@@ -280,7 +278,7 @@ export class CasesService {
     return this.http
       .get(url, {headers, observe: 'body'})
       .pipe(
-        map(response => response.documentResources),
+        map(body => body.documentResources),
         catchError(error => {
           this.errorService.setError(error);
           return throwError(error);
@@ -311,14 +309,9 @@ export class CasesService {
     return url;
   }
 
-  private processResponse(response: any, eventData: CaseEventData) {
-    if (response.headers && response.headers.get('content-type').match(/application\/.*json/)) {
-      // TODO: Handle associated tasks.
-      const json = response;
-      this.processTasksOnSuccess(json, eventData.event);
-      return json;
-    }
-    return {'id': ''};
+  private processResponseBody(body: any, eventData: CaseEventData): any {
+    this.processTasksOnSuccess(body, eventData.event);
+    return body;
   }
 
   private initialiseEventTrigger(eventTrigger: CaseEventTrigger) {

--- a/src/shared/components/case-editor/services/cases.service.ts
+++ b/src/shared/components/case-editor/services/cases.service.ts
@@ -6,7 +6,7 @@ import { catchError, map, tap } from 'rxjs/operators';
 
 import { AbstractAppConfig } from '../../../../app.config';
 import { ShowCondition } from '../../../directives';
-import { CaseEventData, CaseEventTrigger, CasePrintDocument, CaseView, Draft } from '../../../domain';
+import { CaseEventData, CaseEventTrigger, CaseField, CasePrintDocument, CaseView, Draft, FieldType } from '../../../domain';
 import { HttpErrorService, HttpService, OrderService } from '../../../services';
 import { WizardPage } from '../domain';
 import { WizardPageFieldToCaseFieldMapper } from './wizard-page-field-to-case-field.mapper';
@@ -96,15 +96,15 @@ export class CasesService {
 
   /**
    * handleNestedDynamicLists()
-   * Reassigns list_item and value data to DymanicList children
+   * Reassigns list_item and value data to DynamicList children
    * down the tree. Server response returns data only in
    * the `value` object of parent complex type
    *
    * EUI-2530 Dynamic Lists for Elements in a Complex Type
    *
-   * @param jsonBody - {}
+   * @param jsonBody - { case_fields: [ CaseField, CaseField ] }
    */
-  private handleNestedDynamicLists(jsonBody: any): any {
+  private handleNestedDynamicLists(jsonBody: { case_fields: CaseField[] }): any {
 
     if (jsonBody.case_fields) {
       jsonBody.case_fields.forEach(caseField => {
@@ -117,7 +117,7 @@ export class CasesService {
     return jsonBody;
   }
 
-  private setDynamicListDefinition(caseField, caseFieldType, rootCaseField) {
+  private setDynamicListDefinition(caseField: CaseField, caseFieldType: FieldType, rootCaseField: CaseField) {
     if (caseFieldType.type === CasesService.SERVER_RESPONSE_FIELD_TYPE_COMPLEX) {
 
       caseFieldType.complex_fields.forEach(field => {

--- a/src/shared/components/case-history/services/case-history.service.ts
+++ b/src/shared/components/case-history/services/case-history.service.ts
@@ -15,18 +15,15 @@ export class CaseHistoryService {
               private httpErrorService: HttpErrorService,
               private appConfig: AbstractAppConfig) {}
 
-  get(caseId: string,
-      eventId: string): Observable<CaseHistory> {
-
+  get(caseId: string, eventId: string): Observable<CaseHistory> {
     const url = this.appConfig.getCaseHistoryUrl(caseId, eventId);
-    let headers = new HttpHeaders()
+    const headers = new HttpHeaders()
       .set('experimental', 'true')
       .set('Accept', CaseHistoryService.V2_MEDIATYPE_CASE_EVENT_VIEW)
       .set('Content-Type', 'application/json');
 
     return this.httpService
       .get(url, {headers, observe: 'body'})
-      .map(response => response)
       .catch((error: any): any => {
         this.httpErrorService.setError(error);
         return Observable.throw(error);

--- a/src/shared/services/banners/banners.service.ts
+++ b/src/shared/services/banners/banners.service.ts
@@ -14,8 +14,8 @@ export class BannersService {
   }
 
   getBanners(jurisdictionReferences: string[]): Observable<Banner[]> {
-    let url = this.appConfig.getBannersUrl();
-    let headers = new HttpHeaders()
+    const url = this.appConfig.getBannersUrl();
+    const headers = new HttpHeaders()
       .set('experimental', 'true')
       .set('Accept', BannersService.V2_MEDIATYPE_BANNERS)
       .set('Content-Type', 'application/json');
@@ -23,10 +23,6 @@ export class BannersService {
     jurisdictionReferences.forEach(reference => params = params.append('ids', reference));
     return this.httpService
       .get(url, {params, headers, observe: 'body'})
-      .map(response => {
-        let jsonResponse = response;
-        let banners = jsonResponse.banners;
-        return banners;
-      });
+      .map(body => body.banners);
   }
 }

--- a/src/shared/services/document-management/document-management.service.ts
+++ b/src/shared/services/document-management/document-management.service.ts
@@ -29,9 +29,7 @@ export class DocumentManagementService {
       .post(url, formData, {headers, observe: 'body'})
       .pipe(delay(DocumentManagementService.RESPONSE_DELAY))
       .pipe(
-        map(response => {
-          return response;
-        })
+        map(body => body) // EUI-3495. Not sure we need this?
       );
   }
 

--- a/src/shared/services/document-management/document-management.service.ts
+++ b/src/shared/services/document-management/document-management.service.ts
@@ -28,9 +28,7 @@ export class DocumentManagementService {
     return this.http
       .post(url, formData, {headers, observe: 'body'})
       .pipe(delay(DocumentManagementService.RESPONSE_DELAY))
-      .pipe(
-        map(body => body) // EUI-3495. Not sure we need this?
-      );
+      .pipe();
   }
 
   getMediaViewerInfo(documentFieldValue: any): string {

--- a/src/shared/services/draft/draft.service.ts
+++ b/src/shared/services/draft/draft.service.ts
@@ -25,13 +25,12 @@ export class DraftService {
 
   createDraft(ctid: string, eventData: CaseEventData): Observable<Draft> {
     const saveDraftEndpoint = this.appConfig.getCreateOrUpdateDraftsUrl(ctid);
-    let headers = new HttpHeaders()
+    const headers = new HttpHeaders()
       .set('experimental', 'true')
       .set('Accept', DraftService.V2_MEDIATYPE_DRAFT_CREATE)
       .set('Content-Type', 'application/json');
     return this.http
       .post(saveDraftEndpoint, eventData, {headers, observe: 'body'})
-      .map(response => response)
       .catch((error: any): any => {
         this.errorService.setError(error);
         return throwError(error);
@@ -40,13 +39,12 @@ export class DraftService {
 
   updateDraft(ctid: string, draftId: string, eventData: CaseEventData): Observable<Draft> {
     const saveDraftEndpoint = this.appConfig.getCreateOrUpdateDraftsUrl(ctid) + draftId;
-    let headers = new HttpHeaders()
+    const headers = new HttpHeaders()
       .set('experimental', 'true')
       .set('Accept', DraftService.V2_MEDIATYPE_DRAFT_UPDATE)
       .set('Content-Type', 'application/json');
     return this.http
       .put(saveDraftEndpoint, eventData, {headers, observe: 'body'})
-      .map(response => response)
       .catch((error: any): any => {
         this.errorService.setError(error);
         return throwError(error);
@@ -55,13 +53,12 @@ export class DraftService {
 
   getDraft(draftId: string): Observable<CaseView> {
     const url = this.appConfig.getViewOrDeleteDraftsUrl(draftId.slice(DRAFT_PREFIX.length));
-    let headers = new HttpHeaders()
+    const headers = new HttpHeaders()
       .set('experimental', 'true')
       .set('Accept', DraftService.V2_MEDIATYPE_DRAFT_READ)
       .set('Content-Type', 'application/json');
     return this.http
       .get(url, {headers, observe: 'body'})
-      .map(response => response)
       .catch((error: any): any => {
         this.errorService.setError(error);
         return throwError(error);
@@ -70,7 +67,7 @@ export class DraftService {
 
   deleteDraft(draftId: string): Observable<{} | any> {
     const url = this.appConfig.getViewOrDeleteDraftsUrl(draftId.slice(DRAFT_PREFIX.length));
-    let headers = new HttpHeaders()
+    const headers = new HttpHeaders()
       .set('experimental', 'true')
       .set('Accept', DraftService.V2_MEDIATYPE_DRAFT_DELETE)
       .set('Content-Type', 'application/json');

--- a/src/shared/services/profile/profile.service.ts
+++ b/src/shared/services/profile/profile.service.ts
@@ -17,8 +17,8 @@ export class ProfileService {
   constructor(private httpService: HttpService, private appConfig: AbstractAppConfig) {}
 
   get(): Observable<Profile> {
-    let url = this.appConfig.getCaseDataUrl() + ProfileService.URL;
-    let headers = new HttpHeaders()
+    const url = this.appConfig.getCaseDataUrl() + ProfileService.URL;
+    const headers = new HttpHeaders()
       .set('experimental', 'true')
       .set('Accept', ProfileService.V2_MEDIATYPE_USER_PROFILE)
       .set('Content-Type', 'application/json');
@@ -26,7 +26,6 @@ export class ProfileService {
     return this.httpService
       .get(url, {headers, observe: 'body'})
       .pipe(
-        map((response) => response),
         map((p: Object) => plainToClass(Profile, p))
       )
   }

--- a/src/shared/services/search/search.service.ts
+++ b/src/shared/services/search/search.service.ts
@@ -60,7 +60,7 @@ export class SearchService {
   }
 
   getSearchInputs(jurisdictionId: string, caseTypeId: string): Observable<SearchInput[]> {
-    let url = this.getSearchInputUrl(caseTypeId);
+    const url = this.getSearchInputUrl(caseTypeId);
     const headers = new HttpHeaders()
       .set('experimental', 'true')
       .set('Accept', SearchService.V2_MEDIATYPE_SEARCH_INPUTS)
@@ -70,9 +70,8 @@ export class SearchService {
     return this.httpService
       .get(url, { headers, observe: 'body' })
       .pipe(
-        map(response => {
-          let jsonResponse = response;
-          let searchInputs = jsonResponse.searchInputs;
+        map(body => {
+          const searchInputs = body.searchInputs;
           if (this.isDataValid(jurisdictionId, caseTypeId)) {
             searchInputs.forEach(item => {
               item.field.label = item.label;

--- a/src/shared/services/workbasket/workbasket-input-filter.service.ts
+++ b/src/shared/services/workbasket/workbasket-input-filter.service.ts
@@ -33,7 +33,7 @@ export class WorkbasketInputFilterService {
     return this.httpService
       .get(url, {headers, observe: 'body'})
       .map(body => {
-        let workbasketInputs = body.workbasketInputs;
+        const workbasketInputs = body.workbasketInputs;
         if (this.isDataValid(jurisdictionId, caseTypeId)) {
           workbasketInputs.forEach(item => {
             item.field.label = item.label;

--- a/src/shared/services/workbasket/workbasket-input-filter.service.ts
+++ b/src/shared/services/workbasket/workbasket-input-filter.service.ts
@@ -22,8 +22,8 @@ export class WorkbasketInputFilterService {
   }
 
   getWorkbasketInputs(jurisdictionId: string, caseTypeId: string): Observable<WorkbasketInputModel[]> {
-    let url = this.getWorkbasketInputUrl(caseTypeId);
-    let headers = new HttpHeaders()
+    const url = this.getWorkbasketInputUrl(caseTypeId);
+    const headers = new HttpHeaders()
       .set('experimental', 'true')
       .set('Accept', WorkbasketInputFilterService.V2_MEDIATYPE_WORKBASKET_INPUT_DETAILS)
       .set('Content-Type', 'application/json');
@@ -32,9 +32,8 @@ export class WorkbasketInputFilterService {
     this.currentCaseType = caseTypeId;
     return this.httpService
       .get(url, {headers, observe: 'body'})
-      .map(response => {
-        let jsonResponse = response;
-        let workbasketInputs = jsonResponse.workbasketInputs;
+      .map(body => {
+        let workbasketInputs = body.workbasketInputs;
         if (this.isDataValid(jurisdictionId, caseTypeId)) {
           workbasketInputs.forEach(item => {
             item.field.label = item.label;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-3494
https://tools.hmcts.net/jira/browse/EUI-3495


### Change description ###
Fix for case creation that was broken when moving from `Http` to `HttpClient`. This was also a problem for the completion of events on the case.

In the midst of this, tidied up some additional points where changes had been made but code had been left in that was redundant (e.g., `map(response => response)` is a dead operation) or confusing (in the same example, it wasn't actually the _response_, it was the response's _body_.)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```