### PR TITLE
EUI-2667: DatePipe fix

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,8 @@
 ## RELEASE NOTES
 
+### Version 2.73.2-collection-date-field
+**EUI-2667** Fix to date field rendering within collections
+
 ### Version 2.73.0
 **EUI-3222** Loading spinner
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.73.0",
+  "version": "2.73.2-alpha-collection-date-field",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.73.2-alpha-collection-date-field",
+  "version": "2.73.2-collection-date-field",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/directives/substitutor/label-substitutor.directive.spec.ts
+++ b/src/shared/directives/substitutor/label-substitutor.directive.spec.ts
@@ -451,16 +451,20 @@ describe('LabelSubstitutorDirective', () => {
     it('should pass form field value with invalid date when both form and case field values present', () => {
       let label = 'someLabel';
       comp.caseField = textField('LabelB', '', label);
-      comp.caseFields = [comp.caseField, field('LabelA', '2018-03', {
+      comp.caseFields = [comp.caseField, field('LabelA', 'bob', {
         id: 'LabelA',
         type: 'Date'
       }, '')];
       comp.formGroup = new FormGroup({
-        LabelA: new FormControl('2018-03')
+        LabelA: new FormControl('bob')
       });
       fixture.detectChanges();
 
-      expect(placeholderService.resolvePlaceholders).toHaveBeenCalledWith({LabelB: '', LabelA: '{ Invalid Date: 2018-03 }'}, label);
+      // EUI-2667. Changing this to expect a null as the DatePipe will no
+      // longer simply throw an exception for an invalid date and will
+      // attempt to parse what's passed in as a date. This is to overcome
+      // collections of dates being passed through twice.
+      expect(placeholderService.resolvePlaceholders).toHaveBeenCalledWith({LabelB: '', LabelA: null}, label);
     });
   });
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-2667 ✅ `DONE`


### Change description ###
The `DatePipe` was throwing exceptions for dates that didn't fit the ISO format. This resulted in console errors and a failure to display dates when they are in a collection - the date is basically formatted twice, except the second time it throws an exception because it receives the already-formatted date.

This will now attempt to parse dates it receives that don't correspond to the ISO format and, when it encounters one, format it appropriately.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```


**Notes**
This is a Draft PR for the moment as the original went stale after not being merged, despite the JIRA having been tested and approved. I've now rebased it against `master` so it should be re-tested.