### PR TITLE
EUI-3594: Error message specifics not being displayed

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,13 +1,16 @@
 ## RELEASE NOTES
 
-### Version 2.73.0-hotfix-error-message-display
-**EUI-3594** Fix issue with error message specifics not being displayed
+### Version 2.74.2
+**EUI-3594** Incorporating Version 2.73.0-hotfix-error-message-display from hotfix branch
 
 ### Version 2.74.1
 **EUI-3506** Non-Descriptive Headings (AA) - issue 04
 
 ### Version 2.73.5-ngmodel-deprecation
 **EUI-3410** ngModel deprecation
+
+### Version 2.73.0-hotfix-error-message-display
+**EUI-3594** Fix issue with error message specifics not being displayed
 
 ### Version 2.73.0
 **EUI-3222** Loading spinner

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,8 @@
 ## RELEASE NOTES
 
+### Version 2.73.0-hotfix-error-message-display
+**EUI-3594** Fix issue with error message specifics not being displayed
+
 ### Version 2.73.0
 **EUI-3222** Loading spinner
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.73.0",
+  "version": "2.73.0-hotfix-error-message-display",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.73.0-hotfix-error-message-display",
+  "version": "2.74.2",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/components/case-viewer/case-viewer.component.spec.ts
+++ b/src/shared/components/case-viewer/case-viewer.component.spec.ts
@@ -1,3 +1,4 @@
+import { HttpErrorResponse } from '@angular/common/http';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component, DebugElement, EventEmitter, Input, Output } from '@angular/core';
 import { CaseViewerComponent } from './case-viewer.component';
@@ -855,11 +856,11 @@ xdescribe('CaseViewerComponent', () => {
   });
 
   it('should pass flag to disable button when form valid but callback errors exist', () => {
-    component.error = HttpError.from({});
+    component.error = HttpError.from(null);
     fixture.detectChanges();
 
     expect(component.isTriggerButtonDisabled()).toBeFalsy();
-    let error = HttpError.from({});
+    const error = HttpError.from(null);
     error.callbackErrors = ['anErrors'];
     component.error = error;
     fixture.detectChanges();
@@ -878,11 +879,11 @@ xdescribe('CaseViewerComponent', () => {
         field_errors: FIELD_ERRORS
       }
     };
-    let httpError = HttpError.from(VALID_ERROR);
+    const httpError = HttpError.from(new HttpErrorResponse({ error: VALID_ERROR }));
     component.error = httpError;
 
-    let eventTriggerElement = de.query(By.directive(EventTriggerComponent));
-    let eventTrigger = eventTriggerElement.componentInstance;
+    const eventTriggerElement = de.query(By.directive(EventTriggerComponent));
+    const eventTrigger = eventTriggerElement.componentInstance;
 
     eventTrigger.onTriggerChange.next(null);
     fixture.detectChanges();

--- a/src/shared/components/error/callback-errors.component.spec.ts
+++ b/src/shared/components/error/callback-errors.component.spec.ts
@@ -1,3 +1,4 @@
+import { HttpErrorResponse } from '@angular/common/http';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { DebugElement, EventEmitter } from '@angular/core';
 import { Subject } from 'rxjs';
@@ -57,56 +58,56 @@ describe('CallbackErrorsComponent', () => {
   }));
 
   it('should have ignore warning label if notified about error with warnings but no errors set', () => {
-    let error = HttpError.from(VALID_WARNING);
+    const error = HttpError.from(new HttpErrorResponse({ error: VALID_WARNING }));
     callbackErrorsSubject.next(error);
 
-    let expectedCallbackErrorsContext: CallbackErrorsContext = new CallbackErrorsContext();
+    const expectedCallbackErrorsContext: CallbackErrorsContext = new CallbackErrorsContext();
     expectedCallbackErrorsContext.ignore_warning = true;
     expectedCallbackErrorsContext.trigger_text = triggerTextIgnore;
     expect(mockCallbackErrorsContext.emit).toHaveBeenCalledWith(expectedCallbackErrorsContext);
   });
 
   it('should not have ignore warning label if notified about error with warnings and errors set', () => {
-    let error = HttpError.from(VALID_WARNING);
+    const error = HttpError.from(new HttpErrorResponse({ error: VALID_WARNING }));
     error.callbackErrors = ['error1', 'error2'];
     callbackErrorsSubject.next(error);
 
-    let expectedCallbackErrorsContext: CallbackErrorsContext = new CallbackErrorsContext();
+    const expectedCallbackErrorsContext: CallbackErrorsContext = new CallbackErrorsContext();
     expectedCallbackErrorsContext.ignore_warning = false;
     expectedCallbackErrorsContext.trigger_text = triggerTextContinue;
     expect(mockCallbackErrorsContext.emit).toHaveBeenCalledWith(expectedCallbackErrorsContext);
   });
 
   it('should not have ignore warning label if notified about callback error and no warnings but errors set', () => {
-    let error = HttpError.from(VALID_ERROR);
+    const error = HttpError.from(new HttpErrorResponse({ error: VALID_ERROR }));
     callbackErrorsSubject.next(error);
 
-    let expectedCallbackErrorsContext: CallbackErrorsContext = new CallbackErrorsContext();
+    const expectedCallbackErrorsContext: CallbackErrorsContext = new CallbackErrorsContext();
     expectedCallbackErrorsContext.ignore_warning = false;
     expectedCallbackErrorsContext.trigger_text = triggerTextContinue;
     expect(mockCallbackErrorsContext.emit).toHaveBeenCalledWith(expectedCallbackErrorsContext);
   });
 
   it('should display callback warnings when warnings get set', () => {
-    component.error = HttpError.from(VALID_WARNING);
+    component.error = HttpError.from(new HttpErrorResponse({ error: VALID_WARNING }));
     fixture.detectChanges();
 
-    let error = de.query($ERROR_SUMMARY);
+    const error = de.query($ERROR_SUMMARY);
     expect(error).toBeTruthy();
 
-    let warningMessages = error.query($WARNING_MESSAGES);
+    const warningMessages = error.query($WARNING_MESSAGES);
     expect(text(warningMessages.children[0])).toBe(VALID_WARNING.callbackWarnings[0]);
     expect(text(warningMessages.children[1])).toBe(VALID_WARNING.callbackWarnings[1]);
   });
 
   it('should display callback errors when errors get set', () => {
-    component.error = HttpError.from(VALID_ERROR);
+    component.error = HttpError.from(new HttpErrorResponse({ error: VALID_ERROR }));
     fixture.detectChanges();
 
-    let error = de.query($ERROR_SUMMARY);
+    const error = de.query($ERROR_SUMMARY);
     expect(error).toBeTruthy();
 
-    let errorMessages = error.query($ERROR_MESSAGES);
+    const errorMessages = error.query($ERROR_MESSAGES);
     expect(text(errorMessages.children[0])).toBe(VALID_ERROR.callbackErrors[0]);
     expect(text(errorMessages.children[1])).toBe(VALID_ERROR.callbackErrors[1]);
   });
@@ -122,13 +123,13 @@ describe('CallbackErrorsComponent', () => {
         field_errors: FIELD_ERRORS
       }
     };
-    let httpError = HttpError.from(VALID_ERROR_NO_CALLBACK_WARNINGS_OR_ERRORS);
+    const httpError = HttpError.from(new HttpErrorResponse({ error: VALID_ERROR_NO_CALLBACK_WARNINGS_OR_ERRORS }));
     httpError.callbackWarnings = [];
     httpError.callbackErrors = [];
     callbackErrorsSubject.next(httpError);
 
     expect(component.error).toEqual(httpError);
-    let expectedCallbackErrorsContext: CallbackErrorsContext = new CallbackErrorsContext();
+    const expectedCallbackErrorsContext: CallbackErrorsContext = new CallbackErrorsContext();
     expectedCallbackErrorsContext.ignore_warning = false;
     expectedCallbackErrorsContext.trigger_text = triggerTextContinue;
     expect(mockCallbackErrorsContext.emit).toHaveBeenCalledWith(expectedCallbackErrorsContext);

--- a/src/shared/domain/http/http-error.model.spec.ts
+++ b/src/shared/domain/http/http-error.model.spec.ts
@@ -1,3 +1,4 @@
+import { HttpErrorResponse } from '@angular/common/http';
 import { HttpError } from './http-error.model';
 
 describe('HttpError', () => {
@@ -30,16 +31,17 @@ describe('HttpError', () => {
       'path': '/caseworkers/0/jurisdictions/TEST/case-types/TestAddressBookCase/cases'
     };
 
-    it('should return default error when given empty object', () => {
-      let error = HttpError.from({});
+    it('should return default error when given null', () => {
+      const error = HttpError.from(null);
 
       expect(error).toEqual(new HttpError());
+      expect(error.status).toBe(500);
     });
 
     it('should copy all known properties from object to error', () => {
-      let error = HttpError.from(ERROR_FULL);
+      const error = HttpError.from(new HttpErrorResponse({ error: ERROR_FULL }));
 
-      let expectedError = new HttpError();
+      const expectedError = new HttpError();
       expectedError.timestamp = ERROR_FULL.timestamp;
       expectedError.status = ERROR_FULL.status;
       expectedError.error = ERROR_FULL.error;
@@ -51,9 +53,9 @@ describe('HttpError', () => {
     });
 
     it('should ignore unknown properties from object to error', () => {
-      let error = HttpError.from(ERROR_PARTIAL);
+      const error = HttpError.from(new HttpErrorResponse({ error: ERROR_PARTIAL }));
 
-      let expectedError = new HttpError();
+      const expectedError = new HttpError();
       expectedError.status = ERROR_PARTIAL.status;
       expectedError.error = ERROR_PARTIAL.error;
       expectedError.exception = ERROR_PARTIAL.exception;
@@ -63,7 +65,7 @@ describe('HttpError', () => {
     });
 
     it('should ignore additional properties of object', () => {
-      let error = HttpError.from({ unknown: 'xxx'});
+      const error = HttpError.from(new HttpErrorResponse({ error: { unknown: 'xxx' } }));
 
       expect(error).toEqual(new HttpError());
     });

--- a/src/shared/domain/http/http-error.model.ts
+++ b/src/shared/domain/http/http-error.model.ts
@@ -1,6 +1,9 @@
+import { HttpErrorResponse } from '@angular/common/http';
+
 export class HttpError {
   private static readonly DEFAULT_ERROR = 'Unknown error';
   private static readonly DEFAULT_MESSAGE = 'Something unexpected happened, our technical staff have been automatically notified';
+  private static readonly DEFAULT_STATUS = 500;
 
   timestamp: string;
   status: number;
@@ -12,12 +15,15 @@ export class HttpError {
   callbackErrors?: any;
   callbackWarnings?: any;
 
-  static from(data: object): HttpError {
-    let error = new HttpError();
+  static from(response: HttpErrorResponse): HttpError {
+    const error = new HttpError();
 
-    Object
-      .keys(error)
-      .forEach(key => error[key] = data.hasOwnProperty(key) && data[key] ? data[key] : error[key]);
+    // Check that the HttpErrorResponse contains an "error" object before mapping the error properties
+    if (!!(response && response.error)) {
+      Object
+        .keys(error)
+        .forEach(key => error[key] = response.error.hasOwnProperty(key) && response.error[key] ? response.error[key] : error[key]);
+    }
 
     return error;
   }
@@ -26,7 +32,7 @@ export class HttpError {
     this.timestamp = new Date().toISOString();
     this.error = HttpError.DEFAULT_ERROR;
     this.message = HttpError.DEFAULT_MESSAGE;
-    this.status = null;
+    this.status = HttpError.DEFAULT_STATUS;
     this.exception = null;
     this.path = null;
     this.details = null;

--- a/src/shared/services/http/http-error.service.spec.ts
+++ b/src/shared/services/http/http-error.service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpErrorService } from './http-error.service';
 import { HttpError } from '../../domain/http/http-error.model';
 import { AuthService } from '../auth/auth.service';
-import { HttpHeaders, HttpResponse } from '@angular/common/http';
+import { HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 
 describe('HttpErrorService', () => {
   const CURRENT_URL = 'http://core-case-data.common-components.reform';
@@ -29,36 +29,36 @@ describe('HttpErrorService', () => {
     'message': 'The server understood the request but refuses to authorize it....',
     'path': CURRENT_URL
   };
-  const VALID_ERROR_RESPONSE = new HttpResponse({
+  const VALID_ERROR_RESPONSE = new HttpErrorResponse({
     headers: new HttpHeaders()
       .set('Content-Type', 'application/json'),
-    body: VALID_ERROR_BODY,
+    error: VALID_ERROR_BODY,
     status: 422
   });
-  const VALID_ERROR_RESPONSE_WITH_CHARSET = new HttpResponse({
+  const VALID_ERROR_RESPONSE_WITH_CHARSET = new HttpErrorResponse({
     headers: new HttpHeaders()
       .set('Content-Type', 'application/json;charset=UTF-8'),
-    body: VALID_ERROR_BODY,
+    error: VALID_ERROR_BODY,
     status: 422
   });
 
-  const NOT_VALID_ERROR_RESPONSE = new HttpResponse({
+  const NOT_VALID_ERROR_RESPONSE = new HttpErrorResponse({
     headers: new HttpHeaders()
       .set('Content-Type', 'application/json'),
-    body: '{notvalidjson}'
+    error: '{notvalidjson}'
   });
 
-  const HTTP_401_RESPONSE = new HttpResponse({
+  const HTTP_401_RESPONSE = new HttpErrorResponse({
     headers: new HttpHeaders()
       .set('Content-Type', 'application/json'),
-    body: HTTP_401_ERROR_BODY,
+    error: HTTP_401_ERROR_BODY,
     status: 401
   });
 
-  const HTTP_403_RESPONSE = new HttpResponse({
+  const HTTP_403_RESPONSE = new HttpErrorResponse({
     headers: new HttpHeaders()
       .set('Content-Type', 'application/json'),
-    body: HTTP_403_ERROR_BODY,
+    error: HTTP_403_ERROR_BODY,
     status: 403
   });
 
@@ -94,7 +94,7 @@ describe('HttpErrorService', () => {
         );
     });
 
-    it('should convert a valid Response error into an HttpError', (done) => {
+    it('should convert a valid HttpErrorResponse error into an HttpError', (done) => {
       errorService.handle(VALID_ERROR_RESPONSE)
         .subscribe(
           () => fail('no error'),
@@ -105,7 +105,7 @@ describe('HttpErrorService', () => {
         );
     });
 
-    it('should handle a valid Response with charsetInfo', (done) => {
+    it('should handle a valid HttpErrorResponse with charsetInfo', (done) => {
       errorService.handle(VALID_ERROR_RESPONSE_WITH_CHARSET)
         .subscribe(
           () => fail('no error'),
@@ -116,12 +116,13 @@ describe('HttpErrorService', () => {
         );
     });
 
-    it('should convert a non-valid Response error into an HttpError', (done) => {
+    it('should convert a non-valid HttpErrorResponse error into an HttpError', (done) => {
       errorService.handle(NOT_VALID_ERROR_RESPONSE)
         .subscribe(
           () => fail('no error'),
           error => {
             expect(error).toEqual(HttpError.from(NOT_VALID_ERROR_RESPONSE));
+            expect(error.status).toBe(500);
             done();
           }
         );

--- a/src/shared/services/http/http-error.service.ts
+++ b/src/shared/services/http/http-error.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Observable, throwError } from 'rxjs';
 import { HttpError } from '../../domain/http/http-error.model';
 import { AuthService } from '../auth';
-import { HttpResponse } from '@angular/common/http';
+import { HttpErrorResponse } from '@angular/common/http';
 
 @Injectable()
 export class HttpErrorService {
@@ -25,14 +25,14 @@ export class HttpErrorService {
       return error;
   }
 
-  handle(error: HttpResponse<any> | any, redirectIfNotAuthorised = true): Observable<never> {
+  handle(error: HttpErrorResponse | any, redirectIfNotAuthorised = true): Observable<never> {
     let httpError = new HttpError();
-    if (error instanceof HttpResponse) {
+    if (error instanceof HttpErrorResponse) {
       if (error.headers
           && error.headers.get(HttpErrorService.CONTENT_TYPE)
           && error.headers.get(HttpErrorService.CONTENT_TYPE).indexOf(HttpErrorService.JSON) !== -1) {
         try {
-          httpError = HttpError.from(error || {});
+          httpError = HttpError.from(error);
         } catch (e) {
           console.error(e, e.message);
         }

--- a/src/shared/services/http/http.service.ts
+++ b/src/shared/services/http/http.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { HttpErrorService } from './http-error.service';
 import { catchError } from 'rxjs/operators';
-import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpHeaders, HttpParams } from '@angular/common/http';
 
 @Injectable()
 export class HttpService {
@@ -27,7 +27,7 @@ export class HttpService {
     return this.httpclient
       .get(url, this.setDefaultValue(options))
       .pipe(
-        catchError(res => {
+        catchError((res: HttpErrorResponse) => {
           return this.httpErrorService.handle(res, redirectIfNotAuthorised);
         })
       );
@@ -45,7 +45,7 @@ export class HttpService {
     return this.httpclient
       .post(url, body, this.setDefaultValue(options))
       .pipe(
-        catchError(res => {
+        catchError((res: HttpErrorResponse) => {
           return this.httpErrorService.handle(res, redirectIfNotAuthorised);
         })
       );
@@ -63,7 +63,7 @@ export class HttpService {
     return this.httpclient
       .put(url, body, this.setDefaultValue(options))
       .pipe(
-        catchError(res => {
+        catchError((res: HttpErrorResponse) => {
           return this.httpErrorService.handle(res);
         })
       );
@@ -80,7 +80,7 @@ export class HttpService {
     return this.httpclient
       .delete(url, this.setDefaultValue(options))
       .pipe(
-        catchError(res => {
+        catchError((res: HttpErrorResponse) => {
           return this.httpErrorService.handle(res);
         })
       );


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-3594

### Change description ###
Fix issue with HTTP error handling post-Angular `HttpClient` upgrade, which failed to map error properties between new `HttpErrorResponse` objects being returned and `HttpError` domain model objects for UI display.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
