### PR TITLE
EUI-3146-numeric-comparator-hot-fix

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,8 @@
 ## RELEASE NOTES
 
+### Version 2.73.6-numeric-comparator
+**EUI-3146** numeric-comparator-hot-fix
+
 ### Version 2.73.5-ngmodel-deprecation
 **EUI-3410** ngModel deprecation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.73.5-ngmodel-deprecation",
+  "version": "2.73.6-numeric-comparator",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/services/search-result/sorting/search-result-view-item-comparator-factory.spec.ts
+++ b/src/shared/services/search-result/sorting/search-result-view-item-comparator-factory.spec.ts
@@ -74,6 +74,17 @@ describe('SearchResultViewItemComparatorFactory', () => {
 
     });
 
+    it('Should return a comparator to order numbers fields', () => {
+
+      let comparator
+        = new SearchResultViewItemComparatorFactory().createSearchResultViewItemComparator(column('Text'));
+
+      expect(comparator.compare(item(123), item(123))).toBe(0);
+      expect(comparator.compare(item(123), item(456))).toBe(-1);
+      expect(comparator.compare(item(456), item(123))).toBe(1);
+
+    });
+
     it('Should return a comparator which co-erces null or undefined field to an empty string', () => {
 
       let comparator

--- a/src/shared/services/search-result/sorting/search-result-view-item-comparator-factory.ts
+++ b/src/shared/services/search-result/sorting/search-result-view-item-comparator-factory.ts
@@ -1,9 +1,11 @@
 import { Injectable } from '@angular/core';
-import { isUndefined } from 'util';
 import { SearchResultViewColumn, SearchResultViewItemComparator, SearchResultViewItem } from '../../../domain';
 
 @Injectable()
 export class SearchResultViewItemComparatorFactory {
+  public static isStr(fieldValue: any): boolean {
+    return typeof fieldValue === 'string' || fieldValue instanceof String
+  }
 
   createSearchResultViewItemComparator(column: SearchResultViewColumn): SearchResultViewItemComparator {
     let fieldId = column.case_field_id;
@@ -38,8 +40,8 @@ export class SearchResultViewItemComparatorFactory {
       compare(a: SearchResultViewItem, b: SearchResultViewItem) {
         let fieldA = a.case_fields[fieldId];
         let fieldB = b.case_fields[fieldId];
-        fieldA = isUndefined(fieldA) || fieldA === null ? 0 : fieldA;
-        fieldB = isUndefined(fieldB) || fieldB === null ? 0 : fieldB;
+        fieldA = fieldA === undefined || fieldA === null ? 0 : fieldA;
+        fieldB = fieldB === undefined || fieldB === null ? 0 : fieldB;
         return fieldA - fieldB;
       }
     };
@@ -50,8 +52,10 @@ export class SearchResultViewItemComparatorFactory {
       compare(a: SearchResultViewItem, b: SearchResultViewItem) {
         let fieldA = a.case_fields[fieldId];
         let fieldB = b.case_fields[fieldId];
-        fieldA = isUndefined(fieldA) || fieldA == null ? '' : fieldA.toLowerCase();
-        fieldB = isUndefined(fieldB) || fieldB == null ? '' : fieldB.toLowerCase();
+        fieldA = fieldA === undefined || fieldA === null ? '' : SearchResultViewItemComparatorFactory.isStr(fieldA) ?
+          fieldA.toLowerCase() : fieldA;
+        fieldB = fieldB === undefined || fieldB === null ? '' : SearchResultViewItemComparatorFactory.isStr(fieldB) ?
+          fieldB.toLowerCase() : fieldB;
         return fieldA === fieldB ? 0 : fieldA > fieldB ? 1 : -1;
       }
     };
@@ -62,8 +66,8 @@ export class SearchResultViewItemComparatorFactory {
       compare(a: SearchResultViewItem, b: SearchResultViewItem) {
         let fieldA = a.case_fields[fieldId];
         let fieldB = b.case_fields[fieldId];
-        fieldA = isUndefined(fieldA) || fieldA == null ? '' : fieldA.join().toLowerCase();
-        fieldB = isUndefined(fieldB) || fieldB == null ? '' : fieldB.join().toLowerCase();
+        fieldA = fieldA === undefined || fieldA === null ? '' : fieldA.join().toLowerCase();
+        fieldB = fieldB === undefined || fieldB === null ? '' : fieldB.join().toLowerCase();
         return fieldA === fieldB ? 0 : fieldA > fieldB ? 1 : -1;
       }
     };


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-3146
https://tools.hmcts.net/jira/browse/RDM-11029

### Change description ###
An edge case when the CCD configs return Case ID for sorting, it's a numeric field not string tyoe, the sort itself at least need to be compatible for string/numeric sorting, right now it only consider string so it failed on .toLowerCase

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
