### PR TITLE
EUI-3587: Fix "Print URL" pipe for rewriting remote Print Service URLs

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,5 @@
 ## RELEASE NOTES
-### Version 2.75.2
+### Version 2.79.2
 **EUI-3587** Fix "Print URL" pipe for rewriting remote Print Service URLs to a "local" version for the front-end
 
 ### Version 2.79.1

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,6 @@
 ## RELEASE NOTES
+### Version 2.75.2
+**EUI-3587** Fix "Print URL" pipe for rewriting remote Print Service URLs to a "local" version for the front-end
 
 ### Version 2.75.1
 **EUI-3577** Fixing DynamicList regression bugs

--- a/demo/src/app/app.config.ts
+++ b/demo/src/app/app.config.ts
@@ -22,7 +22,6 @@ export class AppConfig extends AbstractAppConfig {
     'activity_url': '',
     'activity_max_request_per_batch': 25,
     'print_service_url': '/print',
-    'remote_print_service_url': '/remote_print',
     'pagination_page_size': 25,
     'prd_url': 'api/caseshare/orgs',
     'cache_time_out': 45000,
@@ -72,7 +71,7 @@ export class AppConfig extends AbstractAppConfig {
   public getPaymentsUrl() {
     return this.config.payments_url;
   }
-  
+
   public getPayBulkScanBaseUrl() {
     return this.config.pay_bulk_scan_url;
   }
@@ -114,10 +113,6 @@ export class AppConfig extends AbstractAppConfig {
 
   public getPrintServiceUrl() {
     return this.config.print_service_url;
-  }
-
-  public getRemotePrintServiceUrl() {
-    return this.config.remote_print_service_url;
   }
 
   public getPaginationPageSize() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.75.2-alpha-EUI-3587-print-service-url-rewrite",
+  "version": "2.75.2-beta-EUI-3587-print-service-url-rewrite",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.75.2-beta-EUI-3587-print-service-url-rewrite",
+  "version": "2.75.2-gamma-EUI-3587-print-service-url-rewrite",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.75.1",
+  "version": "2.75.2-alpha-EUI-3587-print-service-url-rewrite",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.75.2-gamma-EUI-3587-print-service-url-rewrite",
+  "version": "2.79.2",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -19,6 +19,14 @@ export abstract class AbstractAppConfig {
   abstract getActivityMaxRequestPerBatch(): number;
   abstract getCaseHistoryUrl(caseId: string, eventId: string): string;
   abstract getPrintServiceUrl(): string;
+  /**
+   * Dummy version replacing deprecated `getRemotePrintServiceUrl()`, to be removed in next major release
+   * @deprecated
+   * @returns `undefined`
+   */
+  getRemotePrintServiceUrl(): string {
+    return undefined;
+  }
   abstract getPaginationPageSize(): number;
   abstract getBannersUrl(): string;
   abstract getPrdUrl(): string;
@@ -46,6 +54,8 @@ export class CaseEditorConfig {
   activity_url: string;
   activity_max_request_per_batch: number;
   print_service_url: string;
+  // remote_print_service_url marked as optional since deprecation, ahead of removal in next major release
+  remote_print_service_url?: string;
   pagination_page_size: number;
   prd_url: string;
   cache_time_out: number;

--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -19,7 +19,6 @@ export abstract class AbstractAppConfig {
   abstract getActivityMaxRequestPerBatch(): number;
   abstract getCaseHistoryUrl(caseId: string, eventId: string): string;
   abstract getPrintServiceUrl(): string;
-  abstract getRemotePrintServiceUrl(): string;
   abstract getPaginationPageSize(): number;
   abstract getBannersUrl(): string;
   abstract getPrdUrl(): string;
@@ -47,7 +46,6 @@ export class CaseEditorConfig {
   activity_url: string;
   activity_max_request_per_batch: number;
   print_service_url: string;
-  remote_print_service_url: string;
   pagination_page_size: number;
   prd_url: string;
   cache_time_out: number;

--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -54,7 +54,10 @@ export class CaseEditorConfig {
   activity_url: string;
   activity_max_request_per_batch: number;
   print_service_url: string;
-  // remote_print_service_url marked as optional since deprecation, ahead of removal in next major release
+  /**
+   * remote_print_service_url marked as optional since deprecation, ahead of removal in next major release
+   * @deprecated
+   */
   remote_print_service_url?: string;
   pagination_page_size: number;
   prd_url: string;

--- a/src/shared/components/case-viewer/printer/case-printer.component.spec.ts
+++ b/src/shared/components/case-viewer/printer/case-printer.component.spec.ts
@@ -64,15 +64,14 @@ describe('CasePrinterComponent', () => {
   let de: DebugElement;
 
   let caseService: CaseNotifier;
-  let casesService;
-  let alertService;
+  let casesService: jasmine.SpyObj<CasesService>;
+  let alertService: jasmine.SpyObj<AlertService>;
 
-  let appConfig;
+  let appConfig: jasmine.SpyObj<AbstractAppConfig>;
 
   beforeEach(async(() => {
-    appConfig = createSpyObj('AbstractAppConfig', ['getPrintServiceUrl', 'getRemotePrintServiceUrl']);
+    appConfig = createSpyObj('AbstractAppConfig', ['getPrintServiceUrl']);
     appConfig.getPrintServiceUrl.and.returnValue(GATEWAY_PRINT_SERVICE_URL);
-    appConfig.getRemotePrintServiceUrl.and.returnValue(REMOTE_PRINT_SERVICE_URL);
 
     caseService = new CaseNotifier();
     caseService.caseView = new BehaviorSubject(CASE_VIEW).asObservable();
@@ -108,12 +107,12 @@ describe('CasePrinterComponent', () => {
 
   it('should render a case header', () => {
     caseService.announceCase(CASE_VIEW);
-    let header = de.query(By.directive(CaseHeaderComponent));
+    const header = de.query(By.directive(CaseHeaderComponent));
     expect(header).toBeTruthy();
     expect(header.componentInstance.caseDetails).toEqual(CASE_VIEW);
   });
 
-  it('should call get print documents on init', () => {
+  it('should call getPrintDocuments() on init', () => {
     expect(casesService.getPrintDocuments).toHaveBeenCalledWith(CASE_VIEW.case_id);
   });
 
@@ -123,13 +122,12 @@ describe('CasePrinterComponent', () => {
   });
 
   it('should display each document', () => {
-    let documents = de.queryAll($DOCUMENTS);
-
+    const documents = de.queryAll($DOCUMENTS);
     expect(documents.length).toEqual(DOCUMENTS.length);
 
     DOCUMENTS.forEach((document, index) => {
-      let documentName = documents[index].query($DOCUMENT_NAME);
-      let documentType = documents[index].query($DOCUMENT_TYPE);
+      const documentName = documents[index].query($DOCUMENT_NAME);
+      const documentType = documents[index].query($DOCUMENT_TYPE);
 
       expect(text(documentName)).toEqual(document.name);
       expect(text(documentType)).toEqual(document.type);
@@ -137,5 +135,4 @@ describe('CasePrinterComponent', () => {
         document.url.replace(REMOTE_PRINT_SERVICE_URL, ''));
     });
   });
-
 });

--- a/src/shared/components/case-viewer/printer/pipes/print-url.pipe.spec.ts
+++ b/src/shared/components/case-viewer/printer/pipes/print-url.pipe.spec.ts
@@ -3,30 +3,72 @@ import createSpyObj = jasmine.createSpyObj;
 import { AbstractAppConfig } from '../../../../../app.config';
 
 describe('PrintUrlPipe', () => {
-  const PRINT_MANAGEMENT_URL = 'http://localhost:1234/print';
-  const MATCHING_REMOTE_PRINT_MANAGEMENT_URL = 'https://return-case-doc.ccd.reform';
-  const NON_MATCHING_REMOTE_PRINT_MANAGEMENT_URL = 'https://external.ccd.reform';
+  const LOCAL_PRINT_SERVICE_URL = '/print';
+  const REMOTE_PRINT_SERVICE_URL_PATHNAME = '/jurisdictions/TEST/case-types/Test1/cases/1111222233334444';
+  const REMOTE_PRINT_SERVICE_URL = 'https://return-case-doc.ccd.reform' + REMOTE_PRINT_SERVICE_URL_PATHNAME;
   let printUrlPipe: PrintUrlPipe;
-  let appConfig: any;
+  let appConfig: jasmine.SpyObj<AbstractAppConfig>;
 
   beforeEach(() => {
-    appConfig = createSpyObj<AbstractAppConfig>('appConfig', ['getPrintServiceUrl', 'getRemotePrintServiceUrl']);
-    appConfig.getPrintServiceUrl.and.returnValue(PRINT_MANAGEMENT_URL);
-    appConfig.getRemotePrintServiceUrl.and.returnValue(MATCHING_REMOTE_PRINT_MANAGEMENT_URL);
+    appConfig = createSpyObj<AbstractAppConfig>('appConfig', ['getPrintServiceUrl']);
+    appConfig.getPrintServiceUrl.and.returnValue(LOCAL_PRINT_SERVICE_URL);
     printUrlPipe = new PrintUrlPipe(appConfig);
-  });
-
-  describe('given the Print Service URL is the one in the app config', () => {
-    it('should be replaced with the Print Service endpoint URL of the API Gateway', () => {
-      let url = printUrlPipe.transform(MATCHING_REMOTE_PRINT_MANAGEMENT_URL);
-      expect(url).toEqual(PRINT_MANAGEMENT_URL);
+    // Workaround using callFake to call "new"; not able to spy on URL constructor (this DOM object constructor
+    // cannot be called as a function)
+    const realURL = URL;
+    spyOn(window, 'URL').and.callFake((url: string) => {
+      return new realURL(url);
     });
   });
 
-  describe('given the Print Service URL is NOT the one in the app config', () => {
-    it('should be left unchanged', () => {
-      let url = printUrlPipe.transform(NON_MATCHING_REMOTE_PRINT_MANAGEMENT_URL);
-      expect(url).toEqual(NON_MATCHING_REMOTE_PRINT_MANAGEMENT_URL);
+  it('should rewrite the remote Print Service URL correctly when the browser is Internet Explorer < 11', () => {
+    // Set navigator.userAgent property to "Internet Explorer" (< 11) identifier
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0)',
+      configurable: true
     });
+    const url = printUrlPipe.transform(REMOTE_PRINT_SERVICE_URL);
+    // Check that the URL interface is NOT called; it's not supported by IE
+    expect(URL).not.toHaveBeenCalled();
+    expect(url).toEqual(LOCAL_PRINT_SERVICE_URL + REMOTE_PRINT_SERVICE_URL_PATHNAME);
+  });
+
+  it('should rewrite the remote Print Service URL correctly when the browser is Internet Explorer 11', () => {
+    // Set navigator.userAgent property to "Internet Explorer 11" identifier
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko',
+      configurable: true
+    });
+    const url = printUrlPipe.transform(REMOTE_PRINT_SERVICE_URL);
+    // Check that the URL interface is NOT called; it's not supported by IE
+    expect(URL).not.toHaveBeenCalled();
+    expect(url).toEqual(LOCAL_PRINT_SERVICE_URL + REMOTE_PRINT_SERVICE_URL_PATHNAME);
+  });
+
+  it('should rewrite the remote Print Service URL correctly when the browser is not Internet Explorer', () => {
+    // Set navigator.userAgent property to non-IE identifier
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.82',
+      configurable: true
+    });
+    const url = printUrlPipe.transform(REMOTE_PRINT_SERVICE_URL);
+    // Check that the URL interface IS called; it's supported by non-IE browsers
+    expect(URL).toHaveBeenCalled();
+    expect(url).toEqual(LOCAL_PRINT_SERVICE_URL + REMOTE_PRINT_SERVICE_URL_PATHNAME);
+  });
+
+  it('should not rewrite the remote Print Service URL if it is null', () => {
+    const url = printUrlPipe.transform(null);
+    expect(url).toBeNull();
+  });
+
+  it('should not rewrite the remote Print Service URL if it is undefined', () => {
+    const url = printUrlPipe.transform(undefined);
+    expect(url).toBeUndefined();
+  });
+
+  it('should not rewrite the remote Print Service URL if it is an empty string', () => {
+    const url = printUrlPipe.transform('');
+    expect(url).toEqual('');
   });
 });

--- a/src/shared/components/case-viewer/printer/pipes/print-url.pipe.ts
+++ b/src/shared/components/case-viewer/printer/pipes/print-url.pipe.ts
@@ -8,7 +8,45 @@ export class PrintUrlPipe implements PipeTransform {
 
   constructor(private appConfig: AbstractAppConfig) {}
 
-  transform(value: string): string {
-    return value.replace(this.appConfig.getRemotePrintServiceUrl(), this.appConfig.getPrintServiceUrl());
+  /**
+   * Takes a "remote" Print Service URL (for example, as returned by calling the `/documents` CCD endpoint) and
+   * rewrites it into a "local", application-specific URL for the front-end. The resulting URL is of the form:
+   *
+   * Configurable "Local URL" (e.g. `/print`) + _pathname_ from original "remote URL"
+   * (e.g. `/jurisdictions/TEST/case-types/Test1/cases/1111222233334444`)
+   *
+   * @param remoteUrl The "remote" URL to rewrite
+   * @returns A rewritten URL as per the above description, or the original `remoteUrl` if it was `null`,
+   * `undefined`, or the empty string
+   */
+  transform(remoteUrl: string): string {
+    if (remoteUrl && remoteUrl.length > 0) {
+      let printServiceUrlPathname: string;
+
+      /**
+       * Check navigator.userAgent to see if the browser is IE or not. Check for either the browser name, "MSIE", or
+       * the rendering engine, "Trident" (used to identify IE 11 because it no longer reports as "MSIE").
+       * Note: IE does not support the URL interface and requires a workaround to parse URLs.
+       */
+      if (navigator.userAgent.indexOf("MSIE") != -1 || navigator.userAgent.indexOf("Trident") != -1) {
+        // Workaround for not being able to use the URL interface
+        const urlParser = document.createElement('a');
+        urlParser.href = remoteUrl;
+        // Get the pathname from the anchor element with the "remote" Print Service URL
+        printServiceUrlPathname = urlParser.pathname;
+        if (printServiceUrlPathname[0] != '/') {
+          // Fix for IE11; it returns the pathname without leading slash
+          printServiceUrlPathname = '/' + printServiceUrlPathname;
+        }
+      } else {
+        // Get the pathname parsed from the "remote" Print Service URL object
+        printServiceUrlPathname = new URL(remoteUrl).pathname;
+      }
+
+      // Return an amended URL comprising the "local" Print Service URL (usually /print) and the "remote" pathname
+      return this.appConfig.getPrintServiceUrl() + printServiceUrlPathname;
+    }
+
+    return remoteUrl;
   }
 }

--- a/src/shared/components/case-viewer/printer/pipes/print-url.pipe.ts
+++ b/src/shared/components/case-viewer/printer/pipes/print-url.pipe.ts
@@ -6,6 +6,9 @@ import { AbstractAppConfig } from '../../../../../app.config';
 })
 export class PrintUrlPipe implements PipeTransform {
 
+  private static readonly MSIE_BROWSER_NAME = 'MSIE';
+  private static readonly IE11_BROWSER_ENGINE = 'Trident';
+
   constructor(private appConfig: AbstractAppConfig) {}
 
   /**
@@ -16,8 +19,8 @@ export class PrintUrlPipe implements PipeTransform {
    * (e.g. `/jurisdictions/TEST/case-types/Test1/cases/1111222233334444`)
    *
    * @param remoteUrl The "remote" URL to rewrite
-   * @returns A rewritten URL as per the above description, or the original `remoteUrl` if it was `null`,
-   * `undefined`, or the empty string
+   * @returns A rewritten URL as per the above description, or the original `remoteUrl` if it is `null`, `undefined`,
+   * or the empty string
    */
   transform(remoteUrl: string): string {
     if (remoteUrl && remoteUrl.length > 0) {
@@ -28,13 +31,14 @@ export class PrintUrlPipe implements PipeTransform {
        * the rendering engine, "Trident" (used to identify IE 11 because it no longer reports as "MSIE").
        * Note: IE does not support the URL interface and requires a workaround to parse URLs.
        */
-      if (navigator.userAgent.indexOf("MSIE") != -1 || navigator.userAgent.indexOf("Trident") != -1) {
+      if (navigator.userAgent.indexOf(PrintUrlPipe.MSIE_BROWSER_NAME) !== -1 ||
+          navigator.userAgent.indexOf(PrintUrlPipe.IE11_BROWSER_ENGINE) !== -1) {
         // Workaround for not being able to use the URL interface
         const urlParser = document.createElement('a');
         urlParser.href = remoteUrl;
         // Get the pathname from the anchor element with the "remote" Print Service URL
         printServiceUrlPathname = urlParser.pathname;
-        if (printServiceUrlPathname[0] != '/') {
+        if (printServiceUrlPathname[0] !== '/') {
           // Fix for IE11; it returns the pathname without leading slash
           printServiceUrlPathname = '/' + printServiceUrlPathname;
         }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-3587

### Change description ###
Fix the pipe to rewrite remote Print Service URLs to the correct "local" version to be used for the front-end, irrespective of environment-based variations of the remote domain name.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
