### PR TITLE
ComplexType labels are now showing on CaseTypeTab irrespective of the…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.79.2",
+  "version": "2.79.3-complex-labels-showing-irrespective-to-field-show-condition",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/components/palette/complex/fields-filter.pipe.ts
+++ b/src/shared/components/palette/complex/fields-filter.pipe.ts
@@ -84,6 +84,8 @@ export class FieldsFilterPipe implements PipeTransform {
    *
    * @param complexField
    * @param keepEmpty
+   * @param index
+   * @param stripHidden
    * @returns {any}
    */
   transform(complexField: CaseField, keepEmpty?: boolean, index?: number, stripHidden= false): CaseField[] {

--- a/src/shared/components/palette/complex/read-complex-field-collection-table.component.spec.ts
+++ b/src/shared/components/palette/complex/read-complex-field-collection-table.component.spec.ts
@@ -9,6 +9,7 @@ import { PaletteUtilsModule } from '../utils/utils.module';
 import { ConditionalShowModule } from '../../../directives/conditional-show/conditional-show.module';
 import { PaletteContext } from '../base-field/palette-context.enum';
 import { createFieldType, newCaseField, textFieldType } from '../../../fixture';
+import { ReadFieldsFilterPipe } from './ccd-read-fields-filter.pipe';
 
 @Component({
   selector: 'ccd-field-read',
@@ -108,6 +109,7 @@ describe('ReadComplexFieldCollectionTableComponent', () => {
           declarations: [
             ReadComplexFieldCollectionTableComponent,
             FieldsFilterPipe,
+            ReadFieldsFilterPipe,
 
             // Mock
             MockFieldReadComponent,
@@ -311,6 +313,7 @@ describe('ReadComplexFieldCollectionTableComponent - nested complex field values
           declarations: [
             ReadComplexFieldCollectionTableComponent,
             FieldsFilterPipe,
+            ReadFieldsFilterPipe,
 
             // Mock
             MockFieldReadComponent,

--- a/src/shared/components/palette/complex/read-complex-field-table.component.spec.ts
+++ b/src/shared/components/palette/complex/read-complex-field-table.component.spec.ts
@@ -12,6 +12,7 @@ import { PaletteContext } from '../base-field/palette-context.enum';
 import { FieldsUtils } from '../../../services/fields/fields.utils';
 import { ConditionalShowRegistrarService } from '../../../directives/conditional-show/services/conditional-show-registrar.service';
 import { GreyBarService } from '../../../directives/conditional-show/services/grey-bar.service';
+import { ReadFieldsFilterPipe } from './ccd-read-fields-filter.pipe';
 
 @Directive({
   selector: '[ccdConditionalShow]'
@@ -85,6 +86,7 @@ describe('ReadComplexFieldTableComponent', () => {
             id: 'Text',
             type: 'Text'
           },
+          hidden: false,
           value: 'Flat 9'
         }),
         <CaseField>({
@@ -95,6 +97,7 @@ describe('ReadComplexFieldTableComponent', () => {
             id: 'Text',
             type: 'Text'
           },
+          hidden: false,
           value: '111 East India road'
         }),
         <CaseField>({
@@ -126,7 +129,8 @@ describe('ReadComplexFieldTableComponent', () => {
                 value: 'UK'
               })
             ]
-          }
+          },
+          hidden: false
         })
       ]
     };
@@ -152,6 +156,7 @@ describe('ReadComplexFieldTableComponent', () => {
           declarations: [
             ReadComplexFieldTableComponent,
             FieldsFilterPipe,
+            ReadFieldsFilterPipe,
             StubConditionalShowDirective,
 
             // Mock
@@ -343,6 +348,7 @@ describe('ReadComplexFieldTableComponent', () => {
           declarations: [
             ReadComplexFieldTableComponent,
             FieldsFilterPipe,
+            ReadFieldsFilterPipe,
             StubConditionalShowDirective,
 
             // Mock
@@ -378,6 +384,7 @@ describe('ReadComplexFieldTableComponent', () => {
         label: line1.label,
         display_context: 'OPTIONAL',
         field_type: line1.field_type,
+        hidden: false,
         value: CASE_FIELD.value['AddressLine1']
       });
 
@@ -387,6 +394,7 @@ describe('ReadComplexFieldTableComponent', () => {
         label: line2.label,
         display_context: 'OPTIONAL',
         field_type: line2.field_type,
+        hidden: false,
         value: CASE_FIELD.value['AddressLine2']
       });
 
@@ -396,6 +404,7 @@ describe('ReadComplexFieldTableComponent', () => {
         label: postcode.label,
         display_context: 'OPTIONAL',
         field_type: postcode.field_type,
+        hidden: false,
         value: CASE_FIELD.value['AddressPostcode']
       });
     });

--- a/src/shared/components/palette/complex/read-complex-field-table.html
+++ b/src/shared/components/palette/complex/read-complex-field-table.html
@@ -2,16 +2,16 @@
   <dl class="complex-panel-title"><dt><span class="text-16">{{caseField.label}}</span></dt><dd></dd></dl>
   <table class="complex-panel-table">
     <tbody>
-      <ng-container *ngFor="let field of caseField | ccdFieldsFilter">
+      <ng-container *ngFor="let field of caseField | ccdReadFieldsFilter:false :undefined :true">
         <ng-container *ngIf="(field | ccdIsCompound); else SimpleRow">
-          <tr class="complex-panel-compound-field">
+          <tr class="complex-panel-compound-field" [hidden]="field.hidden">
             <td colspan="2">
               <span class="text-16"><ccd-field-read [caseField]="field" [context]="context"></ccd-field-read></span>
             </td>
           </tr>
         </ng-container>
         <ng-template #SimpleRow>
-          <tr class="complex-panel-simple-field">
+          <tr class="complex-panel-simple-field" [hidden]="field.hidden">
             <th><span class="text-16">{{field.label}}</span></th>
             <td>
                 <span class="text-16"><ccd-field-read [caseField]="field" [context]="context"></ccd-field-read></span>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-3728


### Change description ###
ComplexLabels are showing up disregarding the show/hide conditions. Hence added the `ccdReadFieldsFilter` pipe to filter out labels which are not meant to be shown.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
