### PR TITLE
Callback Error still not showing proper error message in XUI screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "2.79.5",
+  "version": "2.79.8-Callback-Error-still-not-showing",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/components/case-editor/case-edit-submit/case-edit-submit.html
+++ b/src/shared/components/case-editor/case-edit-submit/case-edit-submit.html
@@ -7,7 +7,7 @@
 </h2>
 
 <!-- Generic error heading and error message to be displayed only if there are no specific callback errors or warnings, or no error details -->
-<div *ngIf="error && !(error.callbackErrors || error.callbackWarnings || error.details)" class="error-summary" role="group" aria-labelledby="edit-case-event_error-summary-heading" tabindex="-1">
+<div *ngIf="error && (!(error.callbackErrors || error.callbackWarnings || error.details) && !error.message.length)" class="error-summary" role="group" aria-labelledby="edit-case-event_error-summary-heading" tabindex="-1">
   <h1 class="heading-h1 error-summary-heading" id="edit-case-event_error-summary-heading">
     Something went wrong
   </h1>
@@ -17,7 +17,7 @@
   </div>
 </div>
 <!-- Event error heading and error message to be displayed if there are specific error details -->
-<div *ngIf="error && error.details" class="error-summary" role="group" aria-labelledby="edit-case-event_error-summary-heading" tabindex="-1">
+<div *ngIf="error && (error.details || error.message)" class="error-summary" role="group" aria-labelledby="edit-case-event_error-summary-heading" tabindex="-1">
   <h3 class="heading-h3 error-summary-heading" id="edit-case-event_error-summary-heading">
     The event could not be created
   </h3>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-3682


### Change description ###
Callback error displays generic error message. I have changed the `case-edit-submit.html` to display the `error.message`. Instead of using the generic error message.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
