### PR TITLE
MoneyGBP issue

### DIFF
--- a/src/shared/directives/substitutor/label-substitutor.directive.spec.ts
+++ b/src/shared/directives/substitutor/label-substitutor.directive.spec.ts
@@ -349,7 +349,7 @@ describe('LabelSubstitutorDirective', () => {
 
   describe('MoneyGBP type fields', () => {
 
-    it('should pass null value for null MoneyGBP', () => {
+    it('should pass empty value for null MoneyGBP', () => {
       let label = 'someLabel';
       comp.caseField = textField('LabelB', '', label);
       comp.caseFields = [comp.caseField, field('LabelA', null, {
@@ -358,7 +358,7 @@ describe('LabelSubstitutorDirective', () => {
       }, '')];
       fixture.detectChanges();
 
-      expect(placeholderService.resolvePlaceholders).toHaveBeenCalledWith({LabelB: '', LabelA: null}, label);
+      expect(placeholderService.resolvePlaceholders).toHaveBeenCalledWith({LabelB: '', LabelA: ''}, label);
     });
 
     it('should pass case field value with MoneyGBP when case field value but no form field value present', () => {

--- a/src/shared/services/fields/fields.utils.spec.ts
+++ b/src/shared/services/fields/fields.utils.spec.ts
@@ -67,15 +67,27 @@ describe('FieldsUtils', () => {
     });
 
     it('should merge simple MoneyGBP field', () => {
-      let formFieldsData = {
-        someText: 'This is test.',
-        caseAmountToPay: '1245'
-      };
-
-      let caseFields = fieldUtils
-        .mergeLabelCaseFieldsAndFormFields([textField, caseAmountToPay], formFieldsData);
-
+      const data = { someText: 'Test', caseAmountToPay: '1245' };
+      const caseFields = fieldUtils.mergeLabelCaseFieldsAndFormFields([textField, caseAmountToPay], data);
       expect(caseFields['caseAmountToPay']).toBe('£12.45');
+    });
+
+    it('should handle zero string in MoneyGBP field', () => {
+      const data = { someText: 'Test', caseAmountToPay: '0' };
+      const caseFields = fieldUtils.mergeLabelCaseFieldsAndFormFields([textField, caseAmountToPay], data);
+      expect(caseFields['caseAmountToPay']).toBe('£0.00');
+    });
+
+    it('should handle numeric zero in MoneyGBP field', () => {
+      const data = { someText: 'Test', caseAmountToPay: 0 };
+      const caseFields = fieldUtils.mergeLabelCaseFieldsAndFormFields([textField, caseAmountToPay], data);
+      expect(caseFields['caseAmountToPay']).toBe('£0.00');
+    });
+
+    it('should handle invalid value in MoneyGBP field', () => {
+      const data = { someText: 'Test', caseAmountToPay: 'bob' };
+      const caseFields = fieldUtils.mergeLabelCaseFieldsAndFormFields([textField, caseAmountToPay], data);
+      expect(caseFields['caseAmountToPay']).toBe('');
     });
 
     it('should merge complex field containing Date and Money field', () => {

--- a/src/shared/services/fields/fields.utils.ts
+++ b/src/shared/services/fields/fields.utils.ts
@@ -128,7 +128,7 @@ export class FieldsUtils {
         break;
       }
       case 'MoneyGBP': {
-        let fieldValue = (result[field.id] || result[field.id] === 0) ? result[field.id] : field.value;
+        const fieldValue = (result[field.id] || result[field.id] === 0) ? result[field.id] : field.value;
         result[field.id] = FieldsUtils.getMoneyGBP(fieldValue);
         break;
       }

--- a/src/shared/services/fields/fields.utils.ts
+++ b/src/shared/services/fields/fields.utils.ts
@@ -128,7 +128,7 @@ export class FieldsUtils {
         break;
       }
       case 'MoneyGBP': {
-        let fieldValue = (result[field.id] || field.value);
+        let fieldValue = (result[field.id] || result[field.id] === 0) ? result[field.id] : field.value;
         result[field.id] = FieldsUtils.getMoneyGBP(fieldValue);
         break;
       }
@@ -159,7 +159,10 @@ export class FieldsUtils {
   };
 
   private static getMoneyGBP(fieldValue: any): string {
-    return fieldValue ? FieldsUtils.currencyPipe.transform(fieldValue / 100, 'GBP', 'symbol') : fieldValue;
+    if (!isNaN(parseInt(fieldValue))) {
+      return FieldsUtils.currencyPipe.transform(fieldValue / 100, 'GBP', 'symbol');
+    }
+    return '';
   }
 
   private static getLabel(fieldValue: CaseField): string {

--- a/src/shared/services/fields/fields.utils.ts
+++ b/src/shared/services/fields/fields.utils.ts
@@ -159,7 +159,7 @@ export class FieldsUtils {
   };
 
   private static getMoneyGBP(fieldValue: any): string {
-    if (!isNaN(parseInt(fieldValue))) {
+    if (!isNaN(parseInt(fieldValue, 10))) {
       return FieldsUtils.currencyPipe.transform(fieldValue / 100, 'GBP', 'symbol');
     }
     return '';


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A, but issue identified here: https://github.com/hmcts/ccd-case-ui-toolkit/pull/618


### Change description ###
Fixed an issue with how `MoneyGBP` fields are rendered as it failed to render correctly for a numeric value of zero and could also weirdly stringify a return value because of the return type.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```