### PR TITLE
Update loading.service.spec.ts

### DIFF
--- a/src/shared/services/loading/loading.service.spec.ts
+++ b/src/shared/services/loading/loading.service.spec.ts
@@ -34,29 +34,41 @@ describe('LoadingService', () => {
 
   });
 
-  it('should return observable of false when a tokens are unregistered', () => {
-
-    const token1 = loadingService.register();
-    const token2 = loadingService.register();
-    loadingService.unregister(token1);
-    loadingService.unregister(token2);
-    subscription = loadingService.isLoading.subscribe(value => {
-      expect(value).toBeFalsy();
-    });
-
+  it('should return observable of false when all tokens are unregistered', async (done) => {
+    let token1: string;
+    let token2: string;
+    setTimeout(() => token1 = loadingService.register(), 1);
+    setTimeout(() => token2 = loadingService.register(), 1);
+    setTimeout(() => {
+      loadingService.unregister(token1);
+      loadingService.unregister(token2);
+      subscription = loadingService.isLoading.subscribe(value => {
+        expect(value).toBeFalsy();
+        done();
+      });
+    }, 5);
   });
 
-  it('should return observable of true when multiple tokens are registered, yet one is unregistered', () => {
-
-    loadingService.register();
-    loadingService.register();
-    const token = loadingService.register();
-    loadingService.register();
-    loadingService.unregister(token);
-    subscription = loadingService.isLoading.subscribe(value => {
-      expect(value).toBeTruthy();
-    });
-
+  it('should return observable of true when multiple tokens are registered, yet one is unregistered', async (done) => {
+    let index = 0;
+    let tokenToRemove: string;
+    let interval = setInterval(() => {
+      if (index === 2) {
+        tokenToRemove = loadingService.register();
+      } else {
+        loadingService.register();
+      }
+      if (index > 3) {
+        loadingService.unregister(tokenToRemove);
+        clearInterval(interval);
+        interval = undefined;
+        subscription = loadingService.isLoading.subscribe(value => {
+          expect(value).toBeTruthy();
+          done();
+        });
+      }
+      index++;
+    }, 1);
   });
 
   afterEach(() => {


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A, but found during development of https://tools.hmcts.net/jira/browse/EUI-2976.


### Change description ###
Made a couple of the unit tests for the `LoadingService` async because one was intermittently failing and it was apparent that the other was suffering from the same symptom, even though it was consistently passing.

Basically, `window.performance.now()` returns a time accurate to 1ms and it was entirely possible for `loadingService.register()` to run several times within the same millisecond... and when this happened, the unit test would fail.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```