### PR TITLE
defaulted hidden state for added complex fields in collection to false

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,8 @@
 ## RELEASE NOTES
 
+### Version 3.1.5-complex-hidden-collection-show
+**EUI-3983** Fixed issue with show fields displaying momentarily before show-condition logic evaluated
+
 ### Version 3.1.5-complex-field-check-answers
 **EUI-4033** Ensured complex fields were interpolated on check you answers page
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "3.1.5-complex-field-check-answers",
+  "version": "3.1.5-complex-hidden-collection-show",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/components/palette/collection/write-collection-field.component.ts
+++ b/src/shared/components/palette/collection/write-collection-field.component.ts
@@ -160,7 +160,7 @@ export class WriteCollectionFieldComponent extends AbstractFieldWriteComponent i
     const fieldType = plainToClassFromExist(new FieldType(), this.caseField.field_type.collection_field_type);
     if (fieldType.complex_fields) {
       fieldType.complex_fields
-        .filter((cf: CaseField) => !cf.show_condition)
+        .filter((cf: CaseField) => !!cf.show_condition)
         .map((cf: CaseField) => cf.hidden = true);
     }
 

--- a/src/shared/components/palette/collection/write-collection-field.component.ts
+++ b/src/shared/components/palette/collection/write-collection-field.component.ts
@@ -2,11 +2,11 @@ import { Component, ElementRef, Input, OnDestroy, OnInit, QueryList, ViewChildre
 import { FormArray, FormControl, FormGroup } from '@angular/forms';
 import { MatDialog, MatDialogConfig } from '@angular/material';
 import { ScrollToService } from '@nicky-lenaers/ngx-scroll-to';
-import { plainToClassFromExist } from 'class-transformer';
+import { plainToClass, plainToClassFromExist } from 'class-transformer';
 import { Subscription } from 'rxjs';
 import { finalize } from 'rxjs/operators';
 
-import { CaseField } from '../../../domain/definition/case-field.model';
+import { CaseField, FieldType } from '../../../domain/definition/case-field.model';
 import { Profile } from '../../../domain/profile';
 import { FieldsUtils, ProfileNotifier } from '../../../services';
 import { FormValidatorsService } from '../../../services/form/form-validators.service';
@@ -156,11 +156,19 @@ export class WriteCollectionFieldComponent extends AbstractFieldWriteComponent i
 
   private newCaseField(id: string, item, index, isNew = false) {
     const isNotAuthorisedToUpdate = !isNew && this.isNotAuthorisedToUpdate(index);
+
+    const fieldType = plainToClassFromExist(new FieldType(), this.caseField.field_type.collection_field_type);
+    if (fieldType.complex_fields) {
+      fieldType.complex_fields
+        .filter((cf: CaseField) => cf.show_condition !== null)
+        .map((cf: CaseField) => cf.hidden = true);
+    }
+
     // Remove the bit setting the hidden flag here as it's an item in the array and
     // its hidden state isn't independently re-evaluated when the form is changed.
     return plainToClassFromExist(new CaseField(), {
       id,
-      field_type: this.caseField.field_type.collection_field_type,
+      field_type: fieldType,
       display_context: isNotAuthorisedToUpdate ? 'READONLY' : this.caseField.display_context,
       value: item.value,
       label: null,

--- a/src/shared/components/palette/collection/write-collection-field.component.ts
+++ b/src/shared/components/palette/collection/write-collection-field.component.ts
@@ -2,7 +2,7 @@ import { Component, ElementRef, Input, OnDestroy, OnInit, QueryList, ViewChildre
 import { FormArray, FormControl, FormGroup } from '@angular/forms';
 import { MatDialog, MatDialogConfig } from '@angular/material';
 import { ScrollToService } from '@nicky-lenaers/ngx-scroll-to';
-import { plainToClass, plainToClassFromExist } from 'class-transformer';
+import { plainToClassFromExist } from 'class-transformer';
 import { Subscription } from 'rxjs';
 import { finalize } from 'rxjs/operators';
 

--- a/src/shared/components/palette/collection/write-collection-field.component.ts
+++ b/src/shared/components/palette/collection/write-collection-field.component.ts
@@ -160,7 +160,7 @@ export class WriteCollectionFieldComponent extends AbstractFieldWriteComponent i
     const fieldType = plainToClassFromExist(new FieldType(), this.caseField.field_type.collection_field_type);
     if (fieldType.complex_fields) {
       fieldType.complex_fields
-        .filter((cf: CaseField) => cf.show_condition !== null)
+        .filter((cf: CaseField) => !cf.show_condition)
         .map((cf: CaseField) => cf.hidden = true);
     }
 

--- a/tsconfig-aot.json
+++ b/tsconfig-aot.json
@@ -14,7 +14,7 @@
     "pretty": true,
     "stripInternal": true,
     "skipLibCheck": true,
-    "outDir": "../rpx-xui-webapp/node_modules/@hmcts/ccd-case-ui-toolkit/dist",
+    "outDir": "dist",
     "rootDir": "./tmp/src-inlined",
     "lib": ["es2015", "dom"]
   },


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/EUI-3983

### Change description ###

#### The Issue
When a collection that contains complex fields is added as part of a collection the fields with show condition are momentarily displayed before the `conditional-show-form.directive.ts` kicks in and hides it. This is because the subscription has a debounce(100) on it. The debounce is there to help performance.

#### The Fix
As I saw it, there are two fixes to this bug, remove the debounce or default added collection complex fields to hidden = true for fields that have show_condition logic. I chose the latter because I think is more sustainable and I know that the show/hide logic all being changed soon too so this fix will withstand the changes to the current directive.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x-x-x] No
```
