### PR TITLE
Turn HRS documentLink URLs into relative URLs, as is done for dm-store URLs

### DIFF
--- a/demo/src/app/app.config.ts
+++ b/demo/src/app/app.config.ts
@@ -56,6 +56,14 @@ export class AppConfig extends AbstractAppConfig {
     return this.config.remote_document_management_url;
   }
 
+  public getHrsUrl() {
+    return this.config.document_management_url;
+  }
+
+  public getRemoteHrsUrl() {
+    return this.config.remote_document_management_url;
+  }
+
   public getAnnotationApiUrl() {
     return this.config.annotation_api_url;
   }

--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -5,6 +5,8 @@ export abstract class AbstractAppConfig {
   abstract getCaseDataUrl(): string;
   abstract getDocumentManagementUrl(): string;
   abstract getRemoteDocumentManagementUrl(): string;
+  abstract getHrsUrl(): string;
+  abstract getRemoteHrsUrl(): string;
   abstract getAnnotationApiUrl(): string;
   abstract getPostcodeLookupUrl(): string;
   abstract getOAuth2ClientId(): string;

--- a/src/shared/components/palette/document/document-url.pipe.spec.ts
+++ b/src/shared/components/palette/document/document-url.pipe.spec.ts
@@ -16,7 +16,7 @@ describe('DocumentUrlPipe', () => {
 
   beforeEach(() => {
     appConfig = createSpyObj<AbstractAppConfig>('appConfig', [
-      'getDocumentManagementUrl', 'getRemoteDocumentManagementUrl','getHrsUrl', 'getRemoteHrsUrl'
+      'getDocumentManagementUrl', 'getRemoteDocumentManagementUrl', 'getHrsUrl', 'getRemoteHrsUrl'
     ]);
     appConfig.getDocumentManagementUrl.and.returnValue(DOCUMENT_MANAGEMENT_URL);
     appConfig.getRemoteDocumentManagementUrl.and.returnValue(REMOTE_DOCUMENT_MANAGEMENT_PATTERN);

--- a/src/shared/components/palette/document/document-url.pipe.spec.ts
+++ b/src/shared/components/palette/document/document-url.pipe.spec.ts
@@ -7,13 +7,21 @@ describe('DocumentUrlPipe', () => {
   const REMOTE_DOCUMENT_MANAGEMENT_PATTERN = '^https://external\\.dm\\.reform/documents';
   const MATCHING_REMOTE_DOCUMENT_MANAGEMENT_URL = 'https://external.dm.reform/documents';
   const NON_MATCHING_REMOTE_DOCUMENT_MANAGEMENT_URL = 'https://external.evidence.reform/documents';
+  const HRS_URL = 'http://localhost:1234/hearing-recordings';
+  const REMOTE_HRS_PATTERN = '^https://external\\.dm\\.reform/hearing-recordings';
+  const MATCHING_REMOTE_HRS_URL = 'https://external.dm.reform/hearing-recordings';
+  const NON_MATCHING_REMOTE_HRS_URL = 'https://external.evidence.reform/hearing-recordings';
   let documentUrlPipe: DocumentUrlPipe;
   let appConfig: any;
 
   beforeEach(() => {
-    appConfig = createSpyObj<AbstractAppConfig>('appConfig', ['getDocumentManagementUrl', 'getRemoteDocumentManagementUrl']);
+    appConfig = createSpyObj<AbstractAppConfig>('appConfig', [
+      'getDocumentManagementUrl', 'getRemoteDocumentManagementUrl','getHrsUrl', 'getRemoteHrsUrl'
+    ]);
     appConfig.getDocumentManagementUrl.and.returnValue(DOCUMENT_MANAGEMENT_URL);
     appConfig.getRemoteDocumentManagementUrl.and.returnValue(REMOTE_DOCUMENT_MANAGEMENT_PATTERN);
+    appConfig.getHrsUrl.and.returnValue(HRS_URL);
+    appConfig.getRemoteHrsUrl.and.returnValue(REMOTE_HRS_PATTERN);
     documentUrlPipe = new DocumentUrlPipe(appConfig);
   });
 
@@ -24,10 +32,24 @@ describe('DocumentUrlPipe', () => {
     });
   });
 
+  describe('given a document URL matching the remote HRS api', () => {
+    it('should be replaced with a relative HRS URL', () => {
+      let url = documentUrlPipe.transform(MATCHING_REMOTE_HRS_URL);
+      expect(url).toEqual(HRS_URL);
+    });
+  });
+
   describe('given the Document Management URL is NOT the one in the app config', () => {
     it('should be left unchanged', () => {
       let url = documentUrlPipe.transform(NON_MATCHING_REMOTE_DOCUMENT_MANAGEMENT_URL);
       expect(url).toEqual(NON_MATCHING_REMOTE_DOCUMENT_MANAGEMENT_URL);
+    });
+  });
+
+  describe('given a document URL not matching the remote HRS api', () => {
+    it('should be left unchanged', () => {
+      let url = documentUrlPipe.transform(NON_MATCHING_REMOTE_HRS_URL);
+      expect(url).toEqual(NON_MATCHING_REMOTE_HRS_URL);
     });
   });
 });

--- a/src/shared/components/palette/document/document-url.pipe.ts
+++ b/src/shared/components/palette/document/document-url.pipe.ts
@@ -9,6 +9,8 @@ export class DocumentUrlPipe implements PipeTransform {
   constructor(private appConfig: AbstractAppConfig) {}
 
   transform(value: string): string {
+    let remoteHrsPattern = new RegExp(this.appConfig.getRemoteHrsUrl());
+    value = value.replace(remoteHrsPattern, this.appConfig.getHrsUrl());
     let remoteDocumentManagementPattern = new RegExp(this.appConfig.getRemoteDocumentManagementUrl());
     return value.replace(remoteDocumentManagementPattern, this.appConfig.getDocumentManagementUrl());
   }

--- a/src/shared/components/palette/document/read-document-field.component.spec.ts
+++ b/src/shared/components/palette/document/read-document-field.component.spec.ts
@@ -41,6 +41,7 @@ describe('ReadDocumentFieldComponent', () => {
       value: VALUE
     });
     const GATEWAY_DOCUMENT_URL = 'http://localhost:1234/documents';
+    const GATEWAY_HRS_URL = 'http://localhost:1234/hearing-recordings';
     const DOCUMENT_CLICKABLE_HREF = 'javascript:void(0)';
 
     let fixture: ComponentFixture<ReadDocumentFieldComponent>;
@@ -51,9 +52,11 @@ describe('ReadDocumentFieldComponent', () => {
 
     beforeEach(() => {
       mockAppConfig = createSpyObj<AbstractAppConfig>('AppConfig',
-        ['getDocumentManagementUrl', 'getRemoteDocumentManagementUrl']);
+        ['getDocumentManagementUrl', 'getRemoteDocumentManagementUrl', 'getHrsUrl', 'getRemoteHrsUrl']);
       mockAppConfig.getDocumentManagementUrl.and.returnValue(GATEWAY_DOCUMENT_URL);
       mockAppConfig.getRemoteDocumentManagementUrl.and.returnValue(VALUE.document_binary_url);
+      mockAppConfig.getHrsUrl.and.returnValue(GATEWAY_HRS_URL);
+      mockAppConfig.getRemoteHrsUrl.and.returnValue(VALUE.document_binary_url);
       mockDocumentManagementService = createSpyObj<DocumentManagementService>('documentManagementService',
         ['uploadFile', 'getMediaViewerInfo']);
       windowService = createSpyObj('windowService', ['setLocalStorage', 'getLocalStorage']);
@@ -134,6 +137,7 @@ describe('ReadDocumentFieldComponent', () => {
       value: VALUE
     });
     const GATEWAY_DOCUMENT_URL = 'http://localhost:1234/documents';
+    const GATEWAY_HRS_URL = 'http://localhost:1234/hearing-recordings';
 
     let fixture: ComponentFixture<ReadDocumentFieldComponent>;
     let component: ReadDocumentFieldComponent;
@@ -142,9 +146,13 @@ describe('ReadDocumentFieldComponent', () => {
     let mockCasesService: any;
 
     beforeEach(() => {
-      mockAppConfig = createSpyObj<AbstractAppConfig>('AppConfig', ['getDocumentManagementUrl', 'getRemoteDocumentManagementUrl']);
+      mockAppConfig = createSpyObj<AbstractAppConfig>('AppConfig', [
+        'getDocumentManagementUrl', 'getRemoteDocumentManagementUrl', 'getHrsUrl', 'getRemoteHrsUrl'
+      ]);
       mockAppConfig.getDocumentManagementUrl.and.returnValue(GATEWAY_DOCUMENT_URL);
       mockAppConfig.getRemoteDocumentManagementUrl.and.returnValue(VALUE.document_binary_url);
+      mockAppConfig.getHrsUrl.and.returnValue(GATEWAY_HRS_URL);
+      mockAppConfig.getRemoteHrsUrl.and.returnValue(VALUE.document_binary_url);
       mockDocumentManagementService = createSpyObj<DocumentManagementService>('documentManagementService', ['uploadFile']);
       windowService = createSpyObj('windowService', ['setLocalStorage', 'getLocalStorage']);
       router = createSpyObj<Router>('router', ['navigate']);

--- a/src/shared/services/document-management/document-management.service.spec.ts
+++ b/src/shared/services/document-management/document-management.service.spec.ts
@@ -8,6 +8,8 @@ import { CaseField, DocumentData, FieldType } from '../../domain';
 describe('DocumentManagementService', () => {
   const DOCUMENT_MANAGEMENT_URL = 'https://www.example.com/binary';
   const REMOTE_DOCUMENT_MANAGEMENT_URL = 'http://docmanagement.ccd.reform/documents';
+  const HRS_URL = 'https://www.example.com/binary';
+  const REMOTE_HRS_URL = 'http://docmanagement.ccd.reform/documents';
 
   let appConfig: any;
   let httpService: any;
@@ -16,9 +18,14 @@ describe('DocumentManagementService', () => {
 
   beforeEach(() => {
     appConfig = createSpyObj<AbstractAppConfig>('appConfig', [
-      'getDocumentManagementUrl', 'getRemoteDocumentManagementUrl', 'getAnnotationApiUrl']);
+      'getDocumentManagementUrl', 'getRemoteDocumentManagementUrl',
+      'getHrsUrl', 'getRemoteHrsUrl',
+      'getAnnotationApiUrl'
+    ]);
     appConfig.getRemoteDocumentManagementUrl.and.returnValue(REMOTE_DOCUMENT_MANAGEMENT_URL);
     appConfig.getDocumentManagementUrl.and.returnValue(DOCUMENT_MANAGEMENT_URL);
+    appConfig.getRemoteHrsUrl.and.returnValue(REMOTE_HRS_URL);
+    appConfig.getHrsUrl.and.returnValue(HRS_URL);
 
     httpService = createSpyObj<HttpService>('httpService', ['post']);
     documentManagementService = new DocumentManagementService(httpService, appConfig);

--- a/src/shared/services/document-management/document-management.service.spec.ts
+++ b/src/shared/services/document-management/document-management.service.spec.ts
@@ -8,8 +8,8 @@ import { CaseField, DocumentData, FieldType } from '../../domain';
 describe('DocumentManagementService', () => {
   const DOCUMENT_MANAGEMENT_URL = 'https://www.example.com/binary';
   const REMOTE_DOCUMENT_MANAGEMENT_URL = 'http://docmanagement.ccd.reform/documents';
-  const HRS_URL = 'https://www.example.com/binary';
-  const REMOTE_HRS_URL = 'http://docmanagement.ccd.reform/documents';
+  const HRS_URL = 'https://manage-case.hmcts.reform.net/hearing-recording';
+  const REMOTE_HRS_URL = 'https://em-hrs-api.hmcts.reform.net/hearing-recordings';
 
   let appConfig: any;
   let httpService: any;

--- a/src/shared/services/document-management/document-management.service.ts
+++ b/src/shared/services/document-management/document-management.service.ts
@@ -68,6 +68,8 @@ export class DocumentManagementService {
   }
 
   transformDocumentUrl(documentBinaryUrl: string): string {
+    let remoteHrsPattern = new RegExp(this.appConfig.getRemoteHrsUrl());
+    documentBinaryUrl = documentBinaryUrl.replace(remoteHrsPattern, this.appConfig.getHrsUrl());
     let remoteDocumentManagementPattern = new RegExp(this.appConfig.getRemoteDocumentManagementUrl());
     return documentBinaryUrl.replace(remoteDocumentManagementPattern, this.appConfig.getDocumentManagementUrl());
   }


### PR DESCRIPTION
### JIRA link (if applicable) ###
- https://tools.hmcts.net/jira/browse/EUI-4161

### Change description ###
- add getHrsUrl/getRemoteUrl functions, similar to getDocumentManagementUrl/getRemoteDocumentManagementUrl to allow rewriting of em-hrs-api URLs, in a similar fashion to dm-store URLs

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```
