### PR TITLE
Fixing merge conflict issues in release-4.1.0

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,37 @@
 ## RELEASE NOTES
 
+### Version 4.0.0
+**EUI-4227** Fixed an error with show/hide not working quite right in some configurations.
+**EUI-2022** ExUI - Error Messages (Complex Type)
+**EUI-4033** Ensured complex fields were interpolated on Check Your Answers page
+**EUI-4077** Ensuring searchForCompletable not called if user is pui-case-manager
+**EUI-2027** Accessibility amends for button labels
+**EUI-3155** Accessibility amends for non-descriptive headings
+**EUI-3550** Replace heading tags with spans on case edit pages
+**EUI-2792** Datetime picker fixes after testing integration with webapp
+**EUI-3825** Fix for missing FTPA tab contents.
+**EUI-2022** ExUI - Error Messages (A)
+**EUI-2023** ExUI - Labels (A)
+**EUI-2017** ExUI - Navigate in table using keyboard
+**EUI-2022** ExUI - Error Messages (A)
+**EUI-2023** ExUI - Labels (A)
+**EUI-3538** ExUI - FieldShowCondition failing on SearchInputFields and WorkBasketInputFields
+**EUI-3466** ExUI - Spinner issue in demo MO unassigned cases page
+**EUI-3497** ExUI - Unassigned cases does not show all unassigned cases
+**EUI-3049** Create datetime picker for use in write date fields (and edit read date fields for consistency)
+**EUI-3732** ExUI - Breathing space data not persisted on Previous button click with ExpUI Demo
+**EUI-2569** ExUI - Labels not displaying in Case Heading
+**EUI-3870** ExUI - Unresponsive and 'laggy' show-hide conditions
+**EUI-3682** Callback Error still not showing proper error message in XUI screen
+**EUI-3505** Applied fix to disable and enable collection remove button based on CRUD permissions
+**EUI-2039** Changed Date Input fields to conform to accessibility standards
+**EUI-2029** WCAG AA Status Message Fixes
+**EUI-2739** Fix "retain hidden fields" functionality for Complex collection, nested Complex, and nested Complex collection types
+**EUI-3622** Re-evaluate retain hidden value matrix
+**EUI-3868** Retain hidden value matrix
+**EUI-2744** Event to complex type
+**EUI-4106** Show/hide functionality
+
 ### Version 3.1.5-nested-multi-select-labels-theta
 **EUI-3581** Fixed an issue with label placeholders not working for multiselects within complex fields or collections. Also fixed an issue with FixedRadioList fields showing the code, not the label. Finally,
 fixed an issue with the rendering of complex collections on the Case Details tabs.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -24,8 +24,6 @@
 **EUI-3550** Replace heading tags with spans on case edit pages
 **EUI-2792** Datetime picker fixes after testing integration with webapp
 **EUI-3825** Fix for missing FTPA tab contents.
-**EUI-2022** ExUI - Error Messages (A)
-**EUI-2023** ExUI - Labels (A)
 **EUI-2017** ExUI - Navigate in table using keyboard
 **EUI-2022** ExUI - Error Messages (A)
 **EUI-2023** ExUI - Labels (A)
@@ -41,9 +39,9 @@
 **EUI-2039** Changed Date Input fields to conform to accessibility standards
 **EUI-2029** WCAG AA Status Message Fixes
 **EUI-2739** Fix "retain hidden fields" functionality for Complex collection, nested Complex, and nested Complex collection types
-**EUI-3622** Re-evaluate retain hidden value matrix
-**EUI-3868** Retain hidden value matrix
-**EUI-2744** Event to complex type
+**EUI-3622** Re-evaluate "retain hidden value" matrix linked to acceptance criteria
+**EUI-3868** "Retain Hidden Value" matrix - support for Scenarios 5 and 8 for "retain = true"
+**EUI-2744** EventToComplexTypes regression with hidden fields
 **EUI-4106** Show/hide functionality
 
 ### Version 3.1.5-nested-multi-select-labels-theta
@@ -55,23 +53,6 @@ fixed an issue with the rendering of complex collections on the Case Details tab
 
 ### Version 3.1.5-profile-call-before-event-trigger
 **EUI-3335** profile call needs to happen first
-
-### Version 3.1.5-complex-field-check-answers
-**EUI-4033** Ensured complex fields were interpolated on check you answers page
-
-### Version 3.1.5-pcm-role-non-completion
-**EUI-4077** Ensuring searchForCompletable not called if user is pui-case-manager
-
-### Version 3.1.5 - ph-merge-rc-22-2-a
-**EUI-2027** Accessibility amends for button labels
-**EUI-3155** Accessibility amends for non-descriptive headings
-**EUI-3550** Replace heading tags with spans on case edit pages
-
-### Version 3.1.2-datetime-picker-webapp-resolution
-**EUI-2792** Datetime picker fixes after testing integration with webapp
-
-### Version 3.1.2-missing-ftpa-tab-beta
-**EUI-3825** Fix for missing FTPA tab contents.
 
 ### Version 3.1.2
 **EUI-4013**
@@ -93,43 +74,6 @@ Activity Tracker Performance changes
 **EUI-2569** ExUI - Labels not displaying in Case Heading
 **EUI-3870** ExUI - Unresponsive and 'laggy' show-hide conditions
 **EUI-3682** Callback Error still not showing proper error message in XUI screen
-**EUI-2039** Changed Date Input fields to conform to accessibility standards
-
-### Version 3.0.3-Navigate in table using keyboard
-**EUI-2017** ExUI - Navigate in table using keyboard
-
-### Version 3.0.3-validation-error-message-changes
-**EUI-2022** ExUI - Error Messages (A)
-**EUI-2023** ExUI - Labels (A)
-
-### Version 3.0.3-field-show-condition
-**EUI-3538** ExUI - FieldShowCondition failing on SearchInputFields and WorkBasketInputFields
-
-### Version 3.0.3-Spinner-issue-in-demo-MO-unassigned-cases-page
-**EUI-3466** ExUI - Spinner issue in demo MO unassigned cases page
-**EUI-3497** ExUI - Unassigned cases does not show all unassigned cases
-
-### Version 3.0.0
-
-### Version 2.80.0-alpha-datetime-picker
-**EUI-3049** Create datetime picker for use in write date fields (and edit read date fields for consistency)
-
-### Version 2.79.8-breathing-space-data-not-being-persisted
-**EUI-3732** ExUI - Breathing space data not persisted on Previous button click with ExpUI Demo
-
-### Version 2.79.14-labels-not-displaying-case-heading
-**EUI-2569** ExUI - Labels not displaying in Case Heading
-
-### Version 2.79.13-Unresponsive-and-laggy-show-hide-conditions
-**EUI-3870** ExUI - Unresponsive and 'laggy' show-hide conditions
-
-### Version 2.79.12
-**EUI-3682** Callback Error still not showing proper error message in XUI screen
-
-### Version 2.79.11-crud-issues
-**EUI-3505** Applied fix to disable and enable collection remove button based on CRUD permissions
-
-### Version 2.79.10-input-type-accessibility
 **EUI-2039** Changed Date Input fields to conform to accessibility standards
 
 ### Version 2.79.7
@@ -155,7 +99,7 @@ Activity Tracker Performance changes
 ### Version 2.79.1
 **EUI-3452** Fix to some issues on the Check your answers page.
 
-### 2.79.0
+### Version 2.79.0
 **EUI-3548** WA integration
 
 ### Version 2.75.1
@@ -262,9 +206,6 @@ Merge master to simplify final branch merge
 ### Version 2.68.9-prerelease-conditional-show-perf
 **EUI-3151** dynamic lists and nested complex in collection fixes
 
-### Version 2.68.8-wcag-status-message
-**EUI-2029** WCAG AA Status Message Fixes
-
 ### Version 2.68.8-prerelease-conditional-show-perf
 **EUI-3151** form validation and label fixes
 
@@ -290,8 +231,6 @@ Merge master to simplify final branch merge
 **EUI-3055** Better performance in edit forms through new show hide implementation
 
 ### Version 2.67.10-feature-toggle-work-allocation
-
-### 2.67.10-feature-toggle-work-allocation
 **Feature Toggle Work Allocation** Hot Fix
 
 ### Version 2.67.6-task-event-completion

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,19 @@
 ## RELEASE NOTES
 
+### Version 4.1.0
+**EUI-2027** Button Labels (AA)
+**EUI-2030** Colour Contrast (AA)
+**EUI-3155** Non-Descriptive Headings (AA) - issues 02, 06, 05 (part of it)
+**EUI-4118** Mandatory datetime picker fields are not giving required field errors
+**EUI-1621** Date/time DISPLAY for Workbasket & Search Input & Results
+**EUI-1692** DateTime Entry & Display Formatting for Complex Types
+**EUI-2792** Date and Time entry (Testing Story)
+**EUI-4155** WA post-MVP Pagination- Angular - My tasks (in Tasks list) - CCD UI Toolkit
+**EUI-3049** Wrap and restyle date time picker component
+**EUI-3051** Handle #DATETIMEENTRY field context
+**EUI-3581** Field interpolation does not work for the field type MultiSelectList
+**EUI-4244** SSCS - Midevent callbacks sending empty fields for optional empty document
+
 ### Version 4.0.0
 **EUI-4227** Fixed an error with show/hide not working quite right in some configurations.
 **EUI-2022** ExUI - Error Messages (Complex Type)

--- a/demo/test/mockData/caseEvent.js
+++ b/demo/test/mockData/caseEvent.js
@@ -1,4 +1,3 @@
-
 const CCDCaseConfig = require('../nodeMock/ccd/ccdCaseConfig/caseCreateConfigGenerator');
 
 
@@ -23,7 +22,7 @@ function addCaseField(event, fieldConfig) {
 }
 
 function setCaseFieldProps(event, fieldId, fieldProps) {
-    
+
     event.setFieldProps(fieldProps)
     return event;
 }
@@ -32,9 +31,7 @@ function getDateTimeTestEvent(){
     const eventConfig = getEventTemplate();
     eventConfig.addWizardPage("dateTimeFieldsPage", "Date time fields test page")
     .addCaseField({ id : "dateField", type: "Date", label:  "Date only" })
-        // .setFieldProps({ display_context_parameter: "#test(YYYY YYYY YY),#DATETIMEDISPLAY(YYYY-MM),#DATETIMEENTRY(YYYY-MM-DD)"})
     .addCaseField({ id: "dateTimeField", type: "DateTime", label: "Date and time" })
-    //     .setFieldProps({ display_context_parameter: "#DATETIMEENTRY(YYYY)" })
     return eventConfig;
 }
 
@@ -42,9 +39,8 @@ function getDateTimeInComplexTestEvent() {
     const eventConfig = getEventTemplate();
     eventConfig.addWizardPage("dateTimeFieldsPage", "Date time fields test page")
         .addCaseField({ id: "complexfield", type: "Complex", label: "Complex field of Date" })
-      
+
     const DateField = eventConfig.getCCDFieldTemplateCopy({ id: "dateField", type: "Date", label: "Date only" });
-    // DateField.display_context = "READONLY";
     DateField.display_context_parameter = "#test(YYYY YYYY YY),#DATETIMEDISPLAY(YYYY-MM),#DATETIMEENTRY(YYYY-MM-DD)";
     DateField.value = "2021-02-13T09:30:55.15";
 

--- a/demo/test/pageObjects/demoAppheader.page.js
+++ b/demo/test/pageObjects/demoAppheader.page.js
@@ -12,7 +12,6 @@ class AppHeader{
 
     async clickHeader(header){
         await browserWaits.waitForElement(this.headerContainer);
-        // await this.navigateToModule(header);
         await element(by.xpath(`//li //a[text()='${header}']`)).click();
         await browserWaits.waitForElement($(this.getCCDComponentForheader(header)));
         await this.scrollToExampleComponent();
@@ -22,18 +21,6 @@ class AppHeader{
         await browser.executeScript('arguments[0].scrollIntoView()',
             this.exampleElement.getWebElement())
     }
-
-    // async navigateToModule(module){
-    //     switch(module){
-    //         case "Create Case":
-    //             await $('li a[href="/case/create"]').click();
-    //             break;
-
-    //         default:
-    //             throw new Error(`Module navigation ${module} not found`);
-    //     }
-
-    // }
 
     getCCDComponentForheader(header){
         let componentTag = "";

--- a/demo/test/step_definitions/workbasket.steps.js
+++ b/demo/test/step_definitions/workbasket.steps.js
@@ -2,8 +2,6 @@ var { defineSupportCode } = require('cucumber');
 
 const MockApp = require('../nodeMock/app');
 
-// const browserUtil = require('../../util/browserUtil');
-// const nodeAppMockData = require('../../../nodeMock/nodeApp/mockData');
 const CucumberReporter = require('../support/reportLogger');
 const dateTimePickerComponent = require('../pageObjects/dateTimePicker');
 const WorkbasketConfig = require('../nodeMock/ccd/ccdCaseConfig/workBasketInputGenerator');
@@ -28,7 +26,7 @@ defineSupportCode(function ({ And, But, Given, Then, When }) {
 
     });
 
-  
+
 
     Given('I set mock workbasket config {string}', async function (workbasketConfigref) {
         const workbasketConfig = global.scenarioData[workbasketConfigref];
@@ -60,15 +58,15 @@ defineSupportCode(function ({ And, But, Given, Then, When }) {
         for (let i = 0; i < fields.length; i++) {
             await caseListFilters.openDateTimePickerForFieldWithId(fields[i].fieldId);
             await caseListFilters.setDatetimeField(fields[i].value);
-  
+
         }
     });
-  
+
     Then('I validate date time picker field values in workbasket', async function(datatable){
         const softAssert = new SoftAssert();
         const fields = datatable.hashes();
         for (let i = 0; i < fields.length; i++) {
-           
+
             softAssert.setScenario(`field with id ${fields[i].fieldId}`)
             await softAssert.assert(async () => expect(await caseListFilters.getDateTimeFieldValueWithId(fields[i].fieldId), `field value mismatch`).to.equal(fields[i].value))
         }

--- a/demo/test/support/reports.js
+++ b/demo/test/support/reports.js
@@ -4,11 +4,6 @@ const mkdirp = require('mkdirp');
 
 const xmlReports = `${process.cwd()}/reports/xml`;
 
-// var createXmlDir = (function() {
-//     if (!fs.existsSync(xmlReports)) {
-//         mkdirp.sync(xmlReports);
-//     }
-// })();
 
 reporter.config({ targetDir: xmlReports });
 

--- a/demo/test/support/softAssert.js
+++ b/demo/test/support/softAssert.js
@@ -30,7 +30,6 @@ class SoftAssert {
 
         } catch (assertError) {
             this.scenarios.push(`${this.scenarioCounter}.${this.scrAssertionsCounter}  FAILED **:   ${this.scenario}`);
-            // addContext(this.testContext, { title: "Screenshot path" , value: "../../"});
             this.isPassed = false;
             this.assertions.push(`${this.scenarioCounter}.${this.scrAssertionsCounter} : ${assertError.message}`);
             reportLogger.AddMessage(`************* ${this.scenarioCounter}.${this.scrAssertionsCounter}  FAILED **:   ${this.scenario}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "4.1.0-rc.3",
+  "version": "4.1.0",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "4.1.0",
+  "version": "4.1.0-rc.4",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/components/case-editor/case-edit-page/case-edit-page.component.spec.ts
+++ b/src/shared/components/case-editor/case-edit-page/case-edit-page.component.spec.ts
@@ -1,33 +1,25 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { CaseEditPageComponent } from './case-edit-page.component';
 import { DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
-import { By } from '@angular/platform-browser';
-import { CaseEditComponent } from '../case-edit/case-edit.component';
-import { ActivatedRoute } from '@angular/router';
-import { of } from 'rxjs';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatDialog, MatDialogRef } from '@angular/material';
-import { FormValueService } from '../../../services/form/form-value.service';
-import { FormErrorService } from '../../../services/form/form-error.service';
-import { PageValidationService } from '../services/page-validation.service';
-import { SaveOrDiscardDialogComponent } from '../../dialogs/save-or-discard-dialog/save-or-discard-dialog.component';
-import { CaseReferencePipe } from '../../../pipes/case-reference/case-reference.pipe';
-import { aCaseField } from '../../../fixture/shared.test.fixture';
-import { WizardPage } from '../domain/wizard-page.model';
-import { Wizard } from '../domain/wizard.model';
-import { CaseField, FieldType } from '../../../domain/definition/case-field.model';
-import { CaseFieldService } from '../../../services/case-fields/case-field.service';
-import { Draft } from '../../../domain/draft.model';
-import { CaseEventData } from '../../../domain/case-event-data.model';
-import { CaseEventTrigger } from '../../../domain/case-view/case-event-trigger.model';
-import { HttpError } from '../../../domain/http/http-error.model';
-import { CallbackErrorsContext } from '../../error/domain/error-context';
-import { FieldTypeSanitiser } from '../../../services/form/field-type-sanitiser';
-import { text } from '../../../test/helpers';
-import createSpyObj = jasmine.createSpyObj;
-import { FieldsFilterPipe } from '../../palette/complex';
-import { CcdPageFieldsPipe } from '../../palette/complex/cdd-page-fields.pipe';
+import { By } from '@angular/platform-browser';
+import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
 
+import { CaseEventData, CaseEventTrigger, CaseField, Draft, FieldType, HttpError } from '../../../domain';
+import { aCaseField } from '../../../fixture/shared.test.fixture';
+import { CaseReferencePipe } from '../../../pipes/case-reference/case-reference.pipe';
+import { CaseFieldService, FieldTypeSanitiser, FormErrorService, FormValueService } from '../../../services';
+import { text } from '../../../test/helpers';
+import { SaveOrDiscardDialogComponent } from '../../dialogs/save-or-discard-dialog/save-or-discard-dialog.component';
+import { CallbackErrorsContext } from '../../error/domain/error-context';
+import { CcdPageFieldsPipe, FieldsFilterPipe } from '../../palette/complex';
+import { CaseEditComponent } from '../case-edit/case-edit.component';
+import { Wizard, WizardPage } from '../domain';
+import { PageValidationService } from '../services';
+import { CaseEditPageComponent } from './case-edit-page.component';
+
+import createSpyObj = jasmine.createSpyObj;
 describe('CaseEditPageComponent', () => {
 
   let de: DebugElement;
@@ -802,7 +794,32 @@ describe('CaseEditPageComponent', () => {
     const F_GROUP = new FormGroup({
       'data': new FormGroup({'Invalidfield1': new FormControl(null, Validators.required)
                               , 'Invalidfield2': new FormControl(null, Validators.required)
+                              , 'OrganisationField': new FormControl(null, Validators.required)
                             })
+    });
+
+    const FIELD_TYPE_WITH_VALUES: FieldType = {
+      id: 'Organisation',
+      type: 'Complex',
+      complex_fields: [
+        {
+          id: 'OrganisationName',
+          label: 'Organisation Name',
+          display_context: 'MANDATORY',
+          field_type: {
+            id: 'Text',
+            type: 'Text'
+          }
+        } as CaseField
+      ]
+    };
+
+    const CASE_FIELD: CaseField = <CaseField>({
+      id: 'OrganisationField',
+      label: 'OrganisationField',
+      display_context: 'MANDATORY',
+      field_type: FIELD_TYPE_WITH_VALUES,
+      value: ''
     });
 
     beforeEach(async(() => {
@@ -865,21 +882,21 @@ describe('CaseEditPageComponent', () => {
     });
 
     it('should validate Mandatory Fields and log error message ', () => {
-        wizardPage.case_fields.push(aCaseField('Invalidfield1', 'Invalidfield1', 'Text', 'MANDATORY', null));
-        wizardPage.case_fields.push(aCaseField('Invalidfield2', 'Invalidfield2', 'Text', 'MANDATORY', null));
-        wizardPage.isMultiColumn = () => false;
+      wizardPage.case_fields.push(aCaseField('Invalidfield1', 'Invalidfield1', 'Text', 'MANDATORY', null));
+      wizardPage.case_fields.push(aCaseField('Invalidfield2', 'Invalidfield2', 'Text', 'MANDATORY', null));
+      wizardPage.case_fields.push(CASE_FIELD);
+      wizardPage.isMultiColumn = () => false;
 
-        comp.editForm = F_GROUP;
-        comp.currentPage = wizardPage;
-        fixture.detectChanges();
-        expect(comp.currentPageIsNotValid()).toBeTruthy();
+      comp.editForm = F_GROUP;
+      comp.currentPage = wizardPage;
+      fixture.detectChanges();
+      expect(comp.currentPageIsNotValid()).toBeTruthy();
 
-        comp.generateErrorMessage(wizardPage.case_fields);
-        comp.validationErrors.forEach(error => {
-          expect(error.message).toEqual(`${error.id} is required`)
-        });
-
+      comp.generateErrorMessage(wizardPage.case_fields);
+      comp.validationErrors.forEach(error => {
+        expect(error.message).toEqual(`${error.id} is required`)
       });
+    });
   });
 
   function createCaseField(id: string, value: any, display_context = 'READONLY'): CaseField {

--- a/src/shared/components/case-editor/case-edit-page/case-edit-page.html
+++ b/src/shared/components/case-editor/case-edit-page/case-edit-page.html
@@ -18,12 +18,12 @@
   </h2>
   <div *ngFor="let validationError of validationErrors" class="govuk-error-summary__body">
     <ul class="govuk-list govuk-error-summary__list">
-      <li> 
+      <li>
         <a (click)="navigateToErrorElement(validationError.id)" class="validation-error">{{validationError.message}}</a>
-      </li>      
+      </li>
     </ul>
   </div>
-</div>  
+</div>
 
 <!-- Generic error heading and error message to be displayed only if there are no specific callback errors or warnings, or no error details -->
 <div *ngIf="error && !(error.callbackErrors || error.callbackWarnings || error.details)" class="error-summary"

--- a/src/shared/components/case-editor/case-edit-submit/case-edit-submit.component.ts
+++ b/src/shared/components/case-editor/case-edit-submit/case-edit-submit.component.ts
@@ -349,7 +349,7 @@ export class CaseEditSubmitComponent implements OnInit, OnDestroy {
     return this.profile.isSolicitor();
   }
 
-  private buildConfirmation(response: any): Confirmation {
+  private buildConfirmation(response: object): Confirmation {
     if (response['after_submit_callback_response']) {
       return new Confirmation(
         response['id'],
@@ -376,7 +376,7 @@ export class CaseEditSubmitComponent implements OnInit, OnDestroy {
     return this.eventTrigger.case_fields;
   }
 
-  getCaseId(): String {
+  public getCaseId(): string {
     return (this.caseEdit.caseDetails ? this.caseEdit.caseDetails.case_id : '');
   }
 

--- a/src/shared/components/palette/address/write-address-field.html
+++ b/src/shared/components/palette/address/write-address-field.html
@@ -8,7 +8,7 @@
         <span class="form-label">Enter a UK postcode</span>
       </label>
       <span class="error-message" *ngIf="missingPostcode">Enter the Postcode</span>
-      <input type="text" [ngClass]="{'govuk-input--error': missingPostcode}"  
+      <input type="text" [ngClass]="{'govuk-input--error': missingPostcode}"
       [id]="createElementId('postcodeInput')" name="postcode" class="form-control postcodeinput inline-block" [formControl]="postcode">
       <button type="button" class="button button-30" (click)="findAddress()">Find address</button>
     </div>

--- a/src/shared/components/palette/case-link/write-case-link-field.html
+++ b/src/shared/components/palette/case-link/write-case-link-field.html
@@ -3,6 +3,6 @@
     <span class="form-label" *ngIf="caseField.label">{{caseField | ccdFieldLabel}}</span>
   </label>
   <span class="form-hint" *ngIf="caseField.hint_text">{{caseField.hint_text}}</span>
-  <span class="error-message" *ngIf="caseReferenceControl.errors && caseReferenceControl.touched">{{caseReferenceControl.errors | ccdFirstError:caseField.label}}</span>
+  <span class="error-message" *ngIf="caseReferenceControl.errors && caseReferenceControl.dirty">{{caseReferenceControl.errors | ccdFirstError:caseField.label}}</span>
   <input class="form-control bottom-30" [id]="id()" type="text" [formControl]="caseReferenceControl">
 </div>

--- a/src/shared/components/palette/collection/write-collection-field.html
+++ b/src/shared/components/palette/collection/write-collection-field.html
@@ -2,7 +2,7 @@
 
   <div class="panel collection-indicator">
 
-    <h2 *ngIf="caseField.hint_text || formArray.errors" class="heading-h2 error-spacing">
+    <h2 class="heading-h2 error-spacing">
       {{caseField | ccdFieldLabel}}
     </h2>
     <button class="button" type="button" (click)="addItem(true)" [disabled]="isNotAuthorisedToCreate()">Add new</button>

--- a/src/shared/components/palette/complex/read-complex-field-table.html
+++ b/src/shared/components/palette/complex/read-complex-field-table.html
@@ -2,7 +2,7 @@
   <dl class="complex-panel-title"><dt><span class="text-16">{{caseField.label}}</span></dt><dd></dd></dl>
   <table class="complex-panel-table">
     <tbody>
-      <ng-container *ngFor="let field of caseField | ccdReadFieldsFilter:false :undefined :true :topLevelFormGroup">
+      <ng-container *ngFor="let field of caseField | ccdReadFieldsFilter:false :undefined :true">
         <ng-container *ngIf="(field | ccdIsCompound); else SimpleRow">
           <tr class="complex-panel-compound-field" [hidden]="field.hidden">
             <td colspan="2">

--- a/src/shared/components/palette/date/write-date-field.html
+++ b/src/shared/components/palette/date/write-date-field.html
@@ -5,12 +5,12 @@
       <span class="form-label" *ngIf="caseField.label">{{caseField | ccdFieldLabel }}</span>
     </legend>
     <span class="form-hint" *ngIf="caseField.hint_text">{{caseField.hint_text}}</span>
-    <span class="error-message" *ngIf="dateControl && dateControl.errors && dateControl.touched">{{dateControl.errors | ccdFirstError:caseField.label}}</span>
+    <span class="error-message" *ngIf="dateControl && dateControl.errors && dateControl.dirty">{{dateControl.errors | ccdFirstError:caseField.label}}</span>
 
     <cut-date-input [id]="id()"
                     [isDateTime]="isDateTime()"
                     [mandatory]="caseField | ccdIsMandatory"
-                    [isInvalid]="dateControl.errors && dateControl.touched"
+                    [isInvalid]="dateControl.errors && dateControl.dirty"
                     [formControl]="dateControl"></cut-date-input>
 
   </fieldset>

--- a/src/shared/components/palette/datetime-picker/datetime-picker.component.html
+++ b/src/shared/components/palette/datetime-picker/datetime-picker.component.html
@@ -1,20 +1,20 @@
 <div class="govuk-form-group  bottom-30" [id]="caseField.id"
-     [ngClass]="{'form-group-error': dateControl && !dateControl.valid && dateControl.touched}">
+     [ngClass]="{'form-group-error': dateControl && !dateControl.valid && dateControl.dirty}">
   <fieldset>
     <legend>
       <span class="form-label" *ngIf="caseField.label">{{caseField | ccdFieldLabel }}</span>
       <span class="form-hint" *ngIf="caseField.hint_text">{{caseField.hint_text}}</span>
       <span class="error-message"
-            *ngIf="dateControl && dateControl.errors && dateControl.touched && !(this.minError || this.maxError)">{{dateControl.errors | ccdFirstError:caseField.label}}</span>
+            *ngIf="dateControl && dateControl.errors && dateControl.dirty && !(this.minError || this.maxError)">{{dateControl.errors | ccdFirstError:caseField.label}}</span>
             <span class="error-message"
-            *ngIf="dateControl && dateControl.touched && this.minError">This date is older than the minimum date allowed</span>
+            *ngIf="dateControl && dateControl.dirty && this.minError">This date is older than the minimum date allowed</span>
             <span class="error-message"
-            *ngIf="dateControl && dateControl.touched && this.maxError">This date is later than the maximum date allowed</span>
+            *ngIf="dateControl && dateControl.dirty && this.maxError">This date is later than the maximum date allowed</span>
     </legend>
     <div class="datepicker-container">
       <input class="govuk-input"
              #input
-             attr.aria-label="Please enter a date and time in the format {{dateTimeEntryFormat}}"
+             aria-label="Please enter a date and time in the format {{dateTimeEntryFormat}}"
              [min]="minDate(caseField)"
              [max]="maxDate(caseField)"
              [formControl]="dateControl"

--- a/src/shared/components/palette/datetime-picker/datetime-picker.component.html
+++ b/src/shared/components/palette/datetime-picker/datetime-picker.component.html
@@ -14,7 +14,7 @@
     <div class="datepicker-container">
       <input class="govuk-input"
              #input
-             aria-label="Please enter a date and time in the format {{dateTimeEntryFormat}}"
+             attr.aria-label="Please enter a date and time in the format {{dateTimeEntryFormat}}"
              [min]="minDate(caseField)"
              [max]="maxDate(caseField)"
              [formControl]="dateControl"

--- a/src/shared/components/palette/document/write-document-field.html
+++ b/src/shared/components/palette/document/write-document-field.html
@@ -1,6 +1,6 @@
 <div class="form-group" [ngClass]="{'form-group-error bottom-30': !valid}">
   <label [for]="id()">
-    <span class="form-label" attr.aria-label="{{caseField | ccdFieldLabel}}">{{caseField | ccdFieldLabel}}</span>    
+    <span class="form-label" attr.aria-label="{{caseField | ccdFieldLabel}}">{{caseField | ccdFieldLabel}}</span>
   </label>
   <span class="form-hint" *ngIf="caseField.hint_text">{{caseField.hint_text}}</span>
   <span class="error-message" *ngIf="fileUploadMessages && !valid">{{fileUploadMessages}}</span>
@@ -12,7 +12,7 @@
 
   <div style='position:relative'>
 
-    <div [id]="createElementId('fileInputWrapper')" (click)="fileSelectEvent()"  ></div>
+    <div [id]="createElementId('fileInputWrapper')" (click)="fileSelectEvent()"></div>
     <input class="form-control bottom-30" [id]="id()" type="file" (keydown.Tab)="fileValidationsOnTab()" (change)="fileChangeEvent($event)"
            accept="{{caseField.field_type.regular_expression}}" #fileInput/>
   </div>

--- a/src/shared/components/palette/email/write-email-field.html
+++ b/src/shared/components/palette/email/write-email-field.html
@@ -1,12 +1,12 @@
 <div class="form-group bottom-30" [ngClass]="{'form-group-error': !emailControl.valid && emailControl.dirty}">
 
   <label [for]="id()">
-    <span class="form-label" *ngIf="caseField.label">{{caseField | ccdFieldLabel}}</span>    
+    <span class="form-label" *ngIf="caseField.label">{{caseField | ccdFieldLabel}}</span>
   </label>
   <span class="form-hint" *ngIf="caseField.hint_text">{{caseField.hint_text}}</span>
-  <span class="error-message" *ngIf="emailControl.errors && emailControl.touched">{{emailControl.errors | ccdFirstError:caseField.label}}</span>
+  <span class="error-message" *ngIf="emailControl.errors && emailControl.dirty">{{emailControl.errors | ccdFirstError:caseField.label}}</span>
 
-  <input class="form-control" [ngClass]="{'govuk-input--error': emailControl.errors && emailControl.touched}" 
-   [id]="id()" type="email" [formControl]="emailControl">
+  <input class="form-control" [ngClass]="{'govuk-input--error': emailControl.errors && emailControl.dirty}"
+    [id]="id()" type="email" [formControl]="emailControl">
 
 </div>

--- a/src/shared/components/palette/fixed-list/write-fixed-list-field.html
+++ b/src/shared/components/palette/fixed-list/write-fixed-list-field.html
@@ -1,10 +1,10 @@
 <div class="form-group" [ngClass]="{'form-group-error': !fixedListFormControl.valid && fixedListFormControl.dirty}">
 
   <label [for]="id()">
-    <span class="form-label" *ngIf="caseField.label">{{caseField | ccdFieldLabel}}</span>    
+    <span class="form-label" *ngIf="caseField.label">{{caseField | ccdFieldLabel}}</span>
   </label>
   <span class="form-hint" *ngIf="caseField.hint_text">{{caseField.hint_text}}</span>
-  <span class="error-message" *ngIf="fixedListFormControl.errors && fixedListFormControl.touched">{{fixedListFormControl.errors | ccdFirstError:caseField.label}}</span>
+  <span class="error-message" *ngIf="fixedListFormControl.errors && fixedListFormControl.dirty">{{fixedListFormControl.errors | ccdFirstError:caseField.label}}</span>
 
   <select class="form-control ccd-dropdown bottom-30" [id]="id()" [formControl]="fixedListFormControl">
     <option [ngValue]=null>--Select a value--</option>

--- a/src/shared/components/palette/fixed-radio-list/write-fixed-radio-list-field.html
+++ b/src/shared/components/palette/fixed-radio-list/write-fixed-radio-list-field.html
@@ -2,15 +2,15 @@
   <fieldset>
     <legend>
       <label [for]="id()">
-        <span class="form-label" *ngIf="caseField.label">{{caseField | ccdFieldLabel}}</span>        
+        <span class="form-label" *ngIf="caseField.label">{{caseField | ccdFieldLabel}}</span>
       </label>
       <span class="form-hint" *ngIf="caseField.hint_text">{{caseField.hint_text}}</span>
-      <span class="error-message" *ngIf="fixedRadioListControl.errors && fixedRadioListControl.touched">{{fixedRadioListControl.errors | ccdFirstError:caseField.label}}</span>
+      <span class="error-message" *ngIf="fixedRadioListControl.errors && fixedRadioListControl.dirty">{{fixedRadioListControl.errors | ccdFirstError:caseField.label}}</span>
     </legend>
     <ng-container>
       <div class="multiple-choice" *ngFor="let radioButton of caseField.field_type.fixed_list_items" [ngClass]="{selected: fixedRadioListControl.value === radioButton.code}">
-          <input class="form-control" [id]="id()+'-'+radioButton.code" [name]="id()" type="radio" [formControl]="fixedRadioListControl" [value]="radioButton.code">
-          <label class="form-label" [for]="id()+'-'+radioButton.code">{{radioButton.label}}</label>
+        <input class="form-control" [id]="id()+'-'+radioButton.code" [name]="id()" type="radio" [formControl]="fixedRadioListControl" [value]="radioButton.code">
+        <label class="form-label" [for]="id()+'-'+radioButton.code">{{radioButton.label}}</label>
       </div>
     </ng-container>
   </fieldset>

--- a/src/shared/components/palette/money-gbp/write-money-gbp-field.html
+++ b/src/shared/components/palette/money-gbp/write-money-gbp-field.html
@@ -1,10 +1,10 @@
 <div class="form-group bottom-30" [ngClass]="{'form-group-error': !moneyGbpControl.valid && moneyGbpControl.dirty}">
 
   <label [for]="id()">
-    <span class="form-label" *ngIf="caseField.label">{{caseField | ccdFieldLabel}}</span>    
+    <span class="form-label" *ngIf="caseField.label">{{caseField | ccdFieldLabel}}</span>
   </label>
   <span class="form-hint" *ngIf="caseField.hint_text">{{caseField.hint_text}}</span>
-  <span class="error-message" *ngIf="moneyGbpControl.errors && moneyGbpControl.touched">{{moneyGbpControl.errors | ccdFirstError:caseField.label}}</span>
+  <span class="error-message" *ngIf="moneyGbpControl.errors && moneyGbpControl.dirty">{{moneyGbpControl.errors | ccdFirstError:caseField.label}}</span>
 
   <div class="form-money">
     <span class="form-currency">&#163;</span>

--- a/src/shared/components/palette/multi-select-list/write-multi-select-list-field.html
+++ b/src/shared/components/palette/multi-select-list/write-multi-select-list-field.html
@@ -3,10 +3,10 @@
   <fieldset>
 
     <legend>
-      <span class="form-label" *ngIf="caseField.label">{{caseField | ccdFieldLabel}}</span>      
+      <span class="form-label" *ngIf="caseField.label">{{caseField | ccdFieldLabel}}</span>
     </legend>
     <span *ngIf="caseField.hint_text" class="form-hint">{{caseField.hint_text}}</span>
-    <span *ngIf="checkboxes.errors && checkboxes.touched" class="error-message">{{checkboxes.errors | ccdFirstError:caseField.label}}</span>
+    <span *ngIf="checkboxes.errors && checkboxes.dirty" class="error-message">{{checkboxes.errors | ccdFirstError:caseField.label}}</span>
 
     <ng-container *ngFor="let checkbox of caseField.field_type.fixed_list_items">
 

--- a/src/shared/components/palette/number/write-number-field.html
+++ b/src/shared/components/palette/number/write-number-field.html
@@ -1,12 +1,12 @@
 <div class="form-group" [ngClass]="{'form-group-error': !numberControl.valid && numberControl.dirty}">
 
   <label [for]="id()">
-    <span class="form-label" *ngIf="caseField.label">{{caseField | ccdFieldLabel}}</span>    
+    <span class="form-label" *ngIf="caseField.label">{{caseField | ccdFieldLabel}}</span>
   </label>
   <span class="form-hint" *ngIf="caseField.hint_text">{{caseField.hint_text}}</span>
-  <span class="error-message" *ngIf="numberControl.errors && numberControl.touched">{{numberControl.errors | ccdFirstError:caseField.label}}</span>
+  <span class="error-message" *ngIf="numberControl.errors && numberControl.dirty">{{numberControl.errors | ccdFirstError:caseField.label}}</span>
 
-  <input class="form-control bottom-30" [ngClass]="{'govuk-input--error': numberControl.errors && numberControl.touched}"
+  <input class="form-control bottom-30" [ngClass]="{'govuk-input--error': numberControl.errors && numberControl.dirty}"
    [id]="id()" type="number" [formControl]="numberControl">
 
 </div>

--- a/src/shared/components/palette/phone-uk/write-phone-uk-field.html
+++ b/src/shared/components/palette/phone-uk/write-phone-uk-field.html
@@ -1,11 +1,11 @@
 <div class="form-group" [ngClass]="{'form-group-error': !phoneUkControl.valid && phoneUkControl.dirty}">
 
   <label [for]="id()">
-    <span class="form-label" *ngIf="caseField.label">{{caseField | ccdFieldLabel}}</span>    
+    <span class="form-label" *ngIf="caseField.label">{{caseField | ccdFieldLabel}}</span>
   </label>
   <span class="form-hint" *ngIf="caseField.hint_text">{{caseField.hint_text}}</span>
-  <span class="error-message" *ngIf="phoneUkControl.errors && phoneUkControl.touched">{{phoneUkControl.errors | ccdFirstError:caseField.label}}</span>
-  <input class="form-control bottom-30" [ngClass]="{'govuk-input--error': phoneUkControl.errors && phoneUkControl.touched}"
+  <span class="error-message" *ngIf="phoneUkControl.errors && phoneUkControl.dirty">{{phoneUkControl.errors | ccdFirstError:caseField.label}}</span>
+  <input class="form-control bottom-30" [ngClass]="{'govuk-input--error': phoneUkControl.errors && phoneUkControl.dirty}"
    [id]="id()" type="tel" [formControl]="phoneUkControl">
 
 </div>

--- a/src/shared/components/palette/text-area/write-text-area-field.html
+++ b/src/shared/components/palette/text-area/write-text-area-field.html
@@ -4,9 +4,9 @@
     <span class="form-label" *ngIf="caseField.label">{{caseField | ccdFieldLabel}}</span>
   </label>
   <span class="form-hint" *ngIf="caseField.hint_text">{{caseField.hint_text}}</span>
-  <span class="error-message" *ngIf="textareaControl.errors && textareaControl.touched">{{textareaControl.errors | ccdFirstError:caseField.label}}</span>
+  <span class="error-message" *ngIf="textareaControl.errors && textareaControl.dirty">{{textareaControl.errors | ccdFirstError:caseField.label}}</span>
 
-  <textarea (input)="autoGrow($event)" class="form-control bottom-30" [ngClass]="{'govuk-textarea--error': textareaControl.errors && textareaControl.touched}" 
+  <textarea (input)="autoGrow($event)" class="form-control bottom-30" [ngClass]="{'govuk-textarea--error': textareaControl.errors && textareaControl.dirty}" 
    [id]="id()" rows="3" [formControl]="textareaControl"></textarea>
 
 </div>

--- a/src/shared/components/palette/text/write-text-field.html
+++ b/src/shared/components/palette/text/write-text-field.html
@@ -1,12 +1,12 @@
 <div class="form-group" [ngClass]="{'form-group-error': !textControl.valid && textControl.dirty}">
 
   <label [for]="id()">
-    <span class="form-label" *ngIf="caseField.label">{{caseField | ccdFieldLabel}}</span>    
+    <span class="form-label" *ngIf="caseField.label">{{caseField | ccdFieldLabel}}</span>
   </label>
   <span class="form-hint" *ngIf="caseField.hint_text">{{caseField.hint_text}}</span>
-  <span class="error-message" *ngIf="textControl.errors && textControl.touched">{{textControl.errors | ccdFirstError:caseField.label}}</span>
+  <span class="error-message" *ngIf="textControl.errors && textControl.dirty">{{textControl.errors | ccdFirstError:caseField.label}}</span>
 
-  <input class="form-control bottom-30" [ngClass]="{'govuk-input--error': textControl.errors && textControl.touched}"
+  <input class="form-control bottom-30" [ngClass]="{'govuk-input--error': textControl.errors && textControl.dirty}"
   [id]="id()" type="text" [formControl]="textControl">
 
 </div>

--- a/src/shared/components/palette/utils/first-error.pipe.ts
+++ b/src/shared/components/palette/utils/first-error.pipe.ts
@@ -12,10 +12,10 @@ export class FirstErrorPipe implements PipeTransform {
     }
 
     if (!args) {
-      args = 'field';
+      args = 'Field';
     }
 
-    let keys = Object.keys(value);
+    const keys = Object.keys(value);
 
     if (!keys.length) {
       return '';
@@ -25,9 +25,9 @@ export class FirstErrorPipe implements PipeTransform {
     } else if (keys[0] === 'pattern') {
       return `The data entered is not valid for ${args}`;
     } else if (keys[0] === 'minlength') {
-      return `${args} required minimum length`;
+      return `${args} is below the minimum length`;
     } else if (keys[0] === 'maxlength') {
-      return `${args} exceeds maximum length`;
+      return `${args} exceeds the maximum length`;
     } else if (value.hasOwnProperty('matDatetimePickerParse')) {
       return 'The date entered is not valid. Please provide a valid date'
     }

--- a/src/shared/components/palette/yes-no/write-yes-no-field.html
+++ b/src/shared/components/palette/yes-no/write-yes-no-field.html
@@ -3,10 +3,10 @@
 	<fieldset class="inline">
 
     <legend>
-      <span class="form-label" *ngIf="caseField.label">{{caseField | ccdFieldLabel}}</span>      
+      <span class="form-label" *ngIf="caseField.label">{{caseField | ccdFieldLabel}}</span>
     </legend>
     <span class="form-hint" *ngIf="caseField.hint_text">{{caseField.hint_text}}</span>
-    <span class="error-message" *ngIf="yesNoControl.errors && yesNoControl.touched">{{yesNoControl.errors | ccdFirstError:caseField.label}}</span>
+    <span class="error-message" *ngIf="yesNoControl.errors && yesNoControl.dirty">{{yesNoControl.errors | ccdFirstError:caseField.label}}</span>
 
     <div [id]="createElementId('radio')">
 

--- a/src/shared/directives/conditional-show/conditional-show-form.directive.ts
+++ b/src/shared/directives/conditional-show/conditional-show-form.directive.ts
@@ -109,25 +109,25 @@ export class ConditionalShowFormDirective implements OnInit, AfterViewInit, OnDe
   }
 
   // make sure for the 3 callbacks that we are bound to this via an arrow function
-  private handleFormControl = (c: FormControl): void => {
-    this.evaluateControl(c);
+  private handleFormControl = (formControl: FormControl): void => {
+    this.evaluateControl(formControl);
   }
 
-  private handleFormArray = (a: FormArray): void => {
-    this.evaluateControl(a);
-    a.controls.forEach(formControl => {
+  private handleFormArray = (formArray: FormArray): void => {
+    this.evaluateControl(formArray);
+    formArray.controls.forEach(formControl => {
       this.fieldsUtils.controlIterator(formControl, this.handleFormArray, this.handleFormGroup, this.handleFormControl);
     });
   }
 
-  private handleFormGroup = (g: FormGroup): void => {
-    this.evaluateControl(g);
-    let groupControl = g;
-    if (g.get('value') && g.get('value') instanceof FormGroup) { // Complex Field
-      groupControl = g.get('value') as FormGroup;
-    } else if (g.controls) {
+  private handleFormGroup = (formGroup: FormGroup): void => {
+    this.evaluateControl(formGroup);
+    let groupControl = formGroup;
+    if (formGroup.get('value') && formGroup.get('value') instanceof FormGroup) { // Complex Field
+      groupControl = formGroup.get('value') as FormGroup;
+    } else if (formGroup.controls) {
       // Special Fields like AddressUK, AddressGlobal
-      groupControl = g;
+      groupControl = formGroup;
     }
     if (groupControl.controls) {
       Object.keys(groupControl.controls).forEach(cKey => {

--- a/src/shared/services/fields/fields.utils.spec.ts
+++ b/src/shared/services/fields/fields.utils.spec.ts
@@ -234,4 +234,128 @@ describe('FieldsUtils', () => {
       expect(item['value'][`ms${FieldsUtils.LABEL_SUFFIX}`][1]).toBe(ITEMS[2].label);
     });
   });
+
+  describe('containsNonEmptyValues() function tests', () => {
+    it('should return false for null', () => {
+      expect(FieldsUtils.containsNonEmptyValues(null)).toBe(false);
+    });
+
+    it('should return true for a non-empty object', () => {
+      expect(FieldsUtils.containsNonEmptyValues({ field1: 'value' })).toBe(true);
+    });
+
+    it('should return false for an empty object', () => {
+      expect(FieldsUtils.containsNonEmptyValues({})).toBe(false);
+    });
+
+    it('should return false for an object containing only null and empty string values', () => {
+      expect(FieldsUtils.containsNonEmptyValues({ field1: null, field2: '' })).toBe(false);
+    });
+
+    it('should return false for an object containing only an undefined value', () => {
+      expect(FieldsUtils.containsNonEmptyValues({ field1: undefined })).toBe(false);
+    });
+
+    it('should return true for an object containing a zero number value', () => {
+      expect(FieldsUtils.containsNonEmptyValues({ field1: 0 })).toBe(true);
+    });
+
+    it('should return false for an object containing no non-empty descendant values', () => {
+      expect(FieldsUtils.containsNonEmptyValues({
+        field1: {
+          field1_1: null,
+          field1_2: '',
+          field1_3: undefined
+        }
+      })).toBe(false);
+    });
+
+    it('should return true for an object containing at least one non-empty descendant value', () => {
+      expect(FieldsUtils.containsNonEmptyValues({
+        field1: {
+          field1_1: null,
+          field1_2: 'null'
+        }
+      })).toBe(true);
+    });
+
+    it('should return true for an object containing a non-empty array', () => {
+      expect(FieldsUtils.containsNonEmptyValues({ field1: ['value'] })).toBe(true);
+    });
+
+    it('should return false for an object containing an empty array', () => {
+      expect(FieldsUtils.containsNonEmptyValues({ field1: [] })).toBe(false);
+    });
+
+    it('should return false for an object with an array containing only null and empty string values', () => {
+      expect(FieldsUtils.containsNonEmptyValues({ field1: [null, ''] })).toBe(false);
+    });
+
+    it('should return false for an object with an array containing only an undefined value', () => {
+      expect(FieldsUtils.containsNonEmptyValues({ field1: [undefined] })).toBe(false);
+    });
+
+    it('should return true for an object with an array containing a zero number value', () => {
+      expect(FieldsUtils.containsNonEmptyValues({ field1: [0] })).toBe(true);
+    });
+
+    it('should return true for a non-empty array', () => {
+      expect(FieldsUtils.containsNonEmptyValues(['value'])).toBe(true);
+    });
+
+    it('should return false for an empty array', () => {
+      expect(FieldsUtils.containsNonEmptyValues([])).toBe(false);
+    });
+
+    it('should return false for an array containing only null and empty string values', () => {
+      expect(FieldsUtils.containsNonEmptyValues([null, ''])).toBe(false);
+    });
+
+    it('should return false for an array containing only an undefined value', () => {
+      expect(FieldsUtils.containsNonEmptyValues([undefined])).toBe(false);
+    });
+
+    it('should return true for an array containing a zero number value', () => {
+      expect(FieldsUtils.containsNonEmptyValues([0])).toBe(true);
+    });
+
+    it('should return true for an array containing a non-empty object', () => {
+      expect(FieldsUtils.containsNonEmptyValues([{ field1: 'value' }])).toBe(true);
+    });
+
+    it('should return false for an array containing an empty object', () => {
+      expect(FieldsUtils.containsNonEmptyValues([{}])).toBe(false);
+    });
+
+    it('should return false for an array with an object containing only null and empty string values', () => {
+      expect(FieldsUtils.containsNonEmptyValues([{ field1: null, field2: '' }])).toBe(false);
+    });
+
+    it('should return false for an array with an object containing only an undefined value', () => {
+      expect(FieldsUtils.containsNonEmptyValues([{ field1: undefined }])).toBe(false);
+    });
+
+    it('should return true for an array with an object containing a zero number value', () => {
+      expect(FieldsUtils.containsNonEmptyValues([{ field1: 0 }])).toBe(true);
+    });
+
+    it('should return false for an array with an object containing no non-empty descendant values', () => {
+      expect(FieldsUtils.containsNonEmptyValues([{
+        field1: {
+          field1_1: null,
+          field1_2: '',
+          field1_3: undefined
+        }
+      }])).toBe(false);
+    });
+
+    it('should return true for an array with an object containing at least one non-empty descendant value', () => {
+      expect(FieldsUtils.containsNonEmptyValues([{
+        field1: {
+          field1_1: null,
+          field1_2: 'null'
+        }
+      }])).toBe(true);
+    });
+  });
 });

--- a/src/shared/services/fields/fields.utils.ts
+++ b/src/shared/services/fields/fields.utils.ts
@@ -41,7 +41,7 @@ export class FieldsUtils {
   }
 
   public static isNonEmptyObject(elem: any): boolean {
-      return this.isObject(elem) && Object.keys(elem).length !== 0;
+    return this.isObject(elem) && Object.keys(elem).length !== 0;
   }
 
   public static isArray(elem: any): boolean {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/projects/EUI/versions/39208
https://tools.hmcts.net/jira/projects/EUI/versions/38816


### Change description ###
This PR is specifically to address the issues that were identified in https://github.com/hmcts/ccd-case-ui-toolkit/pull/819, which must have come about when rebasing `release-4.1.0` against `master`. It appears that local changes were kept in favour of incoming changes from `master` whenever there was a conflict, which has resulted in a lot of fixes and changes being ditched. It _seems_ like some of the changes were also ditched in files where I can't see how there could have been a conflict as there are no changes going back the other way - just a reversal of what's currently (correctly) on `master`.

Here's a breakdown of what this PR contains:

* All of `Version 4.0.0` was missing from `RELEASE-NOTES.md` so that's been put back in.
* Set the version in `package.json` to be `4.1.0`.
* Reinstated a bunch of tidy-ups in `demo/test` that seemed to have been dismissed.
* Reinstated unit test functionality in the `case-edit-page.component`, which had been incorrectly ditched.
* Re-fixed `getCaseId(): String` to be `public getCaseId(): string` in `case-edit-submit.component`.
* Fixed up a bunch of regressions in the .html files within `shared/components/palette` where `dirty` had been incorrectly replaced with `touched`.
* Re-fixed an issue with labels not showing for collections when there's no `hint_text` and the array is not in error.
* Re-fixed EUI-4227, which had been lost.
* Reinstantiated some changes and fixes in the `FirstErrorPipe`.
* Undid the weird replacement of the `FirstErrorPipe` tests with a copy of the `FirstErrorPipe` class.
* Re-introduced 25 unit tests for `FieldUtils.containsNonEmptyValues(...)`, which had been incorrectly ditched.
* Re-removed pointless whitespace in various places.
* Running "Organise imports" has also done a bit of cleaning up.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```