### PR TITLE
EUI-4244: Mid-event callback error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "4.1.0-rc.4",
+  "version": "4.1.0-rc.5",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/directives/conditional-show/conditional-show.directive.ts
+++ b/src/shared/directives/conditional-show/conditional-show.directive.ts
@@ -44,11 +44,9 @@ export class ConditionalShowDirective implements AfterViewInit, OnDestroy {
     // this.caseField = FieldsUtils.convertToCaseField(this.caseField);
     if (this.caseField.show_condition) {
       this.condition = ShowCondition.getInstance(this.caseField.show_condition);
-      // console.log('FIELD: ' + this.caseField.id + ' init. Show condition: ' + this.caseField.show_condition);
       this.formGroup = this.formGroup || new FormGroup({});
       this.complexFormGroup = this.complexFormGroup || new FormGroup({});
       this.formField = this.complexFormGroup.get(this.caseField.id) || this.formGroup.get(this.caseField.id);
-      // console.log('FIELD: ' + this.caseField.id + '. Is form field:' + this.formField + '. Event fields:', this.eventFields);
       this.updateVisibility(this.getCurrentPagesReadOnlyAndFormFieldValues());
       if (this.greyBarEnabled && this.greyBarService.wasToggledToShow(this.caseField.id)) {
         this.greyBarService.showGreyBar(this.caseField, this.el);
@@ -59,7 +57,6 @@ export class ConditionalShowDirective implements AfterViewInit, OnDestroy {
   }
 
   refreshVisibility() {
-    // console.log('Refresh FIELD: ', this.caseField.id, '. field:', this.formField, '. eventFields:', this.eventFields);
     this.updateVisibility(this.getCurrentPagesReadOnlyAndFormFieldValues(), true);
     this.subscribeToFormChanges();
   }
@@ -70,14 +67,12 @@ export class ConditionalShowDirective implements AfterViewInit, OnDestroy {
 
   private subscribeToFormChanges() {
     this.unsubscribeFromFormChanges();
-    // console.log('FIELD ' + this.caseField.id + ' subscribing to form changes');
     this.formChangesSubscription = this.formGroup
       .valueChanges
       .pipe(
         debounceTime(200)
       )
       .subscribe(_ => {
-        console.log('FIELD ' + this.caseField.id + ' reacting to form change');
         let shown = this.updateVisibility(this.getCurrentPagesReadOnlyAndFormFieldValues());
         if (this.greyBarEnabled && shown !== undefined) {
           this.updateGreyBar(shown);
@@ -89,7 +84,6 @@ export class ConditionalShowDirective implements AfterViewInit, OnDestroy {
    * returns whether the field visibility has changed, or undefined if not
    */
   private updateVisibility(fields, forced = false): boolean {
-    // console.log('FIELD ' + this.caseField.id + ' updatingVisibility based on fields: ', fields, ' forced:', forced);
     if (this.shouldToggleToHide(fields, forced)) {
       this.onHide();
       return false;
@@ -100,10 +94,8 @@ export class ConditionalShowDirective implements AfterViewInit, OnDestroy {
   }
 
   private onHide() {
-    // console.log('on hide is form field', this.formField);
     if (this.formField) {
       this.unsubscribeFromFormChanges();
-      // console.log('FIELD ' + this.caseField.id + ' disabling form field');
       this.formField.disable({emitEvent: false});
       this.subscribeToFormChanges();
     }
@@ -114,7 +106,6 @@ export class ConditionalShowDirective implements AfterViewInit, OnDestroy {
   private onShow() {
     if (this.formField) {
       this.unsubscribeFromFormChanges();
-      // console.log('FIELD ' + this.caseField.id + ' enabling form field', this.formField);
       this.formField.enable({emitEvent: false});
       this.subscribeToFormChanges();
     }
@@ -148,8 +139,7 @@ export class ConditionalShowDirective implements AfterViewInit, OnDestroy {
   }
 
   private getCurrentPagesReadOnlyAndFormFieldValues() {
-    let formFields = this.getFormFieldsValuesIncludingDisabled();
-    // console.log('FIELD ' + this.caseField.id + ' current form values including disabled: ', formFields);
+    const formFields = this.getFormFieldsValuesIncludingDisabled();
     return this.fieldsUtils.mergeCaseFieldsAndFormFields(this.contextFields, formFields);
   }
 
@@ -174,28 +164,22 @@ export class ConditionalShowDirective implements AfterViewInit, OnDestroy {
   // TODO This must be extracted to a generic service for traversing see RDM-2233
   private checkHideShowCondition(key: string, aControl: AbstractControl) {
     if (aControl instanceof FormArray) {  // We're in a collection
-      // console.log('traversing array', aControl);
       aControl.controls.forEach((formControl, i) => {
-        // console.log('in array', formControl);
         this.checkHideShowCondition('' + i, formControl)
       });
     } else if (aControl instanceof FormGroup) {
-      // console.log('met a FormGroup ', aControl, ' fromGroup.controls', aControl.controls);
       if (aControl.get('value')) { // Complex Field
         let complexControl = aControl.get('value') as FormGroup;
         Object.keys(complexControl.controls).forEach(controlKey => {
-          // console.log('traversing formGroup item', key, complexControl.get(key));
           this.checkHideShowCondition(controlKey, complexControl.get(controlKey));
         });
       } else if (aControl.controls) { // Special Field like AddressUK, AddressGlobal
         Object.keys(aControl.controls).forEach(controlKey => {
-          // console.log('traversing formGroup item', key, aControl.get(key));
           this.checkHideShowCondition(controlKey, aControl.get(controlKey));
         })
       }
     } else if (aControl instanceof FormControl) {  // FormControl
       if (aControl.invalid) {
-        console.log('met an invalid FormControl ', key, ' control:', aControl, ' is valid:', aControl.valid);
         this.registry.refresh();
       }
     }

--- a/src/shared/services/fields/fields.utils.ts
+++ b/src/shared/services/fields/fields.utils.ts
@@ -15,7 +15,8 @@ export class FieldsUtils {
 
   private static readonly currencyPipe: CurrencyPipe = new CurrencyPipe('en-GB');
   private static readonly datePipe: DatePipe = new DatePipe(new FormatTranslatorService());
-  public static readonly LABEL_SUFFIX = '-LABEL';
+  // EUI-4244. 3 dashes instead of 1 to make this less likely to clash with a real field.
+  public static readonly LABEL_SUFFIX = '---LABEL';
 
   public static convertToCaseField(obj: any): CaseField {
     if (!(obj instanceof CaseField)) {

--- a/src/shared/services/form/form-value.service.ts
+++ b/src/shared/services/form/form-value.service.ts
@@ -9,7 +9,7 @@ export class FormValueService {
   /**
    * Gets value of a field based on fieldKey which is a dot separated reference to value and collection index.
    * There are two exeptions:
-   * 1) In case of a multiselect being identified as a leaf a '---LABEL' suffix is appended to the key and values og that key are returned
+   * 1) In case of a multiselect being identified as a leaf a '---LABEL' suffix is appended to the key and values of that key are returned
    *      form= { 'list': ['code1', 'code2'],
    *              'list---LABEL': ['label1', 'label2'] },
    *      fieldKey=list,
@@ -447,7 +447,7 @@ export class FormValueService {
       }
     }
 
-    // Clear out any MultiSelec labels.
+    // Clear out any MultiSelect labels.
     FormValueService.removeMultiSelectLabels(data);
   }
 

--- a/src/shared/services/form/form-value.service.ts
+++ b/src/shared/services/form/form-value.service.ts
@@ -6,14 +6,12 @@ import { FieldTypeSanitiser } from './field-type-sanitiser';
 
 @Injectable()
 export class FormValueService {
-  public static readonly LABEL_SUFFIX = '-LABEL';
-
   /**
    * Gets value of a field based on fieldKey which is a dot separated reference to value and collection index.
    * There are two exeptions:
-   * 1) In case of a multiselect being identified as a leaf a '-LABEL' suffix is appended to the key and values og that key are returned
+   * 1) In case of a multiselect being identified as a leaf a '---LABEL' suffix is appended to the key and values og that key are returned
    *      form= { 'list': ['code1', 'code2'],
-   *              'list-LABEL': ['label1', 'label2'] },
+   *              'list---LABEL': ['label1', 'label2'] },
    *      fieldKey=list,
    *      colIndex=0,
    *      value=label1, label2
@@ -123,7 +121,7 @@ export class FormValueService {
     let currentFieldId = fieldIds[0];
     let currentForm = form[currentFieldId];
     if (FieldsUtils.isMultiSelectValue(currentForm)) {
-        return form[currentFieldId + FormValueService.LABEL_SUFFIX].join(', ');
+        return form[currentFieldId + FieldsUtils.LABEL_SUFFIX].join(', ');
     } else if (FieldsUtils.isCollectionOfSimpleTypes(currentForm)) {
         return currentForm.map(fieldValue => fieldValue['value']).join(', ');
     } else if (FieldsUtils.isCollection(currentForm)) {
@@ -135,6 +133,32 @@ export class FormValueService {
     }
   }
 
+
+  /**
+   * A recursive method to remove anything with a `---LABEL` suffix.
+   * @param data The data to recurse through and remove MultiSelect labels.
+   */
+  public static removeMultiSelectLabels(data: any): void {
+    if (data && typeof data === 'object') {
+      if (Array.isArray(data)) {
+        for (const item of data) {
+          FormValueService.removeMultiSelectLabels(item);
+        }
+      } else {
+        const keys: string[] = Object.keys(data);
+        for (const key of keys) {
+          // Have we found one a MultiSelect label?
+          if (key.indexOf(FieldsUtils.LABEL_SUFFIX) > 0) {
+            // If so, remove it.
+            delete data[key];
+          } else {
+            FormValueService.removeMultiSelectLabels(data[key]);
+          }
+        }
+      }
+    }
+  }
+
   private static isReadOnly(field: CaseField): boolean {
     return field.display_context ? field.display_context.toUpperCase() === 'READONLY' : false;
   }
@@ -143,7 +167,7 @@ export class FormValueService {
     return field.display_context ? field.display_context.toUpperCase() === 'OPTIONAL' : false;
   }
 
-  private static isLabel (field: CaseField): boolean {
+  private static isLabel(field: CaseField): boolean {
     if (field.field_type) {
       return field.field_type.type === 'Label';
     } else {
@@ -393,10 +417,10 @@ export class FormValueService {
               }
               break;
             case 'Complex':
-              // Recurse and remove anything unnecessary from within a complex field.
               this.removeUnnecessaryFields(data[field.id], field.field_type.complex_fields, clearEmpty);
               // Also remove any optional complex objects that are completely empty.
-              if (FormValueService.clearOptionalEmpty(clearEmpty, data[field.id], field)) {
+              // EUI-4244: Ritesh's fix, passing true instead of clearEmpty.
+              if (FormValueService.clearOptionalEmpty(true, data[field.id], field)) {
                 delete data[field.id];
               }
               break;
@@ -422,6 +446,9 @@ export class FormValueService {
         }
       }
     }
+
+    // Clear out any MultiSelec labels.
+    FormValueService.removeMultiSelectLabels(data);
   }
 
   /**


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-4244


### Change description ###
Initial fix (identified by @RiteshHMCTS) was to appropriately clear out complex objects that have null values when posting mid-event callbacks. Not doing this caused problems for "optional" fields that were mandatory based on some business logic within CCD.

This then presented with a different issue in `release-4.1.0` as a result of getting label interpolation working for multi-selects. In order to sorted this, added a method to clear out properties that are only there for the multi-select labels when submitting data, either as part of a mid-event callback or at the end of the flow after Check Your Answers.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```