### PR TITLE
Release 4.1.1-IE 11 fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "4.1.0-rc.6",
+  "version": "4.1.0-rc.7",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/components/palette/date/write-date-container-field.component.spec.ts
+++ b/src/shared/components/palette/date/write-date-container-field.component.spec.ts
@@ -2,7 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MatDatepickerModule, MatFormFieldModule, MatInputModule } from '@angular/material';
-import { NgxMatDatetimePickerModule, NgxMatNativeDateModule, NgxMatTimepickerModule } from '@angular-material-components/datetime-picker';
+import { NgxMatDatetimePickerModule, NgxMatNativeDateModule, NgxMatTimepickerModule } from '@angular-material-components/datetime-picker/esm5/angular-material-components-datetime-picker.js';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { CaseField, FieldType } from '../../../domain';

--- a/src/shared/components/palette/datetime-picker/datetime-picker-component.spec.ts
+++ b/src/shared/components/palette/datetime-picker/datetime-picker-component.spec.ts
@@ -2,11 +2,9 @@ import { By } from '@angular/platform-browser';
 import { ComponentFixture, discardPeriodicTasks, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { NgxMatDatetimePickerModule, NgxMatNativeDateModule, NgxMatTimepickerModule }
-  from '@angular-material-components/datetime-picker';
+  from '@angular-material-components/datetime-picker/esm5/angular-material-components-datetime-picker.js';
 import { MatDatepickerModule, MatFormFieldModule, MatInputModule } from '@angular/material';
-import { NGX_MAT_DATE_FORMATS } from '@angular-material-components/datetime-picker';
-import { NgxMatDateAdapter } from '@angular-material-components/datetime-picker';
-import { NgxMatMomentAdapter } from '@angular-material-components/moment-adapter';
+import { NGX_MAT_DATE_FORMATS } from '@angular-material-components/datetime-picker/esm5/angular-material-components-datetime-picker.js';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { CaseField, FieldType } from '../../../domain';
@@ -60,7 +58,6 @@ describe('DatetimePickerComponent', () => {
           ],
           providers: [FormatTranslatorService,
             { provide: NGX_MAT_DATE_FORMATS, useValue: CUSTOM_MOMENT_FORMATS },
-            { provide: NgxMatDateAdapter, useClass: NgxMatMomentAdapter },
             { provide: CaseFieldService, useValue: caseFieldService }
             ]
         })

--- a/src/shared/components/palette/datetime-picker/datetime-picker-utils.ts
+++ b/src/shared/components/palette/datetime-picker/datetime-picker-utils.ts
@@ -1,4 +1,4 @@
-import { NgxMatDateFormats } from '@angular-material-components/datetime-picker';
+import { NgxMatDateFormats } from '@angular-material-components/datetime-picker/esm5/angular-material-components-datetime-picker.js';
 
 export const CUSTOM_MOMENT_FORMATS: NgxMatDateFormats = {
   parse: {

--- a/src/shared/components/palette/datetime-picker/datetime-picker.component.ts
+++ b/src/shared/components/palette/datetime-picker/datetime-picker.component.ts
@@ -3,11 +3,9 @@ import { FormControl, Validators } from '@angular/forms';
 import { Moment } from 'moment/moment';
 import {
   NGX_MAT_DATE_FORMATS,
-  NgxMatDateAdapter,
   NgxMatDateFormats,
   NgxMatDatetimePicker
-} from '@angular-material-components/datetime-picker';
-import { NgxMatMomentAdapter, NGX_MAT_MOMENT_DATE_ADAPTER_OPTIONS } from '@angular-material-components/moment-adapter';
+} from '@angular-material-components/datetime-picker/esm5/angular-material-components-datetime-picker.js';
 import { ThemePalette } from '@angular/material';
 
 import { AbstractFormFieldComponent } from '../base-field/abstract-form-field.component';
@@ -22,9 +20,8 @@ import moment = require('moment/moment');
   styleUrls: ['./datetime-picker.component.scss'],
   encapsulation: ViewEncapsulation.None,
   providers: [
-    {provide: NGX_MAT_DATE_FORMATS, useValue: CUSTOM_MOMENT_FORMATS},
-    {provide: NgxMatDateAdapter, useClass: NgxMatMomentAdapter},
-    {provide: NGX_MAT_MOMENT_DATE_ADAPTER_OPTIONS, useValue: {useUtc: true}}]
+    {provide: NGX_MAT_DATE_FORMATS, useValue: CUSTOM_MOMENT_FORMATS}
+  ]
 })
 
 export class DatetimePickerComponent extends AbstractFormFieldComponent implements OnInit {

--- a/src/shared/components/palette/palette.module.ts
+++ b/src/shared/components/palette/palette.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MAT_DATE_LOCALE, MatDatepickerModule, MatFormFieldModule, MatInputModule } from '@angular/material';
-import { NgxMatDatetimePickerModule, NgxMatNativeDateModule, NgxMatTimepickerModule, } from '@angular-material-components/datetime-picker';
+import { NgxMatDatetimePickerModule, NgxMatNativeDateModule, NgxMatTimepickerModule, } from '@angular-material-components/datetime-picker/esm5/angular-material-components-datetime-picker.js';
 import { ReadTextFieldComponent } from './text/read-text-field.component';
 import { PaletteService } from './palette.service';
 import { ReadNumberFieldComponent } from './number/read-number-field.component';


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-4279


### Change description ###
updated tag, removed moment adapter and updated datepicker to es5 version eg @angular-material-components/datetime-picker/esm5/angular-material-components-datetime-picker.js to work with IE 11


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
