### PR TITLE
EUI-4226: Activity tracker polls unauthorised users continuously

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,6 @@
 ## RELEASE NOTES
 
-### Version 4.0.0-activity-tracker-unauthorised
+### Version 4.0.0-activity-tracker-unauthorised-beta
 **EUI-4226** Fixed an issue with 401/403 errors ignoring that the user is unauthorised.
 
 ### Version 4.0.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,8 @@
 ## RELEASE NOTES
 
+### Version 4.0.0-activity-tracker-unauthorised
+**EUI-4226** Fixed an issue with 401/403 errors ignoring that the user is unauthorised.
+
 ### Version 4.0.0
 **EUI-4164** Add Appellant Name Next to Caseid
 **EUI-4227** Fixed an error with show/hide not working quite right in some configurations.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "4.0.0-activity-tracker-unauthorised",
+  "version": "4.0.0-activity-tracker-unauthorised-beta",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "4.0.0-document-type-4",
+  "version": "4.0.0-activity-tracker-unauthorised",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/domain/http/http-error.model.ts
+++ b/src/shared/domain/http/http-error.model.ts
@@ -5,24 +5,24 @@ export class HttpError {
   private static readonly DEFAULT_MESSAGE = 'Something unexpected happened, our technical staff have been automatically notified';
   private static readonly DEFAULT_STATUS = 500;
 
-  timestamp: string;
-  status: number;
-  error: string;
-  exception: string;
-  message: string;
-  path: string;
-  details?: any;
-  callbackErrors?: any;
-  callbackWarnings?: any;
+  public timestamp: string;
+  public status: number;
+  public error: string;
+  public exception: string;
+  public message: string;
+  public path: string;
+  public details?: any;
+  public callbackErrors?: any;
+  public callbackWarnings?: any;
 
-  static from(response: HttpErrorResponse): HttpError {
+  public static from(response: HttpErrorResponse): HttpError {
     const error = new HttpError();
 
     // Check that the HttpErrorResponse contains an "error" object before mapping the error properties
     if (!!(response && response.error)) {
-      Object
-        .keys(error)
-        .forEach(key => error[key] = response.error.hasOwnProperty(key) && response.error[key] ? response.error[key] : error[key]);
+      Object.keys(error).forEach(key => {
+        error[key] = response.error[key] ? response.error[key] : (response[key] || error[key]);
+      });
     }
 
     return error;

--- a/src/shared/domain/http/http-error.model.ts
+++ b/src/shared/domain/http/http-error.model.ts
@@ -21,7 +21,7 @@ export class HttpError {
     // Check that the HttpErrorResponse contains an "error" object before mapping the error properties
     if (!!(response && response.error)) {
       Object.keys(error).forEach(key => {
-        error[key] = response.error[key] ? response.error[key] : (response[key] || error[key]);
+        error[key] = response.error.hasOwnProperty(key) && response.error[key] ? response.error[key] : error[key];
       });
     }
 

--- a/src/shared/services/activity/activity.service.ts
+++ b/src/shared/services/activity/activity.service.ts
@@ -1,10 +1,11 @@
-import { Injectable } from '@angular/core';
-import { Activity } from '../../domain/activity';
-import { Observable } from 'rxjs';
-import { AbstractAppConfig } from '../../../app.config';
-import { HttpService, OptionsType } from '../../services/http';
 import { HttpHeaders } from '@angular/common/http';
-import { SessionStorageService } from '../session/session-storage.service';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { AbstractAppConfig } from '../../../app.config';
+import { Activity } from '../../domain/activity';
+import { HttpService, OptionsType } from '../http';
+import { SessionStorageService } from '../session';
 
 // @dynamic
 @Injectable()
@@ -13,11 +14,17 @@ export class ActivityService {
   static get ACTIVITY_VIEW() { return 'view'; }
   static get ACTIVITY_EDIT() { return 'edit'; }
 
-  private userAuthorised;
+  private userAuthorised: boolean = undefined;
 
-  constructor(private readonly http: HttpService,
-              private readonly appConfig: AbstractAppConfig,
-              private readonly sessionStorageService: SessionStorageService) {}
+  public get isEnabled(): boolean {
+    return this.activityUrl() && this.userAuthorised;
+  }
+
+  constructor(
+    private readonly http: HttpService,
+    private readonly appConfig: AbstractAppConfig,
+    private readonly sessionStorageService: SessionStorageService
+  ) {}
 
   public getOptions(): OptionsType {
     const userDetails = JSON.parse(this.sessionStorageService.getItem('userDetails'));
@@ -30,7 +37,7 @@ export class ActivityService {
     return options;
   }
 
-  getActivities(...caseId: string[]): Observable<Activity[]> {
+  public getActivities(...caseId: string[]): Observable<Activity[]> {
     const options = this.getOptions();
     const url = this.activityUrl() + `/cases/${caseId.join(',')}/activity`;
     return this.http
@@ -38,25 +45,25 @@ export class ActivityService {
       .map(response => response);
   }
 
-  postActivity(caseId: string, activityType: String): Observable<Activity[]> {
+  public postActivity(caseId: string, activity: string): Observable<Activity[]> {
     const options = this.getOptions();
     const url = this.activityUrl() + `/cases/${caseId}/activity`;
-    let body = { activity: activityType};
+    let body = { activity };
     return this.http
       .post(url, body, options, false)
       .map(response => response);
   }
 
-  verifyUserIsAuthorized(): void {
+  public verifyUserIsAuthorized(): void {
     if (this.activityUrl() && this.userAuthorised === undefined) {
       this.getActivities(ActivityService.DUMMY_CASE_REFERENCE).subscribe(
-        data => this.userAuthorised = true,
+        () => this.userAuthorised = true,
         error => {
-            if (error.status === 403) {
-              this.userAuthorised = false;
-            } else {
-              this.userAuthorised = true
-            }
+          if ([401, 403].indexOf(error.status) > -1) {
+            this.userAuthorised = false;
+          } else {
+            this.userAuthorised = true
+          }
         }
       );
     }
@@ -64,10 +71,6 @@ export class ActivityService {
 
   private activityUrl(): string {
     return this.appConfig.getActivityUrl();
-  }
-
-  get isEnabled(): boolean {
-    return this.activityUrl() && this.userAuthorised;
   }
 
 }

--- a/src/shared/services/activity/activity.service.ts
+++ b/src/shared/services/activity/activity.service.ts
@@ -1,10 +1,11 @@
-import { HttpHeaders } from '@angular/common/http';
+import { HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { AbstractAppConfig } from '../../../app.config';
 import { Activity } from '../../domain/activity';
-import { HttpService, OptionsType } from '../http';
+import { HttpError } from '../../domain/http';
+import { HttpErrorService, HttpService, OptionsType } from '../http';
 import { SessionStorageService } from '../session';
 
 // @dynamic
@@ -18,6 +19,14 @@ export class ActivityService {
 
   public get isEnabled(): boolean {
     return this.activityUrl() && this.userAuthorised;
+  }
+
+  private static handleHttpError(response: HttpErrorResponse): HttpError {
+    const error: HttpError = HttpErrorService.convertToHttpError(response);
+    if (response.status && response.status !== error.status) {
+      error.status = response.status;
+    }
+    return error;
   }
 
   constructor(
@@ -41,7 +50,7 @@ export class ActivityService {
     const options = this.getOptions();
     const url = this.activityUrl() + `/cases/${caseId.join(',')}/activity`;
     return this.http
-      .get(url, options, false)
+      .get(url, options, false, ActivityService.handleHttpError)
       .map(response => response);
   }
 

--- a/src/shared/services/http/http.service.ts
+++ b/src/shared/services/http/http.service.ts
@@ -1,8 +1,10 @@
+import { HttpClient, HttpErrorResponse, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { HttpErrorService } from './http-error.service';
 import { catchError } from 'rxjs/operators';
-import { HttpClient, HttpErrorResponse, HttpHeaders, HttpParams } from '@angular/common/http';
+
+import { HttpError } from '../../domain/http';
+import { HttpErrorService } from './http-error.service';
 
 @Injectable()
 export class HttpService {
@@ -23,12 +25,16 @@ export class HttpService {
    * @see UrlResolverService
    */
 
-  public get(url: string, options?: OptionsType, redirectIfNotAuthorised = true): Observable<any> {
+  public get(url: string, options?: OptionsType, redirectIfNotAuthorised = true, errorHandler?: (error: HttpErrorResponse) => HttpError): Observable<any> {
     return this.httpclient
       .get(url, this.setDefaultValue(options))
       .pipe(
         catchError((res: HttpErrorResponse) => {
-          return this.httpErrorService.handle(res, redirectIfNotAuthorised);
+          let error: HttpErrorResponse | HttpError = res;
+          if (typeof errorHandler === 'function') {
+            error = errorHandler(res);
+          }
+          return this.httpErrorService.handle(error, redirectIfNotAuthorised);
         })
       );
   }

--- a/src/shared/services/http/http.service.ts
+++ b/src/shared/services/http/http.service.ts
@@ -25,7 +25,11 @@ export class HttpService {
    * @see UrlResolverService
    */
 
-  public get(url: string, options?: OptionsType, redirectIfNotAuthorised = true, errorHandler?: (error: HttpErrorResponse) => HttpError): Observable<any> {
+  public get(
+    url: string,
+    options?: OptionsType,
+    redirectIfNotAuthorised = true,
+    errorHandler?: (error: HttpErrorResponse) => HttpError): Observable<any> {
     return this.httpclient
       .get(url, this.setDefaultValue(options))
       .pipe(


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-4226


### Change description ###
Fixed an issue with the error message coming from the Activity Tracker coming back with a 403 but it getting stripped out in the `HttpError.from(...)` method.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```


### Note ###
Linked to https://github.com/hmcts/rpx-xui-webapp/pull/1200.