### PR TITLE
EUI-4404: Read only display is not working for complex type with Collection of Document

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "4.3.1-switch-tabs",
+  "version": "4.5.0-eui-4404-readonly-complex-type-fix",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/commons/constants.ts
+++ b/src/shared/commons/constants.ts
@@ -3,5 +3,6 @@ import { Injectable } from '@angular/core';
 @Injectable()
 export class Constants {
   static readonly MANDATORY: string = 'MANDATORY';
+  static readonly READONLY: string = 'READONLY';
   static readonly REGEX_WHITESPACES: string = '^[^ ]+(?:\\s+[^ ]+)*$';
 }

--- a/src/shared/components/palette/document/write-document-field.component.ts
+++ b/src/shared/components/palette/document/write-document-field.component.ts
@@ -194,6 +194,10 @@ export class WriteDocumentFieldComponent extends AbstractFieldWriteComponent imp
     }
   }
 
+  public isReadOnlyComponent(): boolean {
+    return this.caseField.display_context && this.caseField.display_context === Constants.READONLY;
+  }
+
   private initDialog(): void {
     this.dialogConfig = new MatDialogConfig();
     this.dialogConfig.disableClose = true;

--- a/src/shared/components/palette/document/write-document-field.html
+++ b/src/shared/components/palette/document/write-document-field.html
@@ -11,10 +11,8 @@
   </div>
 
   <div style='position:relative'>
-
     <div [id]="createElementId('fileInputWrapper')" (click)="fileSelectEvent()"></div>
-    <input class="form-control bottom-30" [id]="id()" type="file" (keydown.Tab)="fileValidationsOnTab()" (change)="fileChangeEvent($event)"
-           accept="{{caseField.field_type.regular_expression}}" #fileInput/>
+    <input class="form-control bottom-30" [id]="id()" type="file" (keydown.Tab)="fileValidationsOnTab()" [disabled]="isReadOnlyComponent()" (change)="fileChangeEvent($event)" accept="{{caseField.field_type.regular_expression}}" #fileInput/>
   </div>
 </div>
 <div class="form-group bottom-30">


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-4404

### Change description ###
added disabled attribute to file upload element when display context is readonly.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
