### PR TITLE
EUI-4849: Create Case Flag - "Search for a language interpreter" step validation

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,7 @@
 ## RELEASE NOTES
+### Version 4.13.1-case-flags-search-for-language-interpreter-step-validation
+**EUI-4849** Add validation to language search and manual language inputs of the "Search for a language interpreter" step
+
 ### Version 4.13.1-case-flags-search-for-language-interpreter-step-integration
 **EUI-5654** Integrate "Search for a language interpreter" step with Reference Data list of values for selected flag types
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "4.13.1-case-flags-search-for-language-interpreter-step-integration",
+  "version": "4.13.1-case-flags-search-for-language-interpreter-step-validation",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/components/palette/case-flag/components/search-language-interpreter/search-language-interpreter.component.html
+++ b/src/shared/components/palette/case-flag/components/search-language-interpreter/search-language-interpreter.component.html
@@ -1,18 +1,22 @@
 <h2 class="govuk-heading-l">{{caseFlagWizardStepTitle.SEARCH_LANGUAGE_INTERPRETER}}</h2>
 <div class="form-group" [formGroup]="formGroup">
-  <div class="auto-complete-container">
-    <p>{{searchLanguageInterpreterStep.TITLE_DESCRIPTION}}</p>
-    <input aria-label="Language search box" matInput [formControlName]="languageSearchTermControlName" [matAutocomplete]="autoSearchLanguage"
-      class="govuk-input search-language__input" type="text">
-    <mat-autocomplete class="mat-autocomplete-panel-extend" autoActiveFirstOption #autoSearchLanguage="matAutocomplete"
-      [displayWith]="displayLanguage">
-      <mat-option *ngFor="let language of filteredLanguages$ | async" [value]="language">
-        {{language.value}}
-      </mat-option>
-      <mat-option *ngIf="noResults && searchTerm && searchTerm.length >= minSearchCharacters">No results found</mat-option>
-    </mat-autocomplete>
-  </div>
-  <div class="govuk-form-group">
+  <div class="govuk-form-group" [ngClass]="{'form-group-error': languageNotSelectedErrorMessage}">
+    <div class="auto-complete-container">
+      <p>{{searchLanguageInterpreterStep.TITLE_DESCRIPTION}}</p>
+      <div id="language-not-selected-error-message" class="govuk-error-message"
+        *ngIf="languageNotSelectedErrorMessage">
+        <span class="govuk-visually-hidden">Error:</span> {{languageNotSelectedErrorMessage}}
+      </div>
+      <input aria-label="Language search box" matInput [formControlName]="languageSearchTermControlName" [matAutocomplete]="autoSearchLanguage"
+        class="govuk-input search-language__input" type="text">
+      <mat-autocomplete class="mat-autocomplete-panel-extend" autoActiveFirstOption #autoSearchLanguage="matAutocomplete"
+        [displayWith]="displayLanguage">
+        <mat-option *ngFor="let language of filteredLanguages$ | async" [value]="language">
+          {{language.value}}
+        </mat-option>
+        <mat-option *ngIf="noResults && searchTerm && searchTerm.length >= minSearchCharacters" disabled>No results found</mat-option>
+      </mat-autocomplete>
+    </div>
     <div class="govuk-checkboxes govuk-checkboxes--small govuk-checkboxes--conditional" data-module="govuk-checkboxes">
       <div class="govuk-radios__item">
         <input class="govuk-checkboxes__input" id="enter-language-manually" name="enter-language-manually" type="checkbox" (change)="onEnterLanguageManually($event)">
@@ -20,9 +24,17 @@
           {{searchLanguageInterpreterStep.CHECKBOX_LABEL}}
         </label>
       </div>
-      <div class="govuk-radios__conditional" [ngClass]="{'hidden': !isCheckboxEnabled}">
-        <div class="govuk-form-group">
+      <div class="govuk-radios__conditional" *ngIf="isCheckboxEnabled">
+        <div class="govuk-form-group" [ngClass]="{'form-group-error': languageNotEnteredErrorMessage || languageCharLimitErrorMessage }">
           <label class="govuk-label" for="manual-language-entry">{{searchLanguageInterpreterStep.INPUT_LABEL}}</label>
+          <div id="language-not-entered-error-message" class="govuk-error-message"
+            *ngIf="languageNotEnteredErrorMessage">
+            <span class="govuk-visually-hidden">Error:</span> {{languageNotEnteredErrorMessage}}
+          </div>
+          <div id="language-char-limit-error-message" class="govuk-error-message"
+            *ngIf="languageCharLimitErrorMessage">
+            <span class="govuk-visually-hidden">Error:</span> {{languageCharLimitErrorMessage}}
+          </div>
           <input class="govuk-input govuk-input--width-20" id="manual-language-entry" [name]="manualLanguageEntryControlName" type="text"
             [formControlName]="manualLanguageEntryControlName">
         </div>

--- a/src/shared/components/palette/case-flag/enums/index.ts
+++ b/src/shared/components/palette/case-flag/enums/index.ts
@@ -2,6 +2,7 @@ export * from './add-comments-error-message.enum';
 export * from './add-comments-step.enum';
 export * from './case-flag-status.enum';
 export * from './case-flag-wizard-step-title.enum';
+export * from './search-language-interpreter-error-message.enum';
 export * from './search-language-interpreter-step.enum';
 export * from './select-flag-location-error-message.enum';
 export * from './select-flag-type-error-message.enum';

--- a/src/shared/components/palette/case-flag/enums/search-language-interpreter-error-message.enum.ts
+++ b/src/shared/components/palette/case-flag/enums/search-language-interpreter-error-message.enum.ts
@@ -1,0 +1,4 @@
+export enum SearchLanguageInterpreterErrorMessage {
+  LANGUAGE_NOT_ENTERED = 'Enter the language that will need to be interpreted',
+  LANGUAGE_CHAR_LIMIT_EXCEEDED = 'You can enter up to 80 characters for the required language'
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
[EUI-4849](https://tools.hmcts.net/jira/browse/EUI-4849)

### Change description ###
Add validation to language search and manual language inputs of the "Search for a language interpreter" step.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
