### PR TITLE
EUI-5657: Create Case Flag - "Search for a language interpreter" step validation

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,7 @@
 ## RELEASE NOTES
+### Version 4.13.1-case-flags-language-interpreter-dual-entry-error-2
+**EUI-5657** Fix error styling and HTML structure for page title and hint text
+
 ### Version 4.13.1-case-flags-language-interpreter-dual-entry-error
 **EUI-5657** Additional validation for "Search for a language interpreter" step, covering dual language entry error scenario
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,7 @@
 ## RELEASE NOTES
+### Version 4.13.1-case-flags-language-interpreter-dual-entry-error
+**EUI-5657** Additional validation for "Search for a language interpreter" step, covering dual language entry error scenario
+
 ### Version 4.13.1-case-flags-search-for-language-interpreter-step-validation
 **EUI-4849** Add validation to language search and manual language inputs of the "Search for a language interpreter" step
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "4.13.1-case-flags-language-interpreter-dual-entry-error",
+  "version": "4.13.1-case-flags-language-interpreter-dual-entry-error-2",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "4.13.1-case-flags-search-for-language-interpreter-step-validation",
+  "version": "4.13.1-case-flags-language-interpreter-dual-entry-error",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/components/palette/case-flag/components/search-language-interpreter/search-language-interpreter.component.html
+++ b/src/shared/components/palette/case-flag/components/search-language-interpreter/search-language-interpreter.component.html
@@ -7,6 +7,10 @@
         *ngIf="languageNotSelectedErrorMessage">
         <span class="govuk-visually-hidden">Error:</span> {{languageNotSelectedErrorMessage}}
       </div>
+      <div id="language-entered-in-both-fields-error-message" class="govuk-error-message"
+        *ngIf="languageEnteredInBothFieldsErrorMessage">
+        <span class="govuk-visually-hidden">Error:</span> {{languageEnteredInBothFieldsErrorMessage}}
+      </div>
       <input aria-label="Language search box" matInput [formControlName]="languageSearchTermControlName" [matAutocomplete]="autoSearchLanguage"
         class="govuk-input search-language__input" type="text">
       <mat-autocomplete class="mat-autocomplete-panel-extend" autoActiveFirstOption #autoSearchLanguage="matAutocomplete"
@@ -19,7 +23,8 @@
     </div>
     <div class="govuk-checkboxes govuk-checkboxes--small govuk-checkboxes--conditional" data-module="govuk-checkboxes">
       <div class="govuk-radios__item">
-        <input class="govuk-checkboxes__input" id="enter-language-manually" name="enter-language-manually" type="checkbox" (change)="onEnterLanguageManually($event)">
+        <input class="govuk-checkboxes__input" id="enter-language-manually" name="enter-language-manually" type="checkbox"
+          (change)="onEnterLanguageManually($event)">
         <label class="govuk-label govuk-checkboxes__label" for="enter-language-manually">
           {{searchLanguageInterpreterStep.CHECKBOX_LABEL}}
         </label>

--- a/src/shared/components/palette/case-flag/components/search-language-interpreter/search-language-interpreter.component.html
+++ b/src/shared/components/palette/case-flag/components/search-language-interpreter/search-language-interpreter.component.html
@@ -1,8 +1,13 @@
-<h2 class="govuk-heading-l">{{caseFlagWizardStepTitle.SEARCH_LANGUAGE_INTERPRETER}}</h2>
 <div class="form-group" [formGroup]="formGroup">
-  <div class="govuk-form-group" [ngClass]="{'form-group-error': languageNotSelectedErrorMessage}">
+  <div class="govuk-form-group" [ngClass]="{'form-group-error': languageNotSelectedErrorMessage || languageEnteredInBothFieldsErrorMessage}">
+    <h1 class="govuk-label-wrapper"><label class="govuk-label govuk-label--l" [for]="languageSearchTermControlName">
+      {{caseFlagWizardStepTitle.SEARCH_LANGUAGE_INTERPRETER}}
+      </label>
+    </h1>
+    <div id="language-search-box-hint" class="govuk-hint">
+      {{searchLanguageInterpreterStep.TITLE_DESCRIPTION}}
+    </div>
     <div class="auto-complete-container">
-      <p>{{searchLanguageInterpreterStep.TITLE_DESCRIPTION}}</p>
       <div id="language-not-selected-error-message" class="govuk-error-message"
         *ngIf="languageNotSelectedErrorMessage">
         <span class="govuk-visually-hidden">Error:</span> {{languageNotSelectedErrorMessage}}

--- a/src/shared/components/palette/case-flag/components/search-language-interpreter/search-language-interpreter.component.ts
+++ b/src/shared/components/palette/case-flag/components/search-language-interpreter/search-language-interpreter.component.ts
@@ -37,6 +37,7 @@ export class SearchLanguageInterpreterComponent implements OnInit {
   public languageNotSelectedErrorMessage = '';
   public languageNotEnteredErrorMessage = '';
   public languageCharLimitErrorMessage = '';
+  public languageEnteredInBothFieldsErrorMessage = '';
   public noResults = false;
   private readonly languageMaxCharLimit = 80;
 
@@ -79,6 +80,12 @@ export class SearchLanguageInterpreterComponent implements OnInit {
 
   public onEnterLanguageManually(event: Event): void {
     this.isCheckboxEnabled = (event.target as HTMLInputElement).checked;
+
+    // If the checkbox is disabled, i.e. unchecked, then clear the manual language entry FormControl of any value to
+    // prevent it being retained even when the field itself is hidden
+    if (!this.isCheckboxEnabled) {
+      this.formGroup.get(this.manualLanguageEntryControlName).setValue(null);
+    }
   }
 
   public displayLanguage(language?: Language): string | undefined {
@@ -89,6 +96,7 @@ export class SearchLanguageInterpreterComponent implements OnInit {
     this.languageNotSelectedErrorMessage = null;
     this.languageNotEnteredErrorMessage = null;
     this.languageCharLimitErrorMessage = null;
+    this.languageEnteredInBothFieldsErrorMessage = null;
     this.errorMessages = [];
     // Checkbox not enabled means the user has opted to search for and select the language
     if (!this.isCheckboxEnabled && !this.formGroup.get(this.languageSearchTermControlName).value) {
@@ -114,6 +122,14 @@ export class SearchLanguageInterpreterComponent implements OnInit {
           title: '',
           description: SearchLanguageInterpreterErrorMessage.LANGUAGE_CHAR_LIMIT_EXCEEDED,
           fieldId: this.manualLanguageEntryControlName
+        });
+      } else if (this.formGroup.get(this.languageSearchTermControlName).value) {
+        // Language entry is permitted in only one field at a time
+        this.languageEnteredInBothFieldsErrorMessage = SearchLanguageInterpreterErrorMessage.LANGUAGE_ENTERED_IN_BOTH_FIELDS;
+        this.errorMessages.push({
+          title: '',
+          description: SearchLanguageInterpreterErrorMessage.LANGUAGE_ENTERED_IN_BOTH_FIELDS,
+          fieldId: this.languageSearchTermControlName
         });
       }
     }

--- a/src/shared/components/palette/case-flag/enums/search-language-interpreter-error-message.enum.ts
+++ b/src/shared/components/palette/case-flag/enums/search-language-interpreter-error-message.enum.ts
@@ -1,4 +1,5 @@
 export enum SearchLanguageInterpreterErrorMessage {
   LANGUAGE_NOT_ENTERED = 'Enter the language that will need to be interpreted',
-  LANGUAGE_CHAR_LIMIT_EXCEEDED = 'You can enter up to 80 characters for the required language'
+  LANGUAGE_CHAR_LIMIT_EXCEEDED = 'You can enter up to 80 characters for the required language',
+  LANGUAGE_ENTERED_IN_BOTH_FIELDS = 'The language can only be entered in one of the fields'
 }

--- a/src/shared/components/palette/case-flag/read-case-flag-field.component.ts
+++ b/src/shared/components/palette/case-flag/read-case-flag-field.component.ts
@@ -4,7 +4,6 @@ import { CaseTab } from '../../../domain';
 import { FieldsUtils } from '../../../services/fields';
 import { AbstractFieldReadComponent } from '../base-field/abstract-field-read.component';
 import { FlagDetail, Flags } from './domain';
-import { CaseFlagStatus } from './enums';
 
 @Component({
   selector: 'ccd-read-case-flag-field',


### PR DESCRIPTION
### JIRA link (if applicable) ###
[EUI-5647](https://tools.hmcts.net/jira/browse/EUI-5657)

### Change description ###
Add validation to prevent both language selection and manual language entry at the same time. Also ensure manual language entry value is cleared if "Enter the language manually" checkbox is unchecked.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
