### PR TITLE
EUI-7116: Fix for empty case-level Flags field missing

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,7 @@
 ## RELEASE NOTES
+### Version 6.10.0-case-flags-fix-for-empty-case-level-flags-field
+**EUI-7116** Fix to ensure a "caseFlags" case-level Flags field with an empty value is retained (it will be empty initially because no party name is required)
+
 ### Version 4.18.10-revert-erroneous-html-tag-change
 **EUI-6551** Fix incorrect alignment of tabular display of non built-in CCD complex fields on tabs, caused by an erroneous HTML tag change for the Case Flags feature
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "6.10.0-case-flags-master",
+  "version": "6.10.0-case-flags-fix-for-empty-case-level-flags-field",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/components/palette/case-flag/write-case-flag-field.component.spec.ts
+++ b/src/shared/components/palette/case-flag/write-case-flag-field.component.spec.ts
@@ -190,16 +190,8 @@ describe('WriteCaseFlagFieldComponent', () => {
                 id: 'Flags',
                 type: 'Complex'
               } as FieldType,
-              formatted_value: {
-                partyName: null,
-                roleOnCase: null,
-                details: []
-              },
-              value: {
-                partyName: null,
-                roleOnCase: null,
-                details: []
-              }
+              formatted_value: {},
+              value: {}
             }
           ] as CaseField[]
         }
@@ -418,8 +410,8 @@ describe('WriteCaseFlagFieldComponent', () => {
     expect(component.flagsData[1].flags.details[1].dateTimeCreated).toEqual(new Date(caseFlag1DetailsValue1.dateTimeCreated));
     expect(component.flagsData[1].flags.details[1].hearingRelevant).toBe(true);
     expect(component.flagsData[2].flags.flagsCaseFieldId).toEqual(caseFlagsFieldId);
-    expect(component.flagsData[2].flags.partyName).toBeNull();
-    expect(component.flagsData[2].flags.roleOnCase).toBeNull();
+    expect(component.flagsData[2].flags.partyName).toBeUndefined();
+    expect(component.flagsData[2].flags.roleOnCase).toBeUndefined();
     expect(component.flagsData[2].flags.details).toBeNull();
   });
 

--- a/src/shared/services/fields/fields.utils.ts
+++ b/src/shared/services/fields/fields.utils.ts
@@ -14,6 +14,7 @@ import { FormatTranslatorService } from '../case-fields/format-translator.servic
 @Injectable()
 export class FieldsUtils {
 
+  private static readonly caseLevelCaseFlagsFieldId = 'caseFlags';
   private static readonly currencyPipe: CurrencyPipe = new CurrencyPipe('en-GB');
   private static readonly datePipe: DatePipe = new DatePipe(new FormatTranslatorService());
   // EUI-4244. 3 dashes instead of 1 to make this less likely to clash with a real field.
@@ -381,8 +382,11 @@ export class FieldsUtils {
           // object immediately
           if (FieldsUtils.isFlagsCaseField(caseField)) {
             // If the Flags CaseField has a value, it is a root-level Complex field; if it does not, it is a Flags
-            // CaseField that is a sub-field within another Complex field, so use the currentValue value (if any) instead
-            if (caseField.value && FieldsUtils.isNonEmptyObject(caseField.value)) {
+            // CaseField that is a sub-field within another Complex field, so use the currentValue value (if any)
+            // instead. The exception to this is the "caseFlags" Flags CaseField, which will have an empty object value
+            // initially, because no party name is required
+            if (caseField.value && FieldsUtils.isNonEmptyObject(caseField.value) ||
+              caseField.id === this.caseLevelCaseFlagsFieldId) {
               flags.push(this.mapCaseFieldToFlagsWithFormGroupPathObject(caseField, pathToFlagsFormGroup));
             } else if (currentValue && FieldsUtils.isNonEmptyObject(currentValue)) {
               pathToFlagsFormGroup += `.${caseField.id}`;


### PR DESCRIPTION
### JIRA link (if applicable) ###
[EUI-7116](https://tools.hmcts.net/jira/browse/EUI-7116)

### Change description ###
Fix to ensure a `caseFlags` case-level Flags field with an empty value is retained (empty initially because no party name is required).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
