### PR TITLE
EUI-7210/EUI-7225: Case Flags defect fixes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,8 @@
 ## RELEASE NOTES
+### Version 6.10.0-rc4
+**EUI-7210** Fix mapping of case field to flags object to handle `null` or `undefined` CaseField `value` property
+**EUI-7225** Fix to display party role (if provided) alongside party name for party-level flags options on "Select flag location" page
+
 ### Version 6.10.0-rc3
 **EUI-7116** Re-tag for release
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "6.10.0-rc3",
+  "version": "6.10.0-rc4",
   "engines": {
     "yarn": "^1.12.3",
     "npm": "^5.6.0"

--- a/src/shared/components/palette/case-flag/components/select-flag-location/select-flag-location.component.html
+++ b/src/shared/components/palette/case-flag/components/select-flag-location/select-flag-location.component.html
@@ -14,7 +14,17 @@
         <div class="govuk-radios__item" *ngFor="let flagsInstance of filteredFlagsData; index as i">
           <input class="govuk-radios__input" id="flag-location-{{i}}" [name]="selectedLocationControlName"
             type="radio" [value]="flagsInstance" [formControlName]="selectedLocationControlName"/>
-          <label class="govuk-label govuk-radios__label" for="flag-location-{{i}}">{{flagsInstance.flags.partyName || caseLevelFlagLabel}}</label>
+          <label class="govuk-label govuk-radios__label" for="flag-location-{{i}}">
+            <ng-container *ngIf="flagsInstance.flags.partyName">
+              {{flagsInstance.flags.partyName}}
+              <ng-container *ngIf="flagsInstance.flags.roleOnCase">
+                ({{flagsInstance.flags.roleOnCase}})
+              </ng-container>
+            </ng-container>
+            <ng-container *ngIf="!flagsInstance.flags.partyName">
+              {{caseLevelFlagLabel}}
+            </ng-container>
+          </label>
         </div>
       </div>
     </fieldset>

--- a/src/shared/components/palette/case-flag/components/select-flag-location/select-flag-location.component.spec.ts
+++ b/src/shared/components/palette/case-flag/components/select-flag-location/select-flag-location.component.spec.ts
@@ -40,6 +40,7 @@ describe('SelectFlagLocationComponent', () => {
       flags: {
         flagsCaseFieldId: 'Party2Flags',
         partyName: 'Tom Atin',
+        roleOnCase: 'Claimant',
         details: [
           {
             name: 'Flag 3',
@@ -131,9 +132,10 @@ describe('SelectFlagLocationComponent', () => {
     expect(component.formGroup.get(component.selectedLocationControlName).value).toEqual(flagsData[2]);
     const radioButtonLabelElements = nativeElement.querySelectorAll('.govuk-radios__label');
     expect(radioButtonLabelElements.length).toBe(3);
-    expect(radioButtonLabelElements[0].textContent).toEqual(flagsData[0].flags.partyName);
-    expect(radioButtonLabelElements[1].textContent).toEqual(flagsData[1].flags.partyName);
-    expect(radioButtonLabelElements[2].textContent).toEqual(component.caseLevelFlagLabel);
+    expect(radioButtonLabelElements[0].textContent).toContain(flagsData[0].flags.partyName);
+    expect(radioButtonLabelElements[1].textContent).toContain(flagsData[1].flags.partyName);
+    expect(radioButtonLabelElements[1].textContent).toContain(`(${flagsData[1].flags.roleOnCase})`);
+    expect(radioButtonLabelElements[2].textContent).toContain(component.caseLevelFlagLabel);
   });
 
   it('should emit to parent if the validation succeeds', () => {

--- a/src/shared/services/fields/fields.utils.spec.ts
+++ b/src/shared/services/fields/fields.utils.spec.ts
@@ -620,4 +620,101 @@ describe('FieldsUtils', () => {
       expect(FieldsUtils.isFlagsFieldType(fieldType)).toBe(true);
     });
   });
+
+  describe('extractFlagsDataFromCaseField() function test', () => {
+    it('should extract flags data from a root-level Flags case field', () => {
+      const caseField = {
+        id: 'party1Flags',
+        field_type: {
+          id: 'Flags',
+          type: 'Complex'
+        } as FieldType,
+        value: {
+          partyName: 'Party 1',
+          roleOnCase: null,
+          details: []
+        }
+      } as CaseField;
+      expect(FieldsUtils.extractFlagsDataFromCaseField([], caseField, caseField.id, caseField)).toEqual([
+        {
+          caseField,
+          pathToFlagsFormGroup: caseField.id,
+          flags: {
+            flagsCaseFieldId: caseField.id,
+            partyName: 'Party 1',
+            roleOnCase: null,
+            details: null
+          }
+        }
+      ]);
+    });
+
+    it('should not fail if the root-level Flags case field is the special "caseFlags" field and its value is an empty object', () => {
+      const caseField = {
+        id: 'caseFlags',
+        field_type: {
+          id: 'Flags',
+          type: 'Complex'
+        } as FieldType,
+        value: {}
+      } as CaseField;
+      expect(FieldsUtils.extractFlagsDataFromCaseField([], caseField, caseField.id, caseField)).toEqual([
+        {
+          caseField,
+          pathToFlagsFormGroup: caseField.id,
+          flags: {
+            flagsCaseFieldId: caseField.id,
+            partyName: undefined,
+            roleOnCase: undefined,
+            details: null
+          }
+        }
+      ]);
+    });
+
+    it('should not fail if the root-level Flags case field is the special "caseFlags" field and its value is null', () => {
+      const caseField = {
+        id: 'caseFlags',
+        field_type: {
+          id: 'Flags',
+          type: 'Complex'
+        } as FieldType,
+        value: null
+      } as CaseField;
+      expect(FieldsUtils.extractFlagsDataFromCaseField([], caseField, caseField.id, caseField)).toEqual([
+        {
+          caseField,
+          pathToFlagsFormGroup: caseField.id,
+          flags: {
+            flagsCaseFieldId: caseField.id,
+            partyName: null,
+            roleOnCase: null,
+            details: null
+          }
+        }
+      ]);
+    });
+
+    it('should not fail if the root-level Flags case field is the special "caseFlags" field and its value is undefined', () => {
+      const caseField = {
+        id: 'caseFlags',
+        field_type: {
+          id: 'Flags',
+          type: 'Complex'
+        } as FieldType
+      } as CaseField;
+      expect(FieldsUtils.extractFlagsDataFromCaseField([], caseField, caseField.id, caseField)).toEqual([
+        {
+          caseField,
+          pathToFlagsFormGroup: caseField.id,
+          flags: {
+            flagsCaseFieldId: caseField.id,
+            partyName: null,
+            roleOnCase: null,
+            details: null
+          }
+        }
+      ]);
+    });
+  });
 });

--- a/src/shared/services/fields/fields.utils.ts
+++ b/src/shared/services/fields/fields.utils.ts
@@ -460,9 +460,9 @@ export class FieldsUtils {
       return {
         flags: {
           flagsCaseFieldId: id,
-          partyName: value['partyName'],
-          roleOnCase: value['roleOnCase'],
-          details: value['details'] && value['details'].length > 0
+          partyName: value ? value['partyName'] : null,
+          roleOnCase: value ? value['roleOnCase'] : null,
+          details: value && value['details'] && value['details'].length > 0
             ? (value['details'] as any[]).map(detail => {
               return Object.assign({}, ...Object.keys(detail.value).map(k => {
                 // The id property set below will be null for a new case flag, and a unique id returned from CCD when


### PR DESCRIPTION
### JIRA link (if applicable) ###
[EUI-7210](https://tools.hmcts.net/jira/browse/EUI-7210)
[EUI-7225](https://tools.hmcts.net/jira/browse/EUI-7225)

### Change description ###
EUI-7210: Fix mapping of case field to flags object to handle `null` or `undefined` CaseField `value` property; EUI-7225: Fix to display party role (if provided) alongside party name for party-level flags options on "Select flag location" page.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
