### PR TITLE
EUI-7417: Case File View - Disable document move functionality

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,7 @@
 ## RELEASE NOTES
+### Version 5.0.50-case-file-view-restrict-document-move
+**EUI-7417** Set boolean flag allowing Case File View document move functionality in readonly mode to `false`
+
 ### Version 5.0.50-sscs-sit-release
 **EUI-7564** SSCS SIT release
 
@@ -11,7 +14,7 @@
 ### Version 5.0.46-case-file-view-styling-fixes
 **EUI-7481** Case file view styling issues
 
-### Version 5.0.45-fix-case-acccess-table
+### Version 5.0.45-fix-case-access-table
 **EUI-7454** Fixed table alignment on case view
 
 ### Version 5.0.44-case-flags-integration-fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "5.0.50-sscs-sit-release",
+  "version": "5.0.50-case-file-view-restrict-document-move",
   "engines": {
     "yarn": "^1.22.15",
     "npm": "^8.10.0"

--- a/projects/ccd-case-ui-toolkit/package.json
+++ b/projects/ccd-case-ui-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "5.0.50-sscs-sit-release",
+  "version": "5.0.50-case-file-view-restrict-document-move",
   "engines": {
     "yarn": "^1.22.15",
     "npm": "^8.10.0"

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-file-view/case-file-view-field-read.component.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-file-view/case-file-view-field-read.component.ts
@@ -7,5 +7,5 @@ import { CaseFileViewFieldComponent } from './case-file-view-field.component';
   styleUrls: ['./case-file-view-field.component.scss'],
 })
 export class CaseFileViewFieldReadComponent extends CaseFileViewFieldComponent {
-  public allowMoving = true;
+  public allowMoving = false;
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
[EUI-7417](https://tools.hmcts.net/jira/browse/EUI-7417)

### Change description ###
Ensure document move functionality is disabled when Case File View component is in readonly mode.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
