### PR TITLE
EUI-7796: Case Flags - Fix flag types retrieval for case types with multiple HMCTS service codes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,7 @@
 ## RELEASE NOTES
+### Version 6.13.0-rc11
+**EUI-7796** Re-tag for Release 6.13.0
+
 ### Version 6.13.0-rc7
 **EUI-7796** Fix flag types retrieval to use HMCTSServiceId from supplementary data in the first instance (if available); this caters for case types that are associated with multiple HMCTS service codes
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,8 +1,6 @@
 ## RELEASE NOTES
-
 ### Version 6.13.0-rc7
 **EUI-7796** Fix flag types retrieval to use HMCTSServiceId from supplementary data in the first instance (if available); this caters for case types that are associated with multiple HMCTS service codes
-
 
 ### Version 5.0.50-case-flags-multiple-service-codes-for-jurisdiction
 **EUI-7529** Fix flag types retrieval to use HMCTS service code associated with case type ID, falling back on jurisdiction only if the case type ID is not recognised, since there could be multiple service codes per jurisdiction

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,7 @@
 ## RELEASE NOTES
+### Version 6.13.0-rc7
+**EUI-7796** Fix flag types retrieval to use HMCTSServiceId from supplementary data in the first instance (if available); this caters for case types that are associated with multiple HMCTS service codes
+
 ### Version 5.0.50-case-flags-multiple-service-codes-for-jurisdiction
 **EUI-7529** Fix flag types retrieval to use HMCTS service code associated with case type ID, falling back on jurisdiction only if the case type ID is not recognised, since there could be multiple service codes per jurisdiction
 
@@ -13,14 +16,12 @@
 ### Version 5.0.46-fix-case-link
 **EUI-7521** Fix case link hyperlink on applications tab
 
-### Version 5.0.46-fix-case-link
-**EUI-7521** Fix case link hyperlink on applications tab
-
 ### Version 5.0.46-case-file-view-media-viewer-scrolling-behaviour
 **EUI-7496** Fix incorrect Media Viewer vertical scrolling behaviour beyond Case File View container bottom boundary
 
 ### Version 5.0.46-case-file-view-styling-fixes
 **EUI-7481** Case file view styling issues
+
 ### Version 5.0.45-fix-case-acccess-table
 **EUI-7454** Fixed table alignment on case view
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "6.13.0-rc10",
+  "version": "6.13.0-rc11",
   "engines": {
     "yarn": "^1.22.15",
     "npm": "^8.10.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "6.13.0-rc6",
+  "version": "6.13.0-rc7",
   "engines": {
     "yarn": "^1.22.15",
     "npm": "^8.10.0"

--- a/projects/ccd-case-ui-toolkit/package.json
+++ b/projects/ccd-case-ui-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "6.13.0-rc10",
+  "version": "6.13.0-rc11",
   "engines": {
     "yarn": "^1.22.15",
     "npm": "^8.10.0"

--- a/projects/ccd-case-ui-toolkit/package.json
+++ b/projects/ccd-case-ui-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "6.13.0-rc6",
+  "version": "6.13.0-rc7",
   "engines": {
     "yarn": "^1.22.15",
     "npm": "^8.10.0"

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/select-flag-type/select-flag-type.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/select-flag-type/select-flag-type.component.spec.ts
@@ -351,6 +351,18 @@ describe('SelectFlagTypeComponent', () => {
   });
 
   it('should retrieve the list of flag types for the specified case type ID', () => {
+    // Need to reset caseFlagRefdataService spy object method call because component.hmctsServiceId is undefined on the
+    // first call of ngOnInit() triggered by fixture.detectChanges() - this means getHmctsServiceDetailsByCaseType() gets
+    // called even though it's not expected to be
+    caseFlagRefdataService.getHmctsServiceDetailsByCaseType.calls.reset();
+    component.hmctsServiceId = 'ABC1';
+    component.ngOnInit();
+    expect(caseFlagRefdataService.getCaseFlagsRefdata).toHaveBeenCalledWith('ABC1', RefdataCaseFlagType.PARTY);
+    expect(caseFlagRefdataService.getHmctsServiceDetailsByCaseType).not.toHaveBeenCalled();
+    expect(component.flagTypes).toEqual(flagTypes[0].childFlags);
+  });
+
+  it('should retrieve the list of flag types for the specified case type ID', () => {
     component.ngOnInit();
     expect(caseFlagRefdataService.getHmctsServiceDetailsByCaseType).toHaveBeenCalledWith(caseTypeId);
     expect(caseFlagRefdataService.getHmctsServiceDetailsByServiceName).not.toHaveBeenCalled();

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/write-case-flag-field.component.html
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/write-case-flag-field.component.html
@@ -22,6 +22,7 @@
     </ng-container>
     <ng-container *ngSwitchCase="caseFlagFieldState.FLAG_TYPE">
       <ccd-select-flag-type [formGroup]="caseFlagParentFormGroup" [jurisdiction]="jurisdiction" [caseTypeId]="caseTypeId"
+        [hmctsServiceId]="hmctsServiceId"
         (caseFlagStateEmitter)="onCaseFlagStateEmitted($event)"
         (flagCommentsOptionalEmitter)="onFlagCommentsOptionalEmitted($event)"></ccd-select-flag-type>
     </ng-container>

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/write-case-flag-field.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/write-case-flag-field.component.spec.ts
@@ -192,7 +192,10 @@ xdescribe('WriteCaseFlagFieldComponent', () => {
               formatted_value: null,
               value: null
             }
-          ] as CaseField[]
+          ] as CaseField[],
+          supplementary_data: {
+            HMCTSServiceId: 'BBA3'
+          }
         }
       }
     }
@@ -340,6 +343,12 @@ xdescribe('WriteCaseFlagFieldComponent', () => {
     expect(component.setDisplayContextParameterUpdate).toHaveBeenCalledWith(mockRoute.snapshot.data.eventTrigger.case_fields);
   });
 
+  it('should set jurisdiction, caseTypeId, and hmctsServiceId properties from the snapshot data', () => {
+    expect(component.jurisdiction).toEqual('SSCS');
+    expect(component.caseTypeId).toEqual('TEST');
+    expect(component.hmctsServiceId).toEqual('BBA3');
+  });
+
   it('should set isDisplayContextParameterUpdate boolean correctly', () => {
     const caseFields: CaseField[] = [
       flagLauncherCaseField
@@ -451,11 +460,11 @@ xdescribe('WriteCaseFlagFieldComponent', () => {
     component.selectedFlagsLocation = newFlag;
     component.addFlagToCollection();
     expect(populateNewFlagDetailInstanceSpy).toHaveBeenCalled();
-    // // Check there are now three case flag values in the caseField object for caseFlag1, and two in caseFlag2
+    // Check there are now three case flag values in the caseField object for caseFlag1, and two in caseFlag2
     expect(component.flagsData[0].caseField.value.details.length).toBe(3);
     expect(component.flagsData[0].caseField.value.details[2].id).toBeUndefined();
-    // // FlagDetail value expected to be undefined because no caseFlagParentFormGroup value was set (which is used for
-    // // populating the FlagDetail instance)
+    // FlagDetail value expected to be undefined because no caseFlagParentFormGroup value was set (which is used for
+    // populating the FlagDetail instance)
     expect(component.flagsData[0].caseField.value.details[2].value.name).toBeUndefined();
     expect(component.flagsData[1].caseField.value.details.length).toBe(2);
     newFlag = {

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/write-case-flag-field.component.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/write-case-flag-field.component.ts
@@ -27,6 +27,7 @@ export class WriteCaseFlagFieldComponent extends AbstractFieldWriteComponent imp
   public flagCommentsOptional = false;
   public jurisdiction: string;
   public caseTypeId: string;
+  public hmctsServiceId: string;
   public flagName: string;
   public flagPath: FlagPath[];
   public hearingRelevantFlag: boolean;
@@ -77,24 +78,33 @@ export class WriteCaseFlagFieldComponent extends AbstractFieldWriteComponent imp
       }
     }
     // Extract all flags-related data from the CaseEventTrigger object in the snapshot data
-    if (this.route.snapshot.data.eventTrigger && this.route.snapshot.data.eventTrigger.case_fields) {
-      this.flagsData = ((this.route.snapshot.data.eventTrigger.case_fields) as CaseField[])
+    if (this.route.snapshot.data.eventTrigger) {
+      // Get the HMCTSServiceId from supplementary data, if it exists (required for retrieving the available flag types in
+      // the first instance, only falling back on case type ID or jurisidiction if it's not present)
+      if (this.route.snapshot.data.eventTrigger.supplementary_data
+        && this.route.snapshot.data.eventTrigger.supplementary_data.HMCTSServiceId) {
+        this.hmctsServiceId = this.route.snapshot.data.eventTrigger.supplementary_data.HMCTSServiceId;
+      }
+
+      if (this.route.snapshot.data.eventTrigger.case_fields) {
+        this.flagsData = ((this.route.snapshot.data.eventTrigger.case_fields) as CaseField[])
         .reduce((flags, caseField) => {
           return FieldsUtils.extractFlagsDataFromCaseField(flags, caseField, caseField.id, caseField);
         }, []);
 
-      // Set boolean indicating the display_context_parameter is "update"
-      this.isDisplayContextParameterUpdate =
-        this.setDisplayContextParameterUpdate((this.route.snapshot.data.eventTrigger.case_fields) as CaseField[]);
+        // Set boolean indicating the display_context_parameter is "update"
+        this.isDisplayContextParameterUpdate =
+          this.setDisplayContextParameterUpdate((this.route.snapshot.data.eventTrigger.case_fields) as CaseField[]);
 
-      // Set starting field state
-      this.fieldState = this.isDisplayContextParameterUpdate ? CaseFlagFieldState.FLAG_MANAGE_CASE_FLAGS : CaseFlagFieldState.FLAG_LOCATION;
-      // Get case title, to be used by child components
-      this.caseEditDataService.caseTitle$.subscribe({
-        next: title => {
-          this.caseTitle = title.length > 0 ? title : this.caseNameMissing;
-        }
-      });
+        // Set starting field state
+        this.fieldState = this.isDisplayContextParameterUpdate ? CaseFlagFieldState.FLAG_MANAGE_CASE_FLAGS : CaseFlagFieldState.FLAG_LOCATION;
+        // Get case title, to be used by child components
+        this.caseEditDataService.caseTitle$.subscribe({
+          next: title => {
+            this.caseTitle = title.length > 0 ? title : this.caseNameMissing;
+          }
+        });
+      }
     }
   }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[EUI-7796](https://tools.hmcts.net/jira/browse/EUI-7796)

### Change description ###
Fix flag types retrieval to use `HMCTSServiceId` from supplementary data in the first instance (if available); this caters for case types that are associated with multiple HMCTS service codes.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
