### PR TITLE
EUI-8069/EUI-8070/EUI-8071: Case Flags v2 - UI amendments for View Case Flags

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -31,6 +31,9 @@
 ### Version 6.10.7-case-flags-confirm-flag-status-step
 **EUI-7350** Add "confirm flag status" step of Create Case Flag journey
 
+### Version 6.13.10-case-flags-show-language-for-interpreter-flag-types
+**EUI-8069** Fix Case Flags table display to show selected language for "Language Interpreter" flag types
+
 ### Version 6.13.10-rc1
 **EUI-5298** Release 6.13.10 including 6.13.0, linked cases (EUI-7676) and case file view fix (EUI-7417)
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,9 @@
 ## RELEASE NOTES
+### Version 6.10.7-case-flags-v2-view-case-flags-ui-amendments
+**EUI-8069** Fix Case Flags table display to show selected language for "Language Interpreter" flag types (ported from Case Flags v1)
+**EUI-8070** Display "decision reason" (flag update comment) for "Not approved" flags to internal HMCTS users only
+**EUI-8071** Hide "Active flags" banner from external users
+
 ### Version 6.10.7-case-flags-welsh-language-support
 **EUI-7858** Ensure support for Welsh language toggle by storing flag description and comments entries in correct `_cy` fields, and displaying flag comments according to language selection
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "6.10.7-case-flags-welsh-language-support",
+  "version": "6.10.7-case-flags-v2-view-case-flags-ui-amendments",
   "engines": {
     "yarn": "^1.22.15",
     "npm": "^8.10.0"

--- a/projects/ccd-case-ui-toolkit/package.json
+++ b/projects/ccd-case-ui-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "6.10.7-case-flags-welsh-language-support",
+  "version": "6.10.7-case-flags-v2-view-case-flags-ui-amendments",
   "engines": {
     "yarn": "^1.22.15",
     "npm": "^8.10.0"

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-viewer/case-full-access-view/case-full-access-view.component.html
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-viewer/case-full-access-view/case-full-access-view.component.html
@@ -45,7 +45,7 @@
                         (onTriggerSubmit)="applyTrigger($event)"></ccd-event-trigger>
   </div>
 </div>
-<div class="grid-row" *ngIf="activeCaseFlags">
+<div class="grid-row" *ngIf="activeCaseFlags && !caseFlagsExternalUser">
   <div class="column-full">
     <ccd-notification-banner [notificationBannerConfig]="notificationBannerConfig" (linkClicked)="onLinkClicked($event)">
     </ccd-notification-banner>

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-viewer/case-full-access-view/case-full-access-view.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-viewer/case-full-access-view/case-full-access-view.component.spec.ts
@@ -573,6 +573,7 @@ const WORK_ALLOCATION_CASE_VIEW = {
 const $DIALOG_DELETE_BUTTON = By.css('.button[title=Delete]');
 const $DIALOG_CANCEL_BUTTON = By.css('.button[title=Cancel]');
 const DIALOG_CONFIG = new MatDialogConfig();
+const CASE_FLAGS_READ_EXTERNAL_MODE = '#ARGUMENT(READ,EXTERNAL)';
 
 let fixture: ComponentFixture<CaseFullAccessViewComponent>;
 let fixtureDialog: ComponentFixture<DeleteOrCancelDialogComponent>;
@@ -1546,6 +1547,26 @@ describe('CaseFullAccessViewComponent - appendedTabs', () => {
     viewCaseFlagsLink.click();
     f.detectChanges();
     expect(caseFlagsTab.getAttribute('aria-selected')).toEqual('true');
+  });
+
+  it('should not display active Case Flags banner message for an external user, even if there are active Case Flags', () => {
+    // Set the display_context_parameter attribute of the FlagLauncher CaseField to external mode
+    CASE_VIEW.tabs[3].fields[0].display_context_parameter = CASE_FLAGS_READ_EXTERNAL_MODE;
+    // Set both Case Flags' status to "Active"
+    CASE_VIEW.tabs[3].fields[1].value.details[0].value.status = CaseFlagStatus.ACTIVE;
+    CASE_VIEW.tabs[3].fields[1].value.details[1].value.status = CaseFlagStatus.ACTIVE;
+
+    // Spy on the hasActiveCaseFlags() function to check it is called in ngOnInit(), checking for active Case Flags
+    spyOn(comp, 'hasActiveCaseFlags').and.callThrough();
+
+    // Manual call of ngOnInit() as above
+    comp.ngOnInit();
+    f.detectChanges();
+
+    expect(comp.hasActiveCaseFlags).toHaveBeenCalledTimes(1);
+    const bannerElement = d.nativeElement.querySelector('.govuk-notification-banner');
+    expect(bannerElement).toBeNull();
+    expect(comp.activeCaseFlags).toBe(true);
   });
 });
 

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-viewer/case-full-access-view/case-full-access-view.component.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-viewer/case-full-access-view/case-full-access-view.component.ts
@@ -69,6 +69,8 @@ export class CaseFullAccessViewComponent implements OnInit, OnDestroy, OnChanges
   public notificationBannerConfig: NotificationBannerConfig;
   public selectedTabIndex = 0;
   public activeCaseFlags = false;
+  public caseFlagsExternalUser = false;
+  private readonly caseFlagsReadExternalMode = '#ARGUMENT(READ,EXTERNAL)';
 
   public callbackErrorsSubject: Subject<any> = new Subject();
   @ViewChild('tabGroup', { static: false }) public tabGroup: MatTabGroup;
@@ -120,7 +122,7 @@ export class CaseFullAccessViewComponent implements OnInit, OnDestroy, OnChanges
       });
     }
 
-    this.checkRouteAndSetCaseViewTab ();
+    this.checkRouteAndSetCaseViewTab();
 
     // Check for active Case Flags
     this.activeCaseFlags = this.hasActiveCaseFlags();
@@ -337,6 +339,11 @@ export class CaseFullAccessViewComponent implements OnInit, OnDestroy, OnChanges
       : null;
 
     if (caseFlagsTab) {
+      // Check whether the FlagLauncher CaseField is in external mode or not; the notification banner should not be
+      // displayed for external users
+      this.caseFlagsExternalUser = caseFlagsTab.fields.find(
+        caseField => FieldsUtils.isFlagLauncherCaseField(caseField)).display_context_parameter === this.caseFlagsReadExternalMode;
+
       // Get the active case flags count
       // Cannot filter out anything other than to remove the FlagLauncher CaseField because Flags fields may be
       // contained in other CaseField instances, either as a sub-field of a Complex field, or fields in a collection

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-table/case-flag-table.component.html
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-table/case-flag-table.component.html
@@ -19,6 +19,7 @@
       <td class="govuk-table__cell">
         <div>{{flagDetail.name}}</div>
         <div>{{flagDetail.otherDescription}}</div>
+        <div>{{flagDetail.subTypeValue}}</div>
       </td>
       <td class="govuk-table__cell">{{flagDetail.flagComment}}</td>
       <td class="govuk-table__cell">{{flagDetail.dateTimeCreated | date: 'dd LLL yyyy'}}</td>

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-table/case-flag-table.component.html
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-table/case-flag-table.component.html
@@ -19,9 +19,14 @@
       <td class="govuk-table__cell">
         <div>{{flagDetail.name}}</div>
         <div>{{flagDetail.otherDescription}}</div>
-        <div>{{flagDetail.subTypeValue}}</div>
+        <div>{{flagDetail.subTypeValue | rpxTranslate}}</div>
       </td>
-      <td class="govuk-table__cell">{{flagDetail.flagComment}}</td>
+      <td class="govuk-table__cell">
+        <div>{{flagDetail.flagComment | rpxTranslate}}</div>
+        <div *ngIf="!caseFlagsExternalUser">
+          <strong>{{'Decision Reason:' | rpxTranslate}} {{flagDetail.flagUpdateComment | rpxTranslate}}</strong>
+        </div>
+      </td>
       <td class="govuk-table__cell">{{flagDetail.dateTimeCreated | date: 'dd LLL yyyy'}}</td>
       <td class="govuk-table__cell">{{flagDetail.dateTimeModified | date: 'dd LLL yyyy'}}</td>
       <td class="govuk-table__cell">

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-table/case-flag-table.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-table/case-flag-table.component.spec.ts
@@ -1,5 +1,5 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { CaseFlagStatus } from '../../enums';
 import { CaseFlagTableComponent } from './case-flag-table.component';
 
@@ -41,7 +41,7 @@ describe('CaseFlagTableComponent', () => {
     caseField: null
   };
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
       declarations: [CaseFlagTableComponent]
@@ -78,5 +78,14 @@ describe('CaseFlagTableComponent', () => {
     fixture.detectChanges();
     const caseViewerFieldLabelElement = fixture.debugElement.nativeElement.querySelector('#case-viewer-field-label');
     expect(caseViewerFieldLabelElement).toBeNull();
+  });
+
+  it('should display the sub-type value (i.e. language name) when displaying a "language interpreter" case flag type', () => {
+    component.flagData = flagData;
+    fixture.detectChanges();
+    const tableCellElements = fixture.debugElement.nativeElement.querySelectorAll('.govuk-table__cell');
+    // Check that the first element of the second row of five (i.e. sixth element) contains the language name
+    expect(tableCellElements.length).toBe(10);
+    expect(tableCellElements[5].textContent).toContain(flagData.flags.details[1].subTypeValue);
   });
 });

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-table/case-flag-table.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-table/case-flag-table.component.spec.ts
@@ -1,5 +1,6 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MockRpxTranslatePipe } from '../../../../../../shared/test/mock-rpx-translate.pipe';
 import { CaseFlagStatus } from '../../enums';
 import { CaseFlagTableComponent } from './case-flag-table.component';
 
@@ -16,6 +17,7 @@ describe('CaseFlagTableComponent', () => {
         subTypeKey: '',
         otherDescription: '',
         flagComment: '',
+        flagUpdateComment: 'Flag update comment for first flag',
         dateTimeModified: new Date('2021-09-09 00:00:00'),
         dateTimeCreated: new Date('2021-09-09 00:00:00'),
         path: [],
@@ -29,6 +31,7 @@ describe('CaseFlagTableComponent', () => {
         subTypeKey: '',
         otherDescription: '',
         flagComment: '',
+        flagUpdateComment: 'Flag update comment for second flag',
         dateTimeModified: new Date('2021-09-09 00:00:00'),
         dateTimeCreated: new Date('2021-09-09 00:00:00'),
         path: [],
@@ -44,7 +47,7 @@ describe('CaseFlagTableComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
-      declarations: [CaseFlagTableComponent]
+      declarations: [CaseFlagTableComponent, MockRpxTranslatePipe]
     })
     .compileComponents();
   }));
@@ -87,5 +90,26 @@ describe('CaseFlagTableComponent', () => {
     // Check that the first element of the second row of five (i.e. sixth element) contains the language name
     expect(tableCellElements.length).toBe(10);
     expect(tableCellElements[5].textContent).toContain(flagData.flags.details[1].subTypeValue);
+  });
+
+  it('should display the flag update comment for internal users if and only if the case flag status is "Not approved"', () => {
+    flagData.flags.details[1].status = CaseFlagStatus.NOT_APPROVED;
+    component.flagData = flagData;
+    fixture.detectChanges();
+    const tableCellElements = fixture.debugElement.nativeElement.querySelectorAll('.govuk-table__cell');
+    // Check that the second element of the second row of five (i.e. seventh element) contains the flag update comment
+    expect(tableCellElements.length).toBe(10);
+    expect(tableCellElements[6].textContent).toContain(`Decision Reason: ${flagData.flags.details[1].flagUpdateComment}`);
+  });
+
+  it('should not display the flag update comment for external users even if the case flag status is "Not approved"', () => {
+    flagData.flags.details[1].status = CaseFlagStatus.NOT_APPROVED;
+    component.flagData = flagData;
+    component.caseFlagsExternalUser = true;
+    fixture.detectChanges();
+    const tableCellElements = fixture.debugElement.nativeElement.querySelectorAll('.govuk-table__cell');
+    // Check that the second element of the second row of five (i.e. seventh element) does not contain the flag update comment
+    expect(tableCellElements.length).toBe(10);
+    expect(tableCellElements[6].textContent).not.toContain(`Decision Reason: ${flagData.flags.details[1].flagUpdateComment}`);
   });
 });

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-table/case-flag-table.component.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-table/case-flag-table.component.ts
@@ -11,6 +11,7 @@ export class CaseFlagTableComponent {
   @Input() public tableCaption: string;
   @Input() public flagData: FlagsWithFormGroupPath;
   @Input() public firstColumnHeader: string;
+  @Input() public caseFlagsExternalUser = false;
 
   public get caseFlagStatus(): typeof CaseFlagStatus {
     return CaseFlagStatus;

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/read-case-flag-field.component.html
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/read-case-flag-field.component.html
@@ -18,6 +18,7 @@
                               [tableCaption]="''"
                               [flagData]="flagData"
                               [firstColumnHeader]="flagData.flags.partyName"
+                              [caseFlagsExternalUser]="caseFlagsExternalUser"
         ></ccd-case-flag-table>
       </div>
     </ng-container>

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/read-case-flag-field.component.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/read-case-flag-field.component.ts
@@ -21,7 +21,7 @@ export class ReadCaseFlagFieldComponent extends AbstractFieldReadComponent imple
   public flagForSummaryDisplay: FlagDetailDisplay;
   public summaryListDisplayMode: CaseFlagSummaryListDisplayMode;
   public displayContextParameter: string;
-
+  public caseFlagsExternalUser = false;
   public pathToFlagsFormGroup: string;
   public readonly caseLevelCaseFlagsFieldId = 'caseFlags';
   public readonly caseNameMissing = 'Case name missing';
@@ -44,6 +44,7 @@ export class ReadCaseFlagFieldComponent extends AbstractFieldReadComponent imple
       controlName => FieldsUtils.isFlagLauncherCaseField(this.formGroup.get(controlName)['caseField']));
     const flagLauncherComponent = this.formGroup.get(flagLauncherControlName)?.['component'];
     this.displayContextParameter = flagLauncherComponent?.caseField?.display_context_parameter;
+    this.caseFlagsExternalUser = this.displayContextParameter === this.readSupportMode;
 
     // If the context is PaletteContext.DEFAULT, the Flags fields need to be located by CaseTab (they won't be present
     // in the FormGroup - only the FlagLauncher field is present)
@@ -76,13 +77,11 @@ export class ReadCaseFlagFieldComponent extends AbstractFieldReadComponent imple
         // The FlagLauncher component holds a reference (selectedFlagsLocation) containing the CaseField instance to
         // which the new flag has been added
         if ((flagLauncherComponent.caseField.display_context_parameter === this.createMode ||
-            flagLauncherComponent.caseField.display_context_parameter === this.createExternalMode
-          ) &&
-          flagLauncherComponent.selectedFlagsLocation) {
+            flagLauncherComponent.caseField.display_context_parameter === this.createExternalMode)
+            && flagLauncherComponent.selectedFlagsLocation) {
           this.pathToFlagsFormGroup = flagLauncherComponent.selectedFlagsLocation.pathToFlagsFormGroup;
           this.flagForSummaryDisplay = this.extractNewFlagToFlagDetailDisplayObject(
-            flagLauncherComponent.selectedFlagsLocation
-          );
+            flagLauncherComponent.selectedFlagsLocation);
           // Set the display mode for the "Review flag details" summary page
           this.summaryListDisplayMode = CaseFlagSummaryListDisplayMode.CREATE;
         // The FlagLauncher component holds a reference (selectedFlag), which gets set after the selection step of the


### PR DESCRIPTION
### JIRA link (if applicable) ###
EUI-8069
EUI-8070
EUI-8071

### Change description ###
EUI-8069: Fix Case Flags table display to show selected language for "Language Interpreter" flag types (ported from Case Flags v1); EUI-8070: Display "decision reason" (flag update comment) for "Not approved" flags to internal HMCTS users only; EUI-8071: Hide "Active flags" banner from external users.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
