### PR TITLE
EUI-8778: Prevent flag status tag text from wrapping in Case Flags table

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,7 @@
 ## RELEASE NOTES
+### Version 6.19.2-case-flags-v2-status-text-wrapping-fix
+**EUI-8778** Prevent flag status tag text from wrapping in Case Flags table
+
 ### Version 6.19.2-case-flags-v2-reasonable-adjustments-text-amendments-v3
 **EUI-8283** Reasonable adjustments amend the term flag and flag type
 **EUI-8284** Reasonable adjustments amend screen caption text on the tell us more about the request screen

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "6.19.2-case-flags-v2-reasonable-adjustments-text-amendments-v3",
+  "version": "6.19.2-case-flags-v2-status-text-wrapping-fix",
   "engines": {
     "yarn": "^3.5.0",
     "npm": "^8.10.0"

--- a/projects/ccd-case-ui-toolkit/package.json
+++ b/projects/ccd-case-ui-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "6.19.2-case-flags-v2-reasonable-adjustments-text-amendments-v3",
+  "version": "6.19.2-case-flags-v2-status-text-wrapping-fix",
   "engines": {
     "yarn": "^3.5.0",
     "npm": "^8.10.0"

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-table/case-flag-table.component.html
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-table/case-flag-table.component.html
@@ -29,7 +29,7 @@
       </td>
       <td class="govuk-table__cell">{{flagDetail.dateTimeCreated | date: 'dd LLL yyyy'}}</td>
       <td class="govuk-table__cell">{{flagDetail.dateTimeModified | date: 'dd LLL yyyy'}}</td>
-      <td class="govuk-table__cell">
+      <td class="govuk-table__cell cell-flag-status">
         <strong *ngIf="flagDetail.status === caseFlagStatus.ACTIVE" class="govuk-tag">{{'Active' | rpxTranslate}}</strong>
         <strong *ngIf="flagDetail.status === caseFlagStatus.INACTIVE" class="govuk-tag govuk-tag--grey">{{'Inactive' | rpxTranslate}}</strong>
         <strong *ngIf="flagDetail.status === caseFlagStatus.REQUESTED" class="govuk-tag govuk-tag--grey">{{'Requested' | rpxTranslate}}</strong>

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-table/case-flag-table.component.scss
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-table/case-flag-table.component.scss
@@ -21,4 +21,11 @@
       }
     }
   }
+  .govuk-table__body {
+    .govuk-table__row {
+      .cell-flag-status {
+        white-space: nowrap;
+      }
+    }
+  }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
EUI-8778

### Change description ###
Ensure the status tag text is displayed on a single line, irrespective of screen width.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
