### PR TITLE
EUI-8934: Case Flags v2.1 fixes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,7 @@
 ## RELEASE NOTES
+### Version 6.19.9-case-flags-v2-1-consolidation-final-fixes-3
+**EUI-8934** Fix merging of internal and external flags collections to work when a `Flags.details` array is falsy
+
 ### Version 6.19.9-case-flags-exui-848-fix
 **EUI-8947** Fix bug introduced by change to `CaseEditComponent` case event data generation in EXUI-848
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "6.19.9-case-flags-exui-848-fix",
+  "version": "6.19.9-case-flags-v2-1-consolidation-final-fixes-3",
   "engines": {
     "yarn": "^3.5.0",
     "npm": "^8.10.0"

--- a/projects/ccd-case-ui-toolkit/package.json
+++ b/projects/ccd-case-ui-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "6.19.9-case-flags-exui-848-fix",
+  "version": "6.19.9-case-flags-v2-1-consolidation-final-fixes-3",
   "engines": {
     "yarn": "^3.5.0",
     "npm": "^8.10.0"

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/read-case-flag-field.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/read-case-flag-field.component.spec.ts
@@ -79,7 +79,7 @@ describe('ReadCaseFlagFieldComponent', () => {
     status: CaseFlagStatus.ACTIVE
   };
   const caseFlag2DetailsValue2 = {
-    name: 'Sign language',
+    name: 'Language interpreter',
     dateTimeModified: '2022-02-13T00:00:00.000',
     dateTimeCreated: '2022-02-11T00:00:00.000',
     path: [
@@ -101,22 +101,38 @@ describe('ReadCaseFlagFieldComponent', () => {
     flagCode: 'OT0001',
     status: CaseFlagStatus.ACTIVE
   };
+  const witnessCaseFlagGroupId = '10f8dc79-363e-4c43-8391-80157b4c6bcb';
+  const witnessCaseFlagGroupInternalFieldId = 'PartyFlagsInternal';
+  const witnessCaseFlagGroupExternalFieldId = 'PartyFlagsExternal';
   const witnessComplexFieldId = 'witness1';
   const witnessCaseFlagPartyName = 'Sawit All';
   const witnessCaseFlagRoleOnCase = 'Witness';
-  const witnessComplexFieldFlagDetailsArray = [
+  const witnessComplexFieldInternalFlagDetailsArray = [
     {
       id: '1e10472c-1a68-4665-b90a-3bcc6217403f',
       value: caseFlag1DetailsValue1
     }
   ];
+  const witnessComplexFieldExternalFlagDetailsArray = [
+    {
+      id: '1c747e0f-9ea3-4c0a-bacf-24b542cefb02',
+      value: caseFlag1DetailsValue2
+    }
+  ];
   const witnessComplexFieldValue = {
     FirstName: 'Sawit',
     LastName: 'All',
-    PartyFlags: {
+    PartyFlagsInternal: {
       partyName: witnessCaseFlagPartyName,
       roleOnCase: witnessCaseFlagRoleOnCase,
-      details: witnessComplexFieldFlagDetailsArray
+      details: witnessComplexFieldInternalFlagDetailsArray,
+      groupId: witnessCaseFlagGroupId
+    },
+    PartyFlagsExternal: {
+      partyName: witnessCaseFlagPartyName,
+      roleOnCase: witnessCaseFlagRoleOnCase,
+      details: witnessComplexFieldExternalFlagDetailsArray,
+      groupId: witnessCaseFlagGroupId
     }
   };
   const caseFlag3FieldId = 'CaseFlag3';
@@ -276,7 +292,14 @@ describe('ReadCaseFlagFieldComponent', () => {
                         }
                       } as CaseField,
                       {
-                        id: 'PartyFlags',
+                        id: witnessCaseFlagGroupInternalFieldId,
+                        field_type: {
+                          id: 'Flags',
+                          type: 'Complex'
+                        }
+                      } as CaseField,
+                      {
+                        id: witnessCaseFlagGroupExternalFieldId,
                         field_type: {
                           id: 'Flags',
                           type: 'Complex'
@@ -446,17 +469,31 @@ describe('ReadCaseFlagFieldComponent', () => {
           value: {
             FirstName: 'Sawit',
             LastName: 'All',
-            PartyFlags: {
+            PartyFlagsInternal: {
               partyName: witnessCaseFlagPartyName,
               roleOnCase: witnessCaseFlagRoleOnCase,
               details: [
-                ...witnessComplexFieldFlagDetailsArray,
+                ...witnessComplexFieldInternalFlagDetailsArray,
                 {
                   value: {
                     name: 'New flag in Witness field'
                   }
                 }
-              ]
+              ],
+              groupId: witnessCaseFlagGroupId
+            },
+            PartyFlagsExternal: {
+              partyName: witnessCaseFlagPartyName,
+              roleOnCase: witnessCaseFlagRoleOnCase,
+              details: [
+                ...witnessComplexFieldExternalFlagDetailsArray,
+                {
+                  value: {
+                    name: 'Another new flag in Witness field'
+                  }
+                }
+              ],
+              groupId: witnessCaseFlagGroupId
             }
           }
         }
@@ -478,7 +515,7 @@ describe('ReadCaseFlagFieldComponent', () => {
   } as FlagsWithFormGroupPath;
   const selectedFlagsLocationInComplexField = {
     flags: null,
-    pathToFlagsFormGroup: `${[witnessComplexFieldId]}.PartyFlags`,
+    pathToFlagsFormGroup: `${witnessComplexFieldId}.${witnessCaseFlagGroupInternalFieldId}`,
     caseField: formGroup.controls[witnessComplexFieldId]['caseField']
   } as FlagsWithFormGroupPath;
   let caseFlagStateServiceSpy: jasmine.SpyObj<CaseFlagStateService>;
@@ -520,10 +557,24 @@ describe('ReadCaseFlagFieldComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should set whether the user is external or not, from the display_context_parameter', () => {
+    expect(component.caseFlagsExternalUser).toBe(false);
+    formGroup.get(flagLauncher1CaseField.id)['component'].caseField = {
+      display_context_parameter: CaseFlagDisplayContextParameter.READ_EXTERNAL
+    };
+    component.ngOnInit();
+    expect(component.displayContextParameter).toBe(CaseFlagDisplayContextParameter.READ_EXTERNAL);
+    expect(component.caseFlagsExternalUser).toBe(true);
+  });
+
   it('should extract all flags-related data from the CaseView object in the snapshot data, grouping flags by groupId', () => {
     // Flags data is grouped by groupId where present, if the user is not external (the default)
+    formGroup.get(flagLauncher1CaseField.id)['component'].caseField = {
+      display_context_parameter: null
+    };
+    component.ngOnInit();
     expect(component.flagsData).toBeTruthy();
-    expect(component.flagsData.length).toBe(8);
+    expect(component.flagsData.length).toBe(9);
     expect(component.flagsData[0].flags.flagsCaseFieldId).toEqual(caseFlag1FieldId);
     expect(component.flagsData[0].flags.partyName).toEqual(caseFlag1PartyName);
     expect(component.flagsData[0].flags.roleOnCase).toEqual(caseFlag1RoleOnCase);
@@ -548,43 +599,54 @@ describe('ReadCaseFlagFieldComponent', () => {
     expect(component.flagsData[2].flags.details[0].dateTimeModified).toEqual(new Date(caseLevelFlagDetailsValue.dateTimeModified));
     expect(component.flagsData[2].flags.details[0].dateTimeCreated).toEqual(new Date(caseLevelFlagDetailsValue.dateTimeCreated));
     expect(component.flagsData[2].flags.details[0].hearingRelevant).toBe(true);
-    expect(component.flagsData[3].flags.flagsCaseFieldId).toEqual('PartyFlags');
+    expect(component.flagsData[3].flags.flagsCaseFieldId).toEqual(witnessCaseFlagGroupInternalFieldId);
     expect(component.flagsData[3].flags.partyName).toEqual(witnessCaseFlagPartyName);
     expect(component.flagsData[3].flags.roleOnCase).toEqual(witnessCaseFlagRoleOnCase);
-    expect(component.flagsData[3].flags.details.length).toBe(1);
+    // Flags will have been grouped so, due to shared object references, the flags details array length will be 2 not 1
+    expect(component.flagsData[3].flags.details.length).toBe(2);
     expect(component.flagsData[3].flags.details[0].name).toEqual(caseFlag1DetailsValue1.name);
-    expect(component.flagsData[4].flags.flagsCaseFieldId).toEqual(caseFlagGroup1FieldId1);
-    expect(component.flagsData[4].flags.partyName).toEqual(caseFlagGroup1PartyName);
-    expect(component.flagsData[4].flags.roleOnCase).toEqual(caseFlagGroup1RoleOnCase);
-    expect(component.flagsData[4].flags.details[0].name).toEqual(caseFlagGroup1DetailsValue1.name);
-    expect(component.flagsData[5].flags.flagsCaseFieldId).toEqual(caseFlagGroup1FieldId2);
+    expect(component.flagsData[3].flags.details[1].name).toEqual(caseFlag1DetailsValue2.name);
+    expect(component.flagsData[4].flags.flagsCaseFieldId).toEqual(witnessCaseFlagGroupExternalFieldId);
+    expect(component.flagsData[4].flags.partyName).toEqual(witnessCaseFlagPartyName);
+    expect(component.flagsData[4].flags.roleOnCase).toEqual(witnessCaseFlagRoleOnCase);
+    expect(component.flagsData[4].flags.details.length).toBe(1);
+    expect(component.flagsData[4].flags.details[0].name).toEqual(caseFlag1DetailsValue2.name);
+    expect(component.flagsData[5].flags.flagsCaseFieldId).toEqual(caseFlagGroup1FieldId1);
     expect(component.flagsData[5].flags.partyName).toEqual(caseFlagGroup1PartyName);
     expect(component.flagsData[5].flags.roleOnCase).toEqual(caseFlagGroup1RoleOnCase);
-    expect(component.flagsData[5].flags.details[0].name).toEqual(caseFlagGroup1DetailsValue2.name);
-    expect(component.flagsData[6].flags.flagsCaseFieldId).toEqual(caseFlagGroup2FieldId1);
-    expect(component.flagsData[6].flags.partyName).toEqual(caseFlagGroup2PartyName);
-    expect(component.flagsData[6].flags.roleOnCase).toEqual(caseFlagGroup2RoleOnCase);
-    expect(component.flagsData[6].flags.details[0].name).toEqual(caseFlagGroup2DetailsValue1.name);
-    expect(component.flagsData[7].flags.flagsCaseFieldId).toEqual(caseFlagGroup2FieldId2);
+    expect(component.flagsData[5].flags.details[0].name).toEqual(caseFlagGroup1DetailsValue1.name);
+    expect(component.flagsData[6].flags.flagsCaseFieldId).toEqual(caseFlagGroup1FieldId2);
+    expect(component.flagsData[6].flags.partyName).toEqual(caseFlagGroup1PartyName);
+    expect(component.flagsData[6].flags.roleOnCase).toEqual(caseFlagGroup1RoleOnCase);
+    expect(component.flagsData[6].flags.details[0].name).toEqual(caseFlagGroup1DetailsValue2.name);
+    expect(component.flagsData[7].flags.flagsCaseFieldId).toEqual(caseFlagGroup2FieldId1);
     expect(component.flagsData[7].flags.partyName).toEqual(caseFlagGroup2PartyName);
     expect(component.flagsData[7].flags.roleOnCase).toEqual(caseFlagGroup2RoleOnCase);
-    expect(component.flagsData[7].flags.details[0].name).toEqual(caseFlagGroup2DetailsValue2.name);
+    expect(component.flagsData[7].flags.details[0].name).toEqual(caseFlagGroup2DetailsValue1.name);
+    expect(component.flagsData[8].flags.flagsCaseFieldId).toEqual(caseFlagGroup2FieldId2);
+    expect(component.flagsData[8].flags.partyName).toEqual(caseFlagGroup2PartyName);
+    expect(component.flagsData[8].flags.roleOnCase).toEqual(caseFlagGroup2RoleOnCase);
+    expect(component.flagsData[8].flags.details[0].name).toEqual(caseFlagGroup2DetailsValue2.name);
     // Check the party-level and case-level flags are separated correctly, and the party-level flags are grouped by
     // groupId (i.e. there are no duplicate parties). These are expected to appear before the non-grouped flags
     expect(component.partyLevelCaseFlagData.length).toBe(5);
-    expect(component.partyLevelCaseFlagData[0].flags.flagsCaseFieldId).toEqual(caseFlagGroup1FieldId1);
-    expect(component.partyLevelCaseFlagData[0].flags.partyName).toEqual(caseFlagGroup1PartyName);
+    expect(component.partyLevelCaseFlagData[0].flags.flagsCaseFieldId).toEqual(witnessCaseFlagGroupInternalFieldId);
+    expect(component.partyLevelCaseFlagData[0].flags.partyName).toEqual(witnessCaseFlagPartyName);
     expect(component.partyLevelCaseFlagData[0].flags.details.length).toBe(2);
-    expect(component.partyLevelCaseFlagData[0].flags.details[0].name).toEqual(caseFlagGroup1DetailsValue1.name);
-    expect(component.partyLevelCaseFlagData[0].flags.details[1].name).toEqual(caseFlagGroup1DetailsValue2.name);
-    expect(component.partyLevelCaseFlagData[1].flags.flagsCaseFieldId).toEqual(caseFlagGroup2FieldId1);
-    expect(component.partyLevelCaseFlagData[1].flags.partyName).toEqual(caseFlagGroup2PartyName);
+    expect(component.partyLevelCaseFlagData[0].flags.details[0].name).toEqual(caseFlag1DetailsValue1.name);
+    expect(component.partyLevelCaseFlagData[0].flags.details[1].name).toEqual(caseFlag1DetailsValue2.name);
+    expect(component.partyLevelCaseFlagData[1].flags.flagsCaseFieldId).toEqual(caseFlagGroup1FieldId1);
+    expect(component.partyLevelCaseFlagData[1].flags.partyName).toEqual(caseFlagGroup1PartyName);
     expect(component.partyLevelCaseFlagData[1].flags.details.length).toBe(2);
-    expect(component.partyLevelCaseFlagData[1].flags.details[0].name).toEqual(caseFlagGroup2DetailsValue1.name);
-    expect(component.partyLevelCaseFlagData[1].flags.details[1].name).toEqual(caseFlagGroup2DetailsValue2.name);
-    expect(component.partyLevelCaseFlagData[2].flags.flagsCaseFieldId).toEqual(caseFlag1FieldId);
-    expect(component.partyLevelCaseFlagData[3].flags.flagsCaseFieldId).toEqual(caseFlag2FieldId);
-    expect(component.partyLevelCaseFlagData[4].flags.flagsCaseFieldId).toEqual('PartyFlags');
+    expect(component.partyLevelCaseFlagData[1].flags.details[0].name).toEqual(caseFlagGroup1DetailsValue1.name);
+    expect(component.partyLevelCaseFlagData[1].flags.details[1].name).toEqual(caseFlagGroup1DetailsValue2.name);
+    expect(component.partyLevelCaseFlagData[2].flags.flagsCaseFieldId).toEqual(caseFlagGroup2FieldId1);
+    expect(component.partyLevelCaseFlagData[2].flags.partyName).toEqual(caseFlagGroup2PartyName);
+    expect(component.partyLevelCaseFlagData[2].flags.details.length).toBe(2);
+    expect(component.partyLevelCaseFlagData[2].flags.details[0].name).toEqual(caseFlagGroup2DetailsValue1.name);
+    expect(component.partyLevelCaseFlagData[2].flags.details[1].name).toEqual(caseFlagGroup2DetailsValue2.name);
+    expect(component.partyLevelCaseFlagData[3].flags.flagsCaseFieldId).toEqual(caseFlag1FieldId);
+    expect(component.partyLevelCaseFlagData[4].flags.flagsCaseFieldId).toEqual(caseFlag2FieldId);
     expect(component.caseLevelCaseFlagData).toEqual(component.flagsData[2]);
   });
 
@@ -595,7 +657,7 @@ describe('ReadCaseFlagFieldComponent', () => {
     };
     component.ngOnInit();
     expect(component.flagsData).toBeTruthy();
-    expect(component.flagsData.length).toBe(8);
+    expect(component.flagsData.length).toBe(9);
     expect(component.flagsData[0].flags.flagsCaseFieldId).toEqual(caseFlag1FieldId);
     expect(component.flagsData[0].flags.partyName).toEqual(caseFlag1PartyName);
     expect(component.flagsData[0].flags.roleOnCase).toEqual(caseFlag1RoleOnCase);
@@ -620,46 +682,138 @@ describe('ReadCaseFlagFieldComponent', () => {
     expect(component.flagsData[2].flags.details[0].dateTimeModified).toEqual(new Date(caseLevelFlagDetailsValue.dateTimeModified));
     expect(component.flagsData[2].flags.details[0].dateTimeCreated).toEqual(new Date(caseLevelFlagDetailsValue.dateTimeCreated));
     expect(component.flagsData[2].flags.details[0].hearingRelevant).toBe(true);
-    expect(component.flagsData[3].flags.flagsCaseFieldId).toEqual('PartyFlags');
+    expect(component.flagsData[3].flags.flagsCaseFieldId).toEqual(witnessCaseFlagGroupInternalFieldId);
     expect(component.flagsData[3].flags.partyName).toEqual(witnessCaseFlagPartyName);
     expect(component.flagsData[3].flags.roleOnCase).toEqual(witnessCaseFlagRoleOnCase);
     expect(component.flagsData[3].flags.details.length).toBe(1);
     expect(component.flagsData[3].flags.details[0].name).toEqual(caseFlag1DetailsValue1.name);
-    expect(component.flagsData[4].flags.flagsCaseFieldId).toEqual(caseFlagGroup1FieldId1);
-    expect(component.flagsData[4].flags.partyName).toEqual(caseFlagGroup1PartyName);
-    expect(component.flagsData[4].flags.roleOnCase).toEqual(caseFlagGroup1RoleOnCase);
+    expect(component.flagsData[4].flags.flagsCaseFieldId).toEqual(witnessCaseFlagGroupExternalFieldId);
+    expect(component.flagsData[4].flags.partyName).toEqual(witnessCaseFlagPartyName);
+    expect(component.flagsData[4].flags.roleOnCase).toEqual(witnessCaseFlagRoleOnCase);
     expect(component.flagsData[4].flags.details.length).toBe(1);
-    expect(component.flagsData[4].flags.details[0].name).toEqual(caseFlagGroup1DetailsValue1.name);
-    expect(component.flagsData[5].flags.flagsCaseFieldId).toEqual(caseFlagGroup1FieldId2);
+    expect(component.flagsData[4].flags.details[0].name).toEqual(caseFlag1DetailsValue2.name);
+    expect(component.flagsData[5].flags.flagsCaseFieldId).toEqual(caseFlagGroup1FieldId1);
     expect(component.flagsData[5].flags.partyName).toEqual(caseFlagGroup1PartyName);
     expect(component.flagsData[5].flags.roleOnCase).toEqual(caseFlagGroup1RoleOnCase);
     expect(component.flagsData[5].flags.details.length).toBe(1);
-    expect(component.flagsData[5].flags.details[0].name).toEqual(caseFlagGroup1DetailsValue2.name);
-    expect(component.flagsData[6].flags.flagsCaseFieldId).toEqual(caseFlagGroup2FieldId1);
-    expect(component.flagsData[6].flags.partyName).toEqual(caseFlagGroup2PartyName);
-    expect(component.flagsData[6].flags.roleOnCase).toEqual(caseFlagGroup2RoleOnCase);
+    expect(component.flagsData[5].flags.details[0].name).toEqual(caseFlagGroup1DetailsValue1.name);
+    expect(component.flagsData[6].flags.flagsCaseFieldId).toEqual(caseFlagGroup1FieldId2);
+    expect(component.flagsData[6].flags.partyName).toEqual(caseFlagGroup1PartyName);
+    expect(component.flagsData[6].flags.roleOnCase).toEqual(caseFlagGroup1RoleOnCase);
     expect(component.flagsData[6].flags.details.length).toBe(1);
-    expect(component.flagsData[6].flags.details[0].name).toEqual(caseFlagGroup2DetailsValue1.name);
-    expect(component.flagsData[7].flags.flagsCaseFieldId).toEqual(caseFlagGroup2FieldId2);
+    expect(component.flagsData[6].flags.details[0].name).toEqual(caseFlagGroup1DetailsValue2.name);
+    expect(component.flagsData[7].flags.flagsCaseFieldId).toEqual(caseFlagGroup2FieldId1);
     expect(component.flagsData[7].flags.partyName).toEqual(caseFlagGroup2PartyName);
     expect(component.flagsData[7].flags.roleOnCase).toEqual(caseFlagGroup2RoleOnCase);
     expect(component.flagsData[7].flags.details.length).toBe(1);
-    expect(component.flagsData[7].flags.details[0].name).toEqual(caseFlagGroup2DetailsValue2.name);
+    expect(component.flagsData[7].flags.details[0].name).toEqual(caseFlagGroup2DetailsValue1.name);
+    expect(component.flagsData[8].flags.flagsCaseFieldId).toEqual(caseFlagGroup2FieldId2);
+    expect(component.flagsData[8].flags.partyName).toEqual(caseFlagGroup2PartyName);
+    expect(component.flagsData[8].flags.roleOnCase).toEqual(caseFlagGroup2RoleOnCase);
+    expect(component.flagsData[8].flags.details.length).toBe(1);
+    expect(component.flagsData[8].flags.details[0].name).toEqual(caseFlagGroup2DetailsValue2.name);
     // Check the party-level (non-grouped) and case-level flags are separated correctly
-    expect(component.partyLevelCaseFlagData.length).toBe(7);
+    expect(component.partyLevelCaseFlagData.length).toBe(8);
     expect(component.partyLevelCaseFlagData[0].flags.flagsCaseFieldId).toEqual(caseFlag1FieldId);
     expect(component.partyLevelCaseFlagData[1].flags.flagsCaseFieldId).toEqual(caseFlag2FieldId);
-    expect(component.partyLevelCaseFlagData[2].flags.flagsCaseFieldId).toEqual('PartyFlags');
-    expect(component.partyLevelCaseFlagData[3].flags.flagsCaseFieldId).toEqual(caseFlagGroup1FieldId1);
-    expect(component.partyLevelCaseFlagData[4].flags.flagsCaseFieldId).toEqual(caseFlagGroup1FieldId2);
-    expect(component.partyLevelCaseFlagData[5].flags.flagsCaseFieldId).toEqual(caseFlagGroup2FieldId1);
-    expect(component.partyLevelCaseFlagData[6].flags.flagsCaseFieldId).toEqual(caseFlagGroup2FieldId2);
+    expect(component.partyLevelCaseFlagData[2].flags.flagsCaseFieldId).toEqual(witnessCaseFlagGroupInternalFieldId);
+    expect(component.partyLevelCaseFlagData[3].flags.flagsCaseFieldId).toEqual(witnessCaseFlagGroupExternalFieldId);
+    expect(component.partyLevelCaseFlagData[4].flags.flagsCaseFieldId).toEqual(caseFlagGroup1FieldId1);
+    expect(component.partyLevelCaseFlagData[5].flags.flagsCaseFieldId).toEqual(caseFlagGroup1FieldId2);
+    expect(component.partyLevelCaseFlagData[6].flags.flagsCaseFieldId).toEqual(caseFlagGroup2FieldId1);
+    expect(component.partyLevelCaseFlagData[7].flags.flagsCaseFieldId).toEqual(caseFlagGroup2FieldId2);
+    expect(component.caseLevelCaseFlagData).toEqual(component.flagsData[2]);
+  });
+
+  it('should extract all flags-related data from the CaseView object, grouping flags by groupId, where flags.details is null', () => {
+    // Flags data is grouped by groupId where present, if the user is not external (the default)
+    formGroup.get(flagLauncher1CaseField.id)['component'].caseField = {
+      display_context_parameter: null
+    };
+    // Check that code to merge internal and external flag collections still works if a flag details array is falsy
+    witnessComplexFieldValue.PartyFlagsInternal.details = null;
+    component.ngOnInit();
+    expect(component.flagsData).toBeTruthy();
+    expect(component.flagsData.length).toBe(9);
+    expect(component.flagsData[0].flags.flagsCaseFieldId).toEqual(caseFlag1FieldId);
+    expect(component.flagsData[0].flags.partyName).toEqual(caseFlag1PartyName);
+    expect(component.flagsData[0].flags.roleOnCase).toEqual(caseFlag1RoleOnCase);
+    expect(component.flagsData[0].flags.details.length).toBe(2);
+    expect(component.flagsData[0].flags.details[0].name).toEqual(caseFlag1DetailsValue1.name);
+    expect(component.flagsData[0].flags.details[0].dateTimeModified).toEqual(new Date(caseFlag1DetailsValue1.dateTimeModified));
+    expect(component.flagsData[0].flags.details[0].dateTimeCreated).toEqual(new Date(caseFlag1DetailsValue1.dateTimeCreated));
+    expect(component.flagsData[0].flags.details[0].hearingRelevant).toBe(false);
+    expect(component.flagsData[1].flags.flagsCaseFieldId).toEqual(caseFlag2FieldId);
+    expect(component.flagsData[1].flags.partyName).toEqual(caseFlag2PartyName);
+    expect(component.flagsData[1].flags.roleOnCase).toEqual(caseFlag2RoleOnCase);
+    expect(component.flagsData[1].flags.details.length).toBe(2);
+    expect(component.flagsData[1].flags.details[1].name).toEqual(caseFlag2DetailsValue2.name);
+    expect(component.flagsData[1].flags.details[1].dateTimeModified).toEqual(new Date(caseFlag1DetailsValue1.dateTimeModified));
+    expect(component.flagsData[1].flags.details[1].dateTimeCreated).toEqual(new Date(caseFlag1DetailsValue1.dateTimeCreated));
+    expect(component.flagsData[1].flags.details[1].hearingRelevant).toBe(true);
+    expect(component.flagsData[2].flags.flagsCaseFieldId).toEqual(caseFlagsFieldId);
+    expect(component.flagsData[2].flags.partyName).toBeUndefined();
+    expect(component.flagsData[2].flags.roleOnCase).toBeUndefined();
+    expect(component.flagsData[2].flags.details.length).toBe(1);
+    expect(component.flagsData[2].flags.details[0].name).toEqual(caseLevelFlagDetailsValue.name);
+    expect(component.flagsData[2].flags.details[0].dateTimeModified).toEqual(new Date(caseLevelFlagDetailsValue.dateTimeModified));
+    expect(component.flagsData[2].flags.details[0].dateTimeCreated).toEqual(new Date(caseLevelFlagDetailsValue.dateTimeCreated));
+    expect(component.flagsData[2].flags.details[0].hearingRelevant).toBe(true);
+    expect(component.flagsData[3].flags.flagsCaseFieldId).toEqual(witnessCaseFlagGroupInternalFieldId);
+    expect(component.flagsData[3].flags.partyName).toEqual(witnessCaseFlagPartyName);
+    expect(component.flagsData[3].flags.roleOnCase).toEqual(witnessCaseFlagRoleOnCase);
+    // Flags will have been grouped so, due to shared object references, the flags details array length will be 1 not 0
+    // (external flags array with one flag will have been merged with an empty internal flags array)
+    expect(component.flagsData[3].flags.details.length).toBe(1);
+    expect(component.flagsData[3].flags.details[0].name).toEqual(caseFlag1DetailsValue2.name);
+    expect(component.flagsData[4].flags.flagsCaseFieldId).toEqual(witnessCaseFlagGroupExternalFieldId);
+    expect(component.flagsData[4].flags.partyName).toEqual(witnessCaseFlagPartyName);
+    expect(component.flagsData[4].flags.roleOnCase).toEqual(witnessCaseFlagRoleOnCase);
+    expect(component.flagsData[4].flags.details.length).toBe(1);
+    expect(component.flagsData[4].flags.details[0].name).toEqual(caseFlag1DetailsValue2.name);
+    expect(component.flagsData[5].flags.flagsCaseFieldId).toEqual(caseFlagGroup1FieldId1);
+    expect(component.flagsData[5].flags.partyName).toEqual(caseFlagGroup1PartyName);
+    expect(component.flagsData[5].flags.roleOnCase).toEqual(caseFlagGroup1RoleOnCase);
+    expect(component.flagsData[5].flags.details[0].name).toEqual(caseFlagGroup1DetailsValue1.name);
+    expect(component.flagsData[6].flags.flagsCaseFieldId).toEqual(caseFlagGroup1FieldId2);
+    expect(component.flagsData[6].flags.partyName).toEqual(caseFlagGroup1PartyName);
+    expect(component.flagsData[6].flags.roleOnCase).toEqual(caseFlagGroup1RoleOnCase);
+    expect(component.flagsData[6].flags.details[0].name).toEqual(caseFlagGroup1DetailsValue2.name);
+    expect(component.flagsData[7].flags.flagsCaseFieldId).toEqual(caseFlagGroup2FieldId1);
+    expect(component.flagsData[7].flags.partyName).toEqual(caseFlagGroup2PartyName);
+    expect(component.flagsData[7].flags.roleOnCase).toEqual(caseFlagGroup2RoleOnCase);
+    expect(component.flagsData[7].flags.details[0].name).toEqual(caseFlagGroup2DetailsValue1.name);
+    expect(component.flagsData[8].flags.flagsCaseFieldId).toEqual(caseFlagGroup2FieldId2);
+    expect(component.flagsData[8].flags.partyName).toEqual(caseFlagGroup2PartyName);
+    expect(component.flagsData[8].flags.roleOnCase).toEqual(caseFlagGroup2RoleOnCase);
+    expect(component.flagsData[8].flags.details[0].name).toEqual(caseFlagGroup2DetailsValue2.name);
+    // Check the party-level and case-level flags are separated correctly, and the party-level flags are grouped by
+    // groupId (i.e. there are no duplicate parties). These are expected to appear before the non-grouped flags
+    expect(component.partyLevelCaseFlagData.length).toBe(5);
+    expect(component.partyLevelCaseFlagData[0].flags.flagsCaseFieldId).toEqual(witnessCaseFlagGroupInternalFieldId);
+    expect(component.partyLevelCaseFlagData[0].flags.partyName).toEqual(witnessCaseFlagPartyName);
+    // The grouped flags details array length should be 1 (external flags array with one flag will have been merged
+    // with an empty internal flags array)
+    expect(component.partyLevelCaseFlagData[0].flags.details.length).toBe(1);
+    expect(component.partyLevelCaseFlagData[0].flags.details[0].name).toEqual(caseFlag1DetailsValue2.name);
+    expect(component.partyLevelCaseFlagData[1].flags.flagsCaseFieldId).toEqual(caseFlagGroup1FieldId1);
+    expect(component.partyLevelCaseFlagData[1].flags.partyName).toEqual(caseFlagGroup1PartyName);
+    expect(component.partyLevelCaseFlagData[1].flags.details.length).toBe(2);
+    expect(component.partyLevelCaseFlagData[1].flags.details[0].name).toEqual(caseFlagGroup1DetailsValue1.name);
+    expect(component.partyLevelCaseFlagData[1].flags.details[1].name).toEqual(caseFlagGroup1DetailsValue2.name);
+    expect(component.partyLevelCaseFlagData[2].flags.flagsCaseFieldId).toEqual(caseFlagGroup2FieldId1);
+    expect(component.partyLevelCaseFlagData[2].flags.partyName).toEqual(caseFlagGroup2PartyName);
+    expect(component.partyLevelCaseFlagData[2].flags.details.length).toBe(2);
+    expect(component.partyLevelCaseFlagData[2].flags.details[0].name).toEqual(caseFlagGroup2DetailsValue1.name);
+    expect(component.partyLevelCaseFlagData[2].flags.details[1].name).toEqual(caseFlagGroup2DetailsValue2.name);
+    expect(component.partyLevelCaseFlagData[3].flags.flagsCaseFieldId).toEqual(caseFlag1FieldId);
+    expect(component.partyLevelCaseFlagData[4].flags.flagsCaseFieldId).toEqual(caseFlag2FieldId);
     expect(component.caseLevelCaseFlagData).toEqual(component.flagsData[2]);
   });
 
   it('should extract the correct flags-related data for a given FlagLauncher field instance', () => {
     expect(component.flagsData).toBeTruthy();
-    expect(component.flagsData.length).toBe(8);
+    expect(component.flagsData.length).toBe(9);
     expect(component.flagsData[0].flags.flagsCaseFieldId).toEqual(caseFlag1FieldId);
     expect(component.flagsData[0].flags.partyName).toEqual(caseFlag1PartyName);
     expect(component.flagsData[0].flags.roleOnCase).toEqual(caseFlag1RoleOnCase);
@@ -681,7 +835,7 @@ describe('ReadCaseFlagFieldComponent', () => {
     TestBed.inject(ActivatedRoute).snapshot.data.case.tabs[2].fields[1].value = null;
     TestBed.inject(ActivatedRoute).snapshot.data.case.tabs[2].fields[2].value = undefined;
     component.ngOnInit();
-    expect(component.flagsData.length).toBe(6);
+    expect(component.flagsData.length).toBe(7);
   });
 
   xit('should map a Flags case field to a Flags object even if it has no flag details', () => {

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/read-case-flag-field.component.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/read-case-flag-field.component.ts
@@ -69,7 +69,8 @@ export class ReadCaseFlagFieldComponent extends AbstractFieldReadComponent imple
         .filter((f) => f.flags.groupId)
         .reduce((mergedFlagDetails, f) => {
           mergedFlagDetails[f.flags.groupId] = mergedFlagDetails[f.flags.groupId] || [];
-          mergedFlagDetails[f.flags.groupId].push(...f.flags.details);
+          // The flags.details property (which should be an array) could be falsy; spread an empty array if so
+          mergedFlagDetails[f.flags.groupId].push(...(f.flags.details || []));
           return mergedFlagDetails;
         }, Object.create(null));
         // Remove duplicate flags objects with the same groupId (which are going to be treated as one for display

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/write-case-flag-field.component.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/write-case-flag-field.component.ts
@@ -543,6 +543,6 @@ export class WriteCaseFlagFieldComponent extends AbstractFieldWriteComponent imp
   }
 
   public setDisplayContextParameter(caseFields: CaseField[]): string {
-    return caseFields.find(caseField => FieldsUtils.isFlagLauncherCaseField(caseField))?.display_context_parameter;
+    return caseFields.find(caseField => FieldsUtils.isCaseFieldOfType(caseField, ['FlagLauncher']))?.display_context_parameter;
   }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
EUI-8934

### Change description ###
Fix merging of internal and external flags collections to work when a `Flags.details` array is falsy.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
