### PR TITLE
EUI-8990: Case Flags v2 fix - Use original persisted flag status throughout "Manage Case Flags" journey

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,7 @@
 ## RELEASE NOTES
+### Version 6.19.13-case-flags-v2-manage-case-flags-status-fix
+**EUI-8990** Fix bug where `UpdateFlagComponent` and `ManageCaseFlagsComponent` are using the flag status updated via the UI as if it was the actual persisted status. This causes problems when a user sets the status to "Inactive" or "Not approved", then returns to an earlier point in the "Manage Case Flags" journey via the Case Flag Summary (CYA) page. `UpdateFlagComponent` displays the wrong flag status options or none at all (if "Not approved" was selected previously), and `ManageCaseFlagsComponent` no longer displays the flag in the selection list because it has been wrongly filtered out
+
 ### Version 6.19.13-case-flags-v2-1-consolidation-final-fixes-5
 **EUI-8985** Fix incorrect logic for updating tab group selected index, ensuring it is done only when non-zero because zero indicates it is already selected
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "6.19.13-case-flags-v2-1-consolidation-final-fixes-5",
+  "version": "6.19.13-case-flags-v2-manage-case-flags-status-fix",
   "engines": {
     "yarn": "^3.5.0",
     "npm": "^8.10.0"

--- a/projects/ccd-case-ui-toolkit/package.json
+++ b/projects/ccd-case-ui-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "6.19.13-case-flags-v2-1-consolidation-final-fixes-5",
+  "version": "6.19.13-case-flags-v2-manage-case-flags-status-fix",
   "engines": {
     "yarn": "^3.5.0",
     "npm": "^8.10.0"

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/manage-case-flags/manage-case-flags.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/manage-case-flags/manage-case-flags.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { RpxLanguage, RpxTranslationService } from 'rpx-xui-translation';
 import { BehaviorSubject, Observable, of } from 'rxjs';
-import { CaseField } from '../../../../../domain';
+import { CaseField, FieldType } from '../../../../../domain';
 import { MockRpxTranslatePipe } from '../../../../../test/mock-rpx-translate.pipe';
 import { FlagDetail, FlagDetailDisplayWithFormGroupPath, FlagsWithFormGroupPath } from '../../domain';
 import { CaseFlagDisplayContextParameter, CaseFlagFieldState, CaseFlagWizardStepTitle, SelectFlagErrorMessage } from '../../enums';
@@ -14,37 +14,119 @@ describe('ManageCaseFlagsComponent', () => {
   let component: ManageCaseFlagsComponent;
   let fixture: ComponentFixture<ManageCaseFlagsComponent>;
   let mockRpxTranslationService: any;
+  const flag1 = {
+    name: 'Flag 1',
+    flagComment: 'First flag',
+    dateTimeCreated: new Date(),
+    path: [{ id: null, value: 'Reasonable adjustment' }],
+    hearingRelevant: false,
+    flagCode: 'FL1',
+    status: 'Active'
+  };
+  const flag2 = {
+    name: 'Flag 2',
+    flagComment: 'Rose\'s second flag',
+    dateTimeCreated: new Date(),
+    path: [{ id: null, value: 'Reasonable adjustment' }],
+    hearingRelevant: false,
+    flagCode: 'FL2',
+    status: 'Inactive'
+  };
+  const flagX = {
+    name: 'Flag X',
+    flagComment: 'Flag not approved',
+    dateTimeCreated: new Date(),
+    path: [{ id: null, value: 'Reasonable adjustment' }],
+    hearingRelevant: false,
+    flagCode: 'FL1',
+    status: 'Not approved'
+  };
+  const flag3 = {
+    name: 'Flag 3',
+    flagComment: 'First flag',
+    dateTimeCreated: new Date(),
+    path: [{ id: null, value: 'Reasonable adjustment' }],
+    hearingRelevant: false,
+    flagCode: 'FL1',
+    status: 'Active'
+  };
+  const flag4 = {
+    name: 'Flag 4',
+    flagComment: 'Fourth flag',
+    dateTimeCreated: new Date(),
+    path: [
+      { id: null, value: 'Level 1' },
+      { id: null, value: 'Level 2' }
+    ],
+    hearingRelevant: false,
+    flagCode: 'FL1',
+    status: 'Active'
+  };
+  const flag5 = {
+    name: 'Flag 5',
+    name_cy: 'Fflag 5',
+    flagComment: 'Fifth flag',
+    flagComment_cy: 'Fifth flag - Welsh',
+    dateTimeCreated: new Date(),
+    path: [
+      { id: null, value: 'Level 1' }
+    ],
+    hearingRelevant: false,
+    flagCode: 'FL1',
+    status: 'Active',
+    subTypeKey: 'Dummy subtype key',
+    subTypeValue: 'Dummy subtype value',
+    subTypeValue_cy: 'Dummy subtype value - Welsh'
+  };
   const flagsData = [
     {
       flags: {
         partyName: 'Rose Bank',
         details: [
           {
-            id: '1234',
-            name: 'Flag 1',
-            flagComment: 'First flag',
-            dateTimeCreated: new Date(),
-            path: [{ id: null, value: 'Reasonable adjustment' }],
-            hearingRelevant: false,
-            flagCode: 'FL1',
-            status: 'Active'
+            id: '95de3cde-9f1b-468b-863b-8bc29ce7e600',
+            ...flag1
           },
           {
-            id: '2345',
-            name: 'Flag 2',
-            flagComment: 'Rose\'s second flag',
-            dateTimeCreated: new Date(),
-            path: [{ id: null, value: 'Reasonable adjustment' }],
-            hearingRelevant: false,
-            flagCode: 'FL2',
-            status: 'Inactive'
+            id: '34aaf022-19f2-4b03-b78c-6e73fc29e3f2',
+            ...flag2
           }
         ] as FlagDetail[],
         flagsCaseFieldId: 'CaseFlag1'
       },
-      pathToFlagsFormGroup: '',
+      pathToFlagsFormGroup: 'CaseFlag1',
       caseField: {
-        id: 'CaseFlag1'
+        id: 'CaseFlag1',
+        field_type: {
+          id: 'Flags',
+          type: 'Complex'
+        } as FieldType,
+        formatted_value: {
+          partyName: 'Rose Bank',
+          details: [
+            {
+              id: '95de3cde-9f1b-468b-863b-8bc29ce7e600',
+              value: { ...flag1, status: 'Requested' }
+            },
+            {
+              id: '34aaf022-19f2-4b03-b78c-6e73fc29e3f2',
+              value: { ...flag2 }
+            }
+          ]
+        },
+        value: {
+          partyName: 'Rose Bank',
+          details: [
+            {
+              id: '95de3cde-9f1b-468b-863b-8bc29ce7e600',
+              value: { ...flag1 }
+            },
+            {
+              id: '34aaf022-19f2-4b03-b78c-6e73fc29e3f2',
+              value: { ...flag2 }
+            }
+          ]
+        }
       } as CaseField
     },
     {
@@ -52,31 +134,49 @@ describe('ManageCaseFlagsComponent', () => {
         partyName: 'Tom Atin',
         details: [
           {
-            id: '7890',
-            name: 'Flag X',
-            flagComment: 'Flag not approved',
-            dateTimeCreated: new Date(),
-            path: [{ id: null, value: 'Reasonable adjustment' }],
-            hearingRelevant: false,
-            flagCode: 'FL1',
-            status: 'Not approved'
+            id: 'd9348799-1532-444a-b577-cd546e2f58f1',
+            ...flagX
           },
           {
-            id: '3456',
-            name: 'Flag 3',
-            flagComment: 'First flag',
-            dateTimeCreated: new Date(),
-            path: [{ id: null, value: 'Reasonable adjustment' }],
-            hearingRelevant: false,
-            flagCode: 'FL1',
-            status: 'Active'
+            id: '013abc9c-738c-4634-85fa-2910a8cd40a4',
+            ...flag3
           }
         ] as FlagDetail[],
         flagsCaseFieldId: 'CaseFlag2'
       },
-      pathToFlagsFormGroup: '',
+      pathToFlagsFormGroup: 'CaseFlag2',
       caseField: {
-        id: 'CaseFlag2'
+        id: 'CaseFlag2',
+        field_type: {
+          id: 'Flags',
+          type: 'Complex'
+        } as FieldType,
+        formatted_value: {
+          partyName: 'Tom Atin',
+          details: [
+            {
+              id: 'd9348799-1532-444a-b577-cd546e2f58f1',
+              value: { ...flagX }
+            },
+            {
+              id: '013abc9c-738c-4634-85fa-2910a8cd40a4',
+              value: { ...flag3, status: 'Requested' }
+            }
+          ]
+        },
+        value: {
+          partyName: 'Tom Atin',
+          details: [
+            {
+              id: 'd9348799-1532-444a-b577-cd546e2f58f1',
+              value: { ...flagX }
+            },
+            {
+              id: '013abc9c-738c-4634-85fa-2910a8cd40a4',
+              value: { ...flag3 }
+            }
+          ]
+        }
       } as CaseField
     },
     {
@@ -84,24 +184,37 @@ describe('ManageCaseFlagsComponent', () => {
         partyName: '',
         details: [
           {
-            id: '4567',
-            name: 'Flag 4',
-            flagComment: 'Fourth flag',
-            dateTimeCreated: new Date(),
-            path: [
-              { id: null, value: 'Level 1' },
-              { id: null, value: 'Level 2' }
-            ],
-            hearingRelevant: false,
-            flagCode: 'FL1',
-            status: 'Active'
+            id: '573ce187-abae-4121-81d3-53fbba074e62',
+            ...flag4
           }
         ] as FlagDetail[],
         flagsCaseFieldId: 'CaseFlag3'
       },
       pathToFlagsFormGroup: 'caseFlags',
       caseField: {
-        id: 'CaseFlag3'
+        id: 'CaseFlag3',
+        field_type: {
+          id: 'Flags',
+          type: 'Complex'
+        } as FieldType,
+        formatted_value: {
+          partyName: '',
+          details: [
+            {
+              id: '573ce187-abae-4121-81d3-53fbba074e62',
+              value: { ...flag4, status: 'Requested' }
+            }
+          ]
+        },
+        value: {
+          partyName: '',
+          details: [
+            {
+              id: '573ce187-abae-4121-81d3-53fbba074e62',
+              value: { ...flag4 }
+            }
+          ]
+        }
       } as CaseField
     },
     {
@@ -109,28 +222,37 @@ describe('ManageCaseFlagsComponent', () => {
         partyName: '',
         details: [
           {
-            id: '5678',
-            name: 'Flag 5',
-            name_cy: 'Fflag 5',
-            flagComment: 'Fifth flag',
-            flagComment_cy: 'Fifth flag - Welsh',
-            dateTimeCreated: new Date(),
-            path: [
-              { id: null, value: 'Level 1' }
-            ],
-            hearingRelevant: false,
-            flagCode: 'FL1',
-            status: 'Active',
-            subTypeKey: 'Dummy subtype key',
-            subTypeValue: 'Dummy subtype value',
-            subTypeValue_cy: 'Dummy subtype value - Welsh'
+            id: 'aa692b36-9dc0-43de-b5f8-2dba78664376',
+            ...flag5
           }
         ] as FlagDetail[],
         flagsCaseFieldId: 'CaseFlag3'
       },
       pathToFlagsFormGroup: 'caseFlags',
       caseField: {
-        id: 'CaseFlag3'
+        id: 'CaseFlag3',
+        field_type: {
+          id: 'Flags',
+          type: 'Complex'
+        } as FieldType,
+        formatted_value: {
+          partyName: '',
+          details: [
+            {
+              id: 'aa692b36-9dc0-43de-b5f8-2dba78664376',
+              value: { ...flag5, status: 'Requested' }
+            }
+          ]
+        },
+        value: {
+          partyName: '',
+          details: [
+            {
+              id: 'aa692b36-9dc0-43de-b5f8-2dba78664376',
+              value: { ...flag5 }
+            }
+          ]
+        }
       } as CaseField
     }
   ] as FlagsWithFormGroupPath[];
@@ -221,6 +343,7 @@ describe('ManageCaseFlagsComponent', () => {
     expect(displayResult.flagDetailDisplay.flagDetail.name).toEqual(flagDetail.name);
     expect(displayResult.flagDetailDisplay.flagDetail.flagComment).toEqual(flagDetail.flagComment);
     expect(displayResult.flagDetailDisplay.flagDetail.flagCode).toEqual(flagDetail.flagCode);
+    expect(displayResult.originalStatus).toBeUndefined();
     expect(displayResult.pathToFlagsFormGroup).toEqual(flagsInstance.flags.flagsCaseFieldId);
   });
 
@@ -232,21 +355,96 @@ describe('ManageCaseFlagsComponent', () => {
     expect(component.flagsDisplayData[0].flagDetailDisplay.flagDetail.name).toEqual(flagsData[0].flags.details[0].name);
     expect(component.flagsDisplayData[0].flagDetailDisplay.flagDetail.flagComment).toEqual(flagsData[0].flags.details[0].flagComment);
     expect(component.flagsDisplayData[0].flagDetailDisplay.flagDetail.flagCode).toEqual(flagsData[0].flags.details[0].flagCode);
+    expect(component.flagsDisplayData[0].pathToFlagsFormGroup).toEqual(flagsData[0].pathToFlagsFormGroup);
+    expect(component.flagsDisplayData[0].originalStatus).toEqual(flagsData[0].caseField.formatted_value.details[0].value.status);
     // Check correct mapping of the second party's flags
     expect(component.flagsDisplayData[1].flagDetailDisplay.partyName).toEqual(flagsData[1].flags.partyName);
     expect(component.flagsDisplayData[1].flagDetailDisplay.flagDetail.name).toEqual(flagsData[1].flags.details[1].name);
     expect(component.flagsDisplayData[1].flagDetailDisplay.flagDetail.flagComment).toEqual(flagsData[1].flags.details[1].flagComment);
     expect(component.flagsDisplayData[1].flagDetailDisplay.flagDetail.flagCode).toEqual(flagsData[1].flags.details[1].flagCode);
+    expect(component.flagsDisplayData[1].pathToFlagsFormGroup).toEqual(flagsData[1].pathToFlagsFormGroup);
+    expect(component.flagsDisplayData[1].originalStatus).toEqual(flagsData[1].caseField.formatted_value.details[1].value.status);
     // Check correct mapping of the third party's flags
     expect(component.flagsDisplayData[2].flagDetailDisplay.partyName).toEqual(flagsData[2].flags.partyName);
     expect(component.flagsDisplayData[2].flagDetailDisplay.flagDetail.name).toEqual(flagsData[2].flags.details[0].name);
     expect(component.flagsDisplayData[2].flagDetailDisplay.flagDetail.flagComment).toEqual(flagsData[2].flags.details[0].flagComment);
     expect(component.flagsDisplayData[2].flagDetailDisplay.flagDetail.flagCode).toEqual(flagsData[2].flags.details[0].flagCode);
+    expect(component.flagsDisplayData[2].pathToFlagsFormGroup).toEqual(flagsData[2].pathToFlagsFormGroup);
+    expect(component.flagsDisplayData[2].originalStatus).toEqual(flagsData[2].caseField.formatted_value.details[0].value.status);
     // Check correct mapping of the fourth party's flags
     expect(component.flagsDisplayData[3].flagDetailDisplay.partyName).toEqual(flagsData[3].flags.partyName);
     expect(component.flagsDisplayData[3].flagDetailDisplay.flagDetail.name).toEqual(flagsData[3].flags.details[0].name);
     expect(component.flagsDisplayData[3].flagDetailDisplay.flagDetail.flagComment).toEqual(flagsData[3].flags.details[0].flagComment);
     expect(component.flagsDisplayData[3].flagDetailDisplay.flagDetail.flagCode).toEqual(flagsData[3].flags.details[0].flagCode);
+    expect(component.flagsDisplayData[3].pathToFlagsFormGroup).toEqual(flagsData[3].pathToFlagsFormGroup);
+    expect(component.flagsDisplayData[3].originalStatus).toEqual(flagsData[3].caseField.formatted_value.details[0].value.status);
+  });
+
+  it('should map a flag instance for display, where the parent Flags object is a sub-field of a Complex type', () => {
+    const flag1Detail = {
+      id: 'a3e71b29-3f4c-4f60-850c-f002a4d686a8',
+      ...flag1
+    } as FlagDetail;
+    const flagsInstance = {
+      flags: {
+        partyName: 'Ruki Tsunama',
+        details: [
+          flag1Detail,
+          {
+            id: '5fa87240-1856-45a3-9fa7-4dcc8b559396',
+            ...flag2
+          }
+        ] as FlagDetail[],
+        flagsCaseFieldId: 'Witness1'
+      },
+      pathToFlagsFormGroup: 'Witness1.partyFlags',
+      caseField: {
+        id: 'Witness1',
+        field_type: {
+          id: 'Witness',
+          type: 'Complex'
+        } as FieldType,
+        formatted_value: {
+          firstName: 'Ruki',
+          lastName: 'Tsunama',
+          partyFlags: {
+            partyName: 'Ruki Tsunama',
+            details: [
+              {
+                id: 'a3e71b29-3f4c-4f60-850c-f002a4d686a8',
+                value: { ...flag1, status: 'Requested' }
+              },
+              {
+                id: '5fa87240-1856-45a3-9fa7-4dcc8b559396',
+                value: { ...flag2 }
+              }
+            ]
+          }
+        },
+        value: {
+          firstName: 'Ruki',
+          lastName: 'Tsunama',
+          partyFlags: {
+            partyName: 'Ruki Tsunama',
+            details: [
+              {
+                id: 'a3e71b29-3f4c-4f60-850c-f002a4d686a8',
+                value: { ...flag1 }
+              },
+              {
+                id: '5fa87240-1856-45a3-9fa7-4dcc8b559396',
+                value: { ...flag2 }
+              }
+            ]
+          }
+        }
+      } as CaseField
+    } as FlagsWithFormGroupPath;
+    const flagDetailMappedForDisplay = component.mapFlagDetailForDisplay(flag1Detail, flagsInstance);
+    expect(flagDetailMappedForDisplay.flagDetailDisplay.partyName).toEqual(flagsInstance.flags.partyName);
+    expect(flagDetailMappedForDisplay.flagDetailDisplay.flagDetail).toEqual(flag1Detail);
+    expect(flagDetailMappedForDisplay.pathToFlagsFormGroup).toEqual(flagsInstance.pathToFlagsFormGroup);
+    expect(flagDetailMappedForDisplay.originalStatus).toEqual(flagsInstance.caseField.formatted_value.partyFlags.details[0].value.status);
   });
 
   it('should emit to parent with the selected party and flag details if the validation succeeds', () => {
@@ -265,9 +463,10 @@ describe('ManageCaseFlagsComponent', () => {
           flagDetail: flagsData[1].flags.details[1],
           flagsCaseFieldId: flagsData[1].flags.flagsCaseFieldId
         },
-        pathToFlagsFormGroup: '',
+        pathToFlagsFormGroup: flagsData[1].pathToFlagsFormGroup,
         caseField: flagsData[1].caseField,
-        roleOnCase: undefined
+        roleOnCase: undefined,
+        originalStatus: flagsData[1].caseField.formatted_value.details[1].value.status
       } as FlagDetailDisplayWithFormGroupPath
     });
     expect(component.errorMessages.length).toBe(0);

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/update-flag/update-flag.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/update-flag/update-flag.component.spec.ts
@@ -689,4 +689,23 @@ describe('UpdateFlagComponent', () => {
     // The "Make inactive" button should no longer be visible
     expect(fixture.debugElement.nativeElement.querySelector('.button-secondary')).toBeNull();
   });
+
+  it('should use the original persisted flag status instead of the UI value, to determine the actual flag status', () => {
+    // Set the original status of selectedFlag1 to "Requested" (its UI value is "Active")
+    selectedFlag1.originalStatus = 'Requested';
+    // Reset activeFlag status to "Active" because it gets changed by other tests
+    activeFlag.status = 'Active';
+    component.formGroup = new FormGroup({
+      selectedManageCaseLocation: new FormControl(selectedFlag1)
+    });
+    fixture.detectChanges();
+    // All four status options should be in the list of valid progressions
+    expect(component.validStatusProgressions).toEqual(Object.keys(CaseFlagStatus));
+    // Remove the original status of selectedFlag1; the component should fall back on the UI value
+    selectedFlag1.originalStatus = null;
+    component.ngOnInit();
+    // Only "Active" and "Inactive" status options should be in the list of valid progressions
+    expect(component.validStatusProgressions).toEqual(
+      Object.keys(CaseFlagStatus).filter(key => !['REQUESTED', 'NOT_APPROVED'].includes(key)));
+  });
 });

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/update-flag/update-flag.component.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/update-flag/update-flag.component.ts
@@ -52,7 +52,12 @@ export class UpdateFlagComponent implements OnInit {
     this.selectedFlag = this.formGroup.get(this.selectedManageCaseLocation).value as FlagDetailDisplayWithFormGroupPath;
     if (this.selectedFlag?.flagDetailDisplay?.flagDetail) {
       this.flagDetail = this.selectedFlag.flagDetailDisplay.flagDetail;
-      const currentFlagStatusKey = Object.keys(CaseFlagStatus).find(key => CaseFlagStatus[key] === this.flagDetail.status);
+      // If present, use the *original* flag status, not the one in the flagDetail object, because the status could have
+      // been modified via a previous "Update Flag" journey through the UI but not persisted yet (thus not the *true* flag
+      // status). Otherwise, use the status from the flagDetail object (initially, the original flag status won't be
+      // present because it gets cached only on first update by WriteCaseFlagFieldComponent)
+      const currentFlagStatusKey = Object.keys(CaseFlagStatus).find(
+        (key) => CaseFlagStatus[key] === (this.selectedFlag.originalStatus || this.flagDetail.status));
 
       // Populate flag comments text area with existing comments; use the comments appropriate for the selected language,
       // falling back on their alternate counterpart if none are available. Comments are to be populated one time only -

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/domain/case-flag.model.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/domain/case-flag.model.ts
@@ -55,7 +55,8 @@ export interface FlagsWithFormGroupPath {
 }
 
 /**
- * Wrapper interface for FlagDetailDisplay that adds the path to the corresponding FormGroup, and the CaseField
+ * Wrapper interface for FlagDetailDisplay that adds the path to the corresponding FormGroup, the CaseField, and the
+ * original flag status
  */
 export interface FlagDetailDisplayWithFormGroupPath {
   flagDetailDisplay: FlagDetailDisplay;
@@ -63,4 +64,5 @@ export interface FlagDetailDisplayWithFormGroupPath {
   caseField: CaseField;
   roleOnCase?: string;
   label?: string;
+  originalStatus?: string;
 }

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/write-case-flag-field.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/write-case-flag-field.component.spec.ts
@@ -750,6 +750,8 @@ describe('WriteCaseFlagFieldComponent', () => {
     expect(component.flagsData[0].caseField.value.details[0].value.status).toEqual(
       CaseFlagStatus[component.caseFlagParentFormGroup.value[CaseFlagFormFields.STATUS]]);
     expect(component.flagsData[0].caseField.value.details[0].value.dateTimeModified).toBeTruthy();
+    // Check the original status has been cached
+    expect(component.selectedFlag.originalStatus).toEqual('Active');
     // Check all other existing changes have been discarded (i.e. values restored from corresponding values in formatted_value)
     expect(component.flagsData[0].caseField.value.details[1].value.otherDescription).toEqual('Original description');
     expect(component.flagsData[0].caseField.value.details[1].value.otherDescription_cy).toEqual('Welsh description');

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/write-case-flag-field.component.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/write-case-flag-field.component.ts
@@ -416,6 +416,10 @@ export class WriteCaseFlagFieldComponent extends AbstractFieldWriteComponent imp
       const flagDetailToUpdate = flagsCaseFieldValue.details.find(
         detail => detail.id === this.selectedFlag.flagDetailDisplay.flagDetail.id);
       if (flagDetailToUpdate) {
+        // Cache the *original* status of the flag before it is modified. This is needed if the user changes the flag status
+        // then decides to return to any part of the flag update journey. The ManageCaseFlagsComponent and UpdateFlagComponent
+        // should refer to a flag's original status, not the one set via the UI because this hasn't been persisted yet
+        this.selectedFlag.originalStatus = flagDetailToUpdate.value.status;
         // Update description fields only if flag type is "Other" (flag code OT0001); these fields apply only to that flag type
         flagDetailToUpdate.value.otherDescription = flagDetailToUpdate.value.flagCode === this.otherFlagTypeCode
           ? this.caseFlagParentFormGroup.get(CaseFlagFormFields.OTHER_FLAG_DESCRIPTION)?.value


### PR DESCRIPTION
### JIRA link (if applicable) ###
EUI-8990

### Change description ###
Fix bug where the flag status updated via the UI is used as if it was the actual persisted status. This causes problems when a user sets the status to "Inactive" or "Not approved", then returns to an earlier point in the "Manage Case Flags" journey. `UpdateFlagComponent` displays the wrong flag status options or none at all (if "Not approved" was selected previously), and `ManageCaseFlagsComponent` no longer displays the flag in the selection list.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
