### PR TITLE
EUI-9000/EUI-9009: Case Flags v2.1 fixes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,8 @@
 ## RELEASE NOTES
+### Version 6.19.13-case-flags-v2-1-consolidation-final-fixes-7
+**EUI-9000** Amend "Comments" field label for external users to display static text instead of duplicating the page title
+**EUI-9009** Fix bug where `otherDescription`, `otherDescription_cy`, and `flagComment_cy` field values are not retained when a flag is updated and those fields are not part of the update
+
 ### Version 6.19.13-case-flags-v2-1-consolidation-final-fixes-6
 **EUI-8999** Restrict display of the comments visibility warning text to flags not of type "Other (internal)" for the "Create Case Flag" journey, and flags that were previously created as external for the "Manage Case Flags" journey
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "6.19.13-case-flags-v2-1-consolidation-final-fixes-6",
+  "version": "6.19.13-case-flags-v2-1-consolidation-final-fixes-7",
   "engines": {
     "yarn": "^3.5.0",
     "npm": "^8.10.0"

--- a/projects/ccd-case-ui-toolkit/package.json
+++ b/projects/ccd-case-ui-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "6.19.13-case-flags-v2-1-consolidation-final-fixes-6",
+  "version": "6.19.13-case-flags-v2-1-consolidation-final-fixes-7",
   "engines": {
     "yarn": "^3.5.0",
     "npm": "^8.10.0"

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-editor/case-edit-submit/case-edit-submit.html
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-editor/case-edit-submit/case-edit-submit.html
@@ -105,9 +105,7 @@
       </button>
     </div>
     <p class="cancel">
-      <a (click)="cancel()" href="javascript:void(0)" [class.disabled]="caseEdit.isSubmitting">
-        {{getCancelText() | rpxTranslate}}
-      </a>
+      <a (click)="cancel()" href="javascript:void(0)" [class.disabled]="caseEdit.isSubmitting">{{getCancelText() | rpxTranslate}}</a>
     </p>
   </form>
 </div>

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/update-flag/update-flag.component.html
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/update-flag/update-flag.component.html
@@ -12,7 +12,11 @@
 
       <div class="govuk-!-margin-bottom-4">
         <label class="govuk-label govuk-label--s" [for]="caseFlagFormFields.COMMENTS">
-          {{updateFlagTitle | rpxTranslate}} {{'comments' | rpxTranslate}}
+          {{
+            externalUserUpdate
+              ? (updateFlagStepEnum.COMMENT_FIELD_LABEL_EXTERNAL | rpxTranslate)
+              : (updateFlagTitle | rpxTranslate) + (' comments' | rpxTranslate)
+          }}
         </label>
         <div id="update-flag-comments-hint-external" class="govuk-hint" *ngIf="externalUserUpdate">
           {{updateFlagStepEnum.COMMENT_HINT_TEXT_EXTERNAL | rpxTranslate}}

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/enums/update-flag-step.enum.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/enums/update-flag-step.enum.ts
@@ -2,6 +2,7 @@ export enum UpdateFlagStep {
   COMMENT_HINT_TEXT_INTERNAL = 'Explain why you are updating this flag. Do not include any sensitive information such as personal details.',
   COMMENT_HINT_TEXT_INTERNAL_2_POINT_1 = 'Update the comments describing the user\'s support needs or flag description. Do not include any sensitive information such as personal details.',
   COMMENT_HINT_TEXT_EXTERNAL = 'Do not include any sensitive information such as personal details.',
+  COMMENT_FIELD_LABEL_EXTERNAL = 'Please provide your comments below',
   CHARACTER_LIMIT_INFO = 'You can enter up to 200 characters',
   STATUS_HINT_TEXT = 'Describe reason for status change.',
   WARNING_TEXT = 'The details entered here MAY be visible to the party in the future.'

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/write-case-flag-field.component.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/write-case-flag-field.component.ts
@@ -421,25 +421,35 @@ export class WriteCaseFlagFieldComponent extends AbstractFieldWriteComponent imp
         // should refer to a flag's original status, not the one set via the UI because this hasn't been persisted yet
         this.selectedFlag.originalStatus = flagDetailToUpdate.value.status;
         // Update description fields only if flag type is "Other" (flag code OT0001); these fields apply only to that flag type
-        flagDetailToUpdate.value.otherDescription = flagDetailToUpdate.value.flagCode === this.otherFlagTypeCode
-          ? this.caseFlagParentFormGroup.get(CaseFlagFormFields.OTHER_FLAG_DESCRIPTION)?.value
-          : null,
-        flagDetailToUpdate.value.otherDescription_cy = flagDetailToUpdate.value.flagCode === this.otherFlagTypeCode
-          ? this.caseFlagParentFormGroup.get(CaseFlagFormFields.OTHER_FLAG_DESCRIPTION_WELSH)?.value
-          : null,
+        // If their FormControls don't exist, it means these fields weren't visited as part of the "Update Flag" journey, so do
+        // *not* update their values (otherwise they will become undefined)
+        if (flagDetailToUpdate.value.flagCode === this.otherFlagTypeCode) {
+          if (this.caseFlagParentFormGroup.get(CaseFlagFormFields.OTHER_FLAG_DESCRIPTION)) {
+            flagDetailToUpdate.value.otherDescription = this.caseFlagParentFormGroup.get(
+              CaseFlagFormFields.OTHER_FLAG_DESCRIPTION).value;
+          }
+          if (this.caseFlagParentFormGroup.get(CaseFlagFormFields.OTHER_FLAG_DESCRIPTION_WELSH)) {
+            flagDetailToUpdate.value.otherDescription_cy = this.caseFlagParentFormGroup.get(
+              CaseFlagFormFields.OTHER_FLAG_DESCRIPTION_WELSH).value;
+          }
+        }
         // Ensure that any comments entered with language set to Welsh do not end up in the English comments field
-        flagDetailToUpdate.value.flagComment = this.rpxTranslationService.language !== 'cy'
-          ? this.caseFlagParentFormGroup.get(CaseFlagFormFields.COMMENTS)?.value
-          : null,
+        if (this.rpxTranslationService.language !== 'cy') {
+          flagDetailToUpdate.value.flagComment = this.caseFlagParentFormGroup.get(CaseFlagFormFields.COMMENTS)?.value;
+        }
         // Populate from the *English* comments field if:
         // * The Welsh comments field has no value (Welsh comments field acquires a value only when an HMCTS internal user has
         // gone through the "add translation" step for Manage Case Flags), AND
         // * The language is set to Welsh
-        flagDetailToUpdate.value.flagComment_cy = this.caseFlagParentFormGroup.get(CaseFlagFormFields.COMMENTS_WELSH)?.value
+        // If the FormControl doesn't exist, it means this field wasn't visited as part of the "Update Flag" journey, so do
+        // *not* update its value (otherwise it will be overridden) - unless the user is external AND working in Welsh
+        if (this.caseFlagParentFormGroup.get(CaseFlagFormFields.COMMENTS_WELSH) || this.rpxTranslationService.language === 'cy') {
+          flagDetailToUpdate.value.flagComment_cy = this.caseFlagParentFormGroup.get(CaseFlagFormFields.COMMENTS_WELSH)?.value
           ? this.caseFlagParentFormGroup.get(CaseFlagFormFields.COMMENTS_WELSH)?.value
           : this.rpxTranslationService.language === 'cy'
             ? this.caseFlagParentFormGroup.get(CaseFlagFormFields.COMMENTS)?.value
-            : null,
+            : null;
+        }
         flagDetailToUpdate.value.flagUpdateComment = this.caseFlagParentFormGroup.get(CaseFlagFormFields.STATUS_CHANGE_REASON)?.value;
         flagDetailToUpdate.value.status = CaseFlagStatus[this.caseFlagParentFormGroup.get(CaseFlagFormFields.STATUS)?.value];
         flagDetailToUpdate.value.dateTimeModified = new Date().toISOString();


### PR DESCRIPTION
### JIRA link (if applicable) ###
EUI-9000
EUI-9009

### Change description ###
EUI-9000: Amend "Comments" field label for external users to display static text instead of duplicating the page title; EUI-9009: Fix bug where `otherDescription`, `otherDescription_cy`, and `flagComment_cy` field values are not retained when a flag is updated and those fields are not part of the update.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
