### PR TITLE
EUI-9016: Amend "Update flag" page to include flag description for flags of type "Other"

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,7 @@
 ## RELEASE NOTES
+### Version 6.19.13-case-flags-v2-update-flag-show-other-description
+**EUI-9016** Amend display of page title and field labels on "Update flag" page, to include the flag description for flags of type "Other"
+
 ### Version 6.19.13-case-flags-v2-1-consolidation-final-fixes-7
 **EUI-9000** Amend "Comments" field label for external users to display static text instead of duplicating the page title
 **EUI-9009** Fix bug where `otherDescription`, `otherDescription_cy`, and `flagComment_cy` field values are not retained when a flag is updated and those fields are not part of the update

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "6.19.13-case-flags-v2-1-consolidation-final-fixes-7",
+  "version": "6.19.13-case-flags-v2-update-flag-show-other-description",
   "engines": {
     "yarn": "^3.5.0",
     "npm": "^8.10.0"

--- a/projects/ccd-case-ui-toolkit/package.json
+++ b/projects/ccd-case-ui-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "6.19.13-case-flags-v2-1-consolidation-final-fixes-7",
+  "version": "6.19.13-case-flags-v2-update-flag-show-other-description",
   "engines": {
     "yarn": "^3.5.0",
     "npm": "^8.10.0"

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/update-flag/update-flag.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/update-flag/update-flag.component.spec.ts
@@ -70,6 +70,39 @@ describe('UpdateFlagComponent', () => {
     status: 'Active',
     subTypeValue: 'Sub Type'
   } as FlagDetail;
+  const activeFlagWithSubTypeValueCy = {
+    name: 'Flag 1',
+    flagComment: 'First flag',
+    flagComment_cy: 'Cymraeg',
+    dateTimeCreated: new Date(),
+    path: [{id: null, value: 'Reasonable adjustment'}],
+    hearingRelevant: false,
+    flagCode: 'FL1',
+    status: 'Active',
+    subTypeValue_cy: 'Sub Type (Welsh)'
+  } as FlagDetail;
+  const activeFlagWithOtherDescription = {
+    name: 'Flag 1',
+    flagComment: 'First flag',
+    flagComment_cy: 'Cymraeg',
+    dateTimeCreated: new Date(),
+    path: [{id: null, value: 'Reasonable adjustment'}],
+    hearingRelevant: false,
+    flagCode: 'OT0001',
+    status: 'Active',
+    otherDescription: 'Description'
+  } as FlagDetail;
+  const activeFlagWithOtherDescriptionCy = {
+    name: 'Flag 1',
+    flagComment: 'First flag',
+    flagComment_cy: 'Cymraeg',
+    dateTimeCreated: new Date(),
+    path: [{id: null, value: 'Reasonable adjustment'}],
+    hearingRelevant: false,
+    flagCode: 'OT0001',
+    status: 'Active',
+    otherDescription_cy: 'Description (Welsh)'
+  } as FlagDetail;
   const selectedFlag1 = {
     flagDetailDisplay: {
       partyName: 'Rose Bank',
@@ -507,7 +540,14 @@ describe('UpdateFlagComponent', () => {
     component.displayContextParameter = '';
     expect(component.setUpdateCaseFlagTitle(activeFlag)).toEqual(CaseFlagWizardStepTitle.NONE);
     component.displayContextParameter = CaseFlagDisplayContextParameter.UPDATE;
-    expect(component.setUpdateCaseFlagTitle(activeFlagWithSubTypeValue)).toEqual(`${CaseFlagWizardStepTitle.UPDATE_FLAG_TITLE} "Flag 1, Sub Type"`);
+    expect(component.setUpdateCaseFlagTitle(activeFlagWithSubTypeValue)).toEqual(
+      `${CaseFlagWizardStepTitle.UPDATE_FLAG_TITLE} "Flag 1, Sub Type"`);
+    expect(component.setUpdateCaseFlagTitle(activeFlagWithSubTypeValueCy)).toEqual(
+      `${CaseFlagWizardStepTitle.UPDATE_FLAG_TITLE} "Flag 1, Sub Type (Welsh)"`);
+    expect(component.setUpdateCaseFlagTitle(activeFlagWithOtherDescription)).toEqual(
+      `${CaseFlagWizardStepTitle.UPDATE_FLAG_TITLE} "Flag 1, Description"`);
+    expect(component.setUpdateCaseFlagTitle(activeFlagWithOtherDescriptionCy)).toEqual(
+      `${CaseFlagWizardStepTitle.UPDATE_FLAG_TITLE} "Flag 1, Description (Welsh)"`);
     const flag = {} as FlagDetail;
     component.displayContextParameter = CaseFlagDisplayContextParameter.UPDATE;
     expect(component.setUpdateCaseFlagTitle(flag)).toEqual(CaseFlagWizardStepTitle.UPDATE_FLAG_TITLE);

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/update-flag/update-flag.component.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/update-flag/update-flag.component.ts
@@ -104,8 +104,15 @@ export class UpdateFlagComponent implements OnInit {
       case CaseFlagDisplayContextParameter.UPDATE:
       case CaseFlagDisplayContextParameter.UPDATE_2_POINT_1:
         if (flagDetail?.name) {
-          const subTypeValue = flagDetail.subTypeValue ? `, ${flagDetail.subTypeValue}` : ''
-          return `${CaseFlagWizardStepTitle.UPDATE_FLAG_TITLE} "${flagDetail.name}${subTypeValue}"`;
+          const subTypeValue = flagDetail.subTypeValue || flagDetail.subTypeValue_cy
+            ? `, ${flagDetail.subTypeValue || flagDetail.subTypeValue_cy}`
+            : '';
+          const otherDescription = flagDetail.otherDescription || flagDetail.otherDescription_cy
+            ? `, ${flagDetail.otherDescription || flagDetail.otherDescription_cy}`
+            : '';
+          return subTypeValue
+            ? `${CaseFlagWizardStepTitle.UPDATE_FLAG_TITLE} "${flagDetail.name}${subTypeValue}"`
+            : `${CaseFlagWizardStepTitle.UPDATE_FLAG_TITLE} "${flagDetail.name}${otherDescription}"`;
         }
         return `${CaseFlagWizardStepTitle.UPDATE_FLAG_TITLE}`;
       case CaseFlagDisplayContextParameter.UPDATE_EXTERNAL:


### PR DESCRIPTION
### JIRA link (if applicable) ###
EUI-9016

### Change description ###
Amend display of page title and field labels on "Update flag" page, to include the flag description for flags of type "Other".

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
