### PR TITLE
EUI-9035: Case Flags v2 fix - Ensure Case Flag Summary (CYA) page displays flag update comments

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,7 @@
 ## RELEASE NOTES
+### Version 6.19.13-case-flags-v2-manage-case-flags-flag-update-comments-fix
+**EUI-9035** Fix bug where Case Flag Summary (CYA) page displays original flag comments instead of flag update comments, during the "Manage support" journey for an external user. Also amend Case Flags page to display flag update comments for "Inactive" flags
+
 ### Version 6.19.13-case-flags-v2-manage-case-flags-value-caching-fix
 **EUI-9020** Fix bug where previous changes to a flag are retained in the UI when the user starts over and selects the same flag to update again
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "6.19.13-case-flags-v2-manage-case-flags-value-caching-fix",
+  "version": "6.19.13-case-flags-v2-manage-case-flags-flag-update-comments-fix",
   "engines": {
     "yarn": "^3.5.0",
     "npm": "^8.10.0"

--- a/projects/ccd-case-ui-toolkit/package.json
+++ b/projects/ccd-case-ui-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "6.19.13-case-flags-v2-manage-case-flags-value-caching-fix",
+  "version": "6.19.13-case-flags-v2-manage-case-flags-flag-update-comments-fix",
   "engines": {
     "yarn": "^3.5.0",
     "npm": "^8.10.0"

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-summary-list/case-flag-summary-list.component.html
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-summary-list/case-flag-summary-list.component.html
@@ -46,7 +46,7 @@
       {{'Comments' | rpxTranslate}}
     </dt>
     <dd class="govuk-summary-list__value">
-      {{flagComments}}
+      {{externalUserUpdate ? flagUpdateComments : flagComments}}
     </dd>
     <dd class="govuk-summary-list__actions">
       <a class="govuk-link" href="javascript:void(0)"

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-summary-list/case-flag-summary-list.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-summary-list/case-flag-summary-list.component.spec.ts
@@ -15,6 +15,8 @@ describe('CaseFlagSummaryListComponent', () => {
   let mockRpxTranslationService: any;
   const updateFlagHeaderText = 'Update flag for';
   const addFlagHeaderText = 'Add flag to';
+  const updateSupportHeaderText = 'Update support for';
+  const addSupportHeaderText = 'Add support to';
 
   const flagDetailDisplay = {
     partyName: 'Rose Bank',
@@ -25,7 +27,8 @@ describe('CaseFlagSummaryListComponent', () => {
       path: [{ id: '', value: 'Reasonable adjustment' }],
       hearingRelevant: false,
       flagCode: 'FL1',
-      status: 'Active'
+      status: 'Active',
+      flagStatusReasonChange: 'Change of status'
     } as FlagDetail
   } as FlagDetailDisplay;
 
@@ -158,9 +161,61 @@ describe('CaseFlagSummaryListComponent', () => {
     expect(summaryListValues[3].textContent).toContain(flag.flagDetail.status);
   });
 
+  it('should display the flag summary for a flag with comments, as part of the Create Case Flag journey for an external user', () => {
+    component.flagForSummaryDisplay = flagDetailDisplay;
+    component.displayContextParameter = CaseFlagDisplayContextParameter.CREATE_EXTERNAL;
+    fixture.detectChanges();
+    const addUpdateFlagHeaderTextElement = nativeElement.querySelector('dt');
+    expect(addUpdateFlagHeaderTextElement.textContent).toContain(addSupportHeaderText);
+    const summaryListValues = nativeElement.querySelectorAll('dd.govuk-summary-list__value');
+    expect(summaryListValues[0].textContent).toContain(flagDetailDisplay.partyName);
+    expect(summaryListValues[1].textContent).toContain(flagDetailDisplay.flagDetail.name);
+    expect(summaryListValues[2].textContent).toContain(flagDetailDisplay.flagDetail.flagComment);
+    expect(summaryListValues[3].textContent).toContain(flagDetailDisplay.flagDetail.status);
+  });
+
+  it('should display the flag summary for a flag with comments, as part of the Create Case Flag journey with v2.1 enabled', () => {
+    component.flagForSummaryDisplay = flagDetailDisplay;
+    component.displayContextParameter = CaseFlagDisplayContextParameter.CREATE_2_POINT_1;
+    fixture.detectChanges();
+    const addUpdateFlagHeaderTextElement = nativeElement.querySelector('dt');
+    expect(addUpdateFlagHeaderTextElement.textContent).toContain(addFlagHeaderText);
+    const summaryListValues = nativeElement.querySelectorAll('dd.govuk-summary-list__value');
+    expect(summaryListValues[0].textContent).toContain(flagDetailDisplay.partyName);
+    expect(summaryListValues[1].textContent).toContain(flagDetailDisplay.flagDetail.name);
+    expect(summaryListValues[2].textContent).toContain(flagDetailDisplay.flagDetail.flagComment);
+    expect(summaryListValues[3].textContent).toContain(flagDetailDisplay.flagDetail.status);
+  });
+
   it('should display the flag summary for a flag with comments, as part of the Manage Case Flags journey', () => {
     component.flagForSummaryDisplay = flagDetailDisplay;
     component.displayContextParameter = CaseFlagDisplayContextParameter.UPDATE;
+    fixture.detectChanges();
+    const addUpdateFlagHeaderTextElement = nativeElement.querySelector('dt');
+    expect(addUpdateFlagHeaderTextElement.textContent).toContain(updateFlagHeaderText);
+    const summaryListValues = nativeElement.querySelectorAll('dd.govuk-summary-list__value');
+    expect(summaryListValues[0].textContent).toContain(flagDetailDisplay.partyName);
+    expect(summaryListValues[1].textContent).toContain(flagDetailDisplay.flagDetail.name);
+    expect(summaryListValues[2].textContent).toContain(flagDetailDisplay.flagDetail.flagComment);
+    expect(summaryListValues[3].textContent).toContain(flagDetailDisplay.flagDetail.status);
+  });
+
+  it('should display the flag update comments in the summary, as part of the Manage Case Flags journey for an external user', () => {
+    component.flagForSummaryDisplay = flagDetailDisplay;
+    component.displayContextParameter = CaseFlagDisplayContextParameter.UPDATE_EXTERNAL;
+    fixture.detectChanges();
+    const addUpdateFlagHeaderTextElement = nativeElement.querySelector('dt');
+    expect(addUpdateFlagHeaderTextElement.textContent).toContain(updateSupportHeaderText);
+    const summaryListValues = nativeElement.querySelectorAll('dd.govuk-summary-list__value');
+    expect(summaryListValues[0].textContent).toContain(flagDetailDisplay.partyName);
+    expect(summaryListValues[1].textContent).toContain(flagDetailDisplay.flagDetail.name);
+    expect(summaryListValues[2].textContent).toContain(flagDetailDisplay.flagDetail['flagStatusReasonChange']);
+    expect(summaryListValues[3].textContent).toContain(flagDetailDisplay.flagDetail.status);
+  });
+
+  it('should display the flag comments in the summary, as part of the Manage Case Flags journey with v2.1 enabled', () => {
+    component.flagForSummaryDisplay = flagDetailDisplay;
+    component.displayContextParameter = CaseFlagDisplayContextParameter.UPDATE_2_POINT_1;
     fixture.detectChanges();
     const addUpdateFlagHeaderTextElement = nativeElement.querySelector('dt');
     expect(addUpdateFlagHeaderTextElement.textContent).toContain(updateFlagHeaderText);

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-summary-list/case-flag-summary-list.component.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-summary-list/case-flag-summary-list.component.ts
@@ -24,6 +24,7 @@ export class CaseFlagSummaryListComponent implements OnInit {
   public flagCommentsWelsh: string;
   public otherDescription: string;
   public otherDescriptionWelsh: string;
+  public flagUpdateComments: string;
   public summaryListDisplayMode: CaseFlagSummaryListDisplayMode;
   public addUpdateFlagHeaderText: string;
   public caseFlagFieldState = CaseFlagFieldState;
@@ -31,6 +32,7 @@ export class CaseFlagSummaryListComponent implements OnInit {
   public flagTypeHeaderText: string;
   public caseFlagCheckYourAnswersPageStep = CaseFlagCheckYourAnswersPageStep;
   public is2Point1Enabled = false;
+  public externalUserUpdate = false;
 
   constructor(private readonly rpxTranslationService: RpxTranslationService) { }
 
@@ -41,11 +43,15 @@ export class CaseFlagSummaryListComponent implements OnInit {
       this.flagDescriptionWelsh = flagDetail.otherDescription_cy;
       this.flagComments = flagDetail.flagComment;
       this.flagCommentsWelsh = flagDetail.flagComment_cy;
+      // Flag update comments will be coming from the flagStatusReasonChange property instead of flagUpdateComment
+      // because these haven't been persisted yet
+      this.flagUpdateComments = flagDetail['flagStatusReasonChange'];
       this.flagStatus = flagDetail.status;
       this.addUpdateFlagHeaderText = this.getAddUpdateFlagHeaderText();
       this.flagTypeHeaderText = this.getFlagTypeHeaderText();
       this.summaryListDisplayMode = this.getSummaryListDisplayMode();
       this.is2Point1Enabled = this.getDisplayContextParameter2Point1Enabled();
+      this.externalUserUpdate = this.displayContextParameter === CaseFlagDisplayContextParameter.UPDATE_EXTERNAL;
     }
   }
 

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-table/case-flag-table.component.html
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-table/case-flag-table.component.html
@@ -23,8 +23,10 @@
       </td>
       <td class="govuk-table__cell">
         <div>{{flagDetail | flagFieldDisplay:'flagComment'}}</div>
-        <div *ngIf="!caseFlagsExternalUser && flagDetail.status === caseFlagStatus.NOT_APPROVED && flagDetail.flagUpdateComment">
-          <span class="govuk-!-font-weight-bold">Decision Reason: {{flagDetail.flagUpdateComment}}</span>
+        <div *ngIf="!caseFlagsExternalUser &&
+          (flagDetail.status === caseFlagStatus.NOT_APPROVED || flagDetail.status === caseFlagStatus.INACTIVE) &&
+          flagDetail.flagUpdateComment">
+          <span class="govuk-!-font-weight-bold">Update Reason: {{flagDetail.flagUpdateComment}}</span>
         </div>
       </td>
       <td class="govuk-table__cell">{{flagDetail.dateTimeCreated | date: 'dd LLL yyyy'}}</td>

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-table/case-flag-table.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-table/case-flag-table.component.spec.ts
@@ -119,44 +119,68 @@ describe('CaseFlagTableComponent', () => {
     expect(tableCellElements[5].textContent).toContain(flagData.flags.details[1].subTypeValue);
   });
 
-  it('should display the flag update comment for internal users if and only if the case flag status is "Not approved"', () => {
+  it('should display the flag update comment for internal users if the case flag status is "Not approved" or "Inactive"', () => {
     flagData.flags.details[1].status = CaseFlagStatus.NOT_APPROVED;
     component.flagData = flagData;
     fixture.detectChanges();
     let tableCellElements = fixture.debugElement.nativeElement.querySelectorAll('.govuk-table__cell');
     // Check that the second element of the second row of five (i.e. seventh element) contains the flag update comment
     expect(tableCellElements.length).toBe(10);
-    expect(tableCellElements[6].textContent).toContain(`Decision Reason: ${flagData.flags.details[1].flagUpdateComment}`);
-    // Change flag status to other than "Not approved", which should hide the flag update comment
+    expect(tableCellElements[6].textContent).toContain(`Update Reason: ${flagData.flags.details[1].flagUpdateComment}`);
+    // Change flag status to other than "Not approved" or "Inactive", which should hide the flag update comment
     flagData.flags.details[1].status = CaseFlagStatus.ACTIVE;
     component.flagData = flagData;
     fixture.detectChanges();
     tableCellElements = fixture.debugElement.nativeElement.querySelectorAll('.govuk-table__cell');
     // Check that the second element of the second row of five (i.e. seventh element) does not contain the flag update comment
     expect(tableCellElements.length).toBe(10);
-    expect(tableCellElements[6].textContent).not.toContain(`Decision Reason: ${flagData.flags.details[1].flagUpdateComment}`);
+    expect(tableCellElements[6].textContent).not.toContain(`Update Reason: ${flagData.flags.details[1].flagUpdateComment}`);
+    // Change flag status to "Inactive", which should unhide the flag update comment
+    flagData.flags.details[1].status = CaseFlagStatus.INACTIVE;
+    component.flagData = flagData;
+    fixture.detectChanges();
+    tableCellElements = fixture.debugElement.nativeElement.querySelectorAll('.govuk-table__cell');
+    // Check that the second element of the second row of five (i.e. seventh element) contains the flag update comment
+    expect(tableCellElements.length).toBe(10);
+    expect(tableCellElements[6].textContent).toContain(`Update Reason: ${flagData.flags.details[1].flagUpdateComment}`);
   });
 
-  it('should not display the flag update comment for external users even if the case flag status is "Not approved"', () => {
+  it('should not display the flag update comment for external users even if the case flag status is "Not approved" or "Inactive"', () => {
     flagData.flags.details[1].status = CaseFlagStatus.NOT_APPROVED;
     component.flagData = flagData;
     component.caseFlagsExternalUser = true;
     fixture.detectChanges();
-    const tableCellElements = fixture.debugElement.nativeElement.querySelectorAll('.govuk-table__cell');
+    let tableCellElements = fixture.debugElement.nativeElement.querySelectorAll('.govuk-table__cell');
     // Check that the second element of the second row of five (i.e. seventh element) does not contain the flag update comment
     expect(tableCellElements.length).toBe(10);
-    expect(tableCellElements[6].textContent).not.toContain(`Decision Reason: ${flagData.flags.details[1].flagUpdateComment}`);
+    expect(tableCellElements[6].textContent).not.toContain(`Update Reason: ${flagData.flags.details[1].flagUpdateComment}`);
+    // Change flag status to "Inactive"
+    flagData.flags.details[1].status = CaseFlagStatus.INACTIVE;
+    component.flagData = flagData;
+    fixture.detectChanges();
+    tableCellElements = fixture.debugElement.nativeElement.querySelectorAll('.govuk-table__cell');
+    // Check that the second element of the second row of five (i.e. seventh element) does not contain the flag update comment
+    expect(tableCellElements.length).toBe(10);
+    expect(tableCellElements[6].textContent).not.toContain(`Update Reason: ${flagData.flags.details[1].flagUpdateComment}`);
   });
 
-  it('should not display "Decision Reason: " for internal users if there is no flag update comment for a "Not approved" flag', () => {
+  it('should not display "Update Reason: " for internal users if no flag update comment for "Not approved" or "Inactive" flag', () => {
     flagData.flags.details[1].status = CaseFlagStatus.NOT_APPROVED;
     flagData.flags.details[1].flagUpdateComment = null;
     component.flagData = flagData;
     fixture.detectChanges();
-    const tableCellElements = fixture.debugElement.nativeElement.querySelectorAll('.govuk-table__cell');
-    // Check that the second element of the second row of five (i.e. seventh element) does not contain "Decision Reason: "
+    let tableCellElements = fixture.debugElement.nativeElement.querySelectorAll('.govuk-table__cell');
+    // Check that the second element of the second row of five (i.e. seventh element) does not contain "Update Reason: "
     expect(tableCellElements.length).toBe(10);
-    expect(tableCellElements[6].textContent).not.toContain('Decision Reason: ');
+    expect(tableCellElements[6].textContent).not.toContain('Update Reason: ');
+    // Change flag status to "Inactive"
+    flagData.flags.details[1].status = CaseFlagStatus.INACTIVE;
+    component.flagData = flagData;
+    fixture.detectChanges();
+    tableCellElements = fixture.debugElement.nativeElement.querySelectorAll('.govuk-table__cell');
+    // Check that the second element of the second row of five (i.e. seventh element) does not contain "Update Reason: "
+    expect(tableCellElements.length).toBe(10);
+    expect(tableCellElements[6].textContent).not.toContain('Update Reason: ');
   });
 
   it('should display English values for flag name, "Other" description, sub-type value, and comments if in default language', () => {


### PR DESCRIPTION
### JIRA link (if applicable) ###
EUI-9035

### Change description ###
Fix bug where Case Flag Summary (CYA) page displays original flag comments instead of flag update comments, during the "Manage support" journey for an external user. Also amend Case Flags page to display flag update comments for "Inactive" flags.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
