### PR TITLE
EUI-9061: Case Flags v2 - Case Flag Summary page fix for external user flag updates

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,7 @@
 ## RELEASE NOTES
+### Version 7.0.2-case-flags-v2-1-release-2
+**EUI-9061** Fix bug where Welsh description (for flags of type "Other") and Welsh comments fields are shown on the Case Flag Summary (CYA) page when a flag is updated by an external user
+
 ### Version 7.0.2-case-flags-v2-1-release
 **EUI-9048** Re-tag for re-release of Case Flags v2.1, following sync of `Release` branch with latest from `master` to incorporate Angular 15 and Node 18 upgrade
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "7.0.2-case-flags-v2-1-release",
+  "version": "7.0.2-case-flags-v2-1-release-2",
   "engines": {
     "node": ">=18.17.0"
   },

--- a/projects/ccd-case-ui-toolkit/package.json
+++ b/projects/ccd-case-ui-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "7.0.2-case-flags-v2-1-release",
+  "version": "7.0.2-case-flags-v2-1-release-2",
   "engines": {
     "node": ">=18.17.0"
   },

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-summary-list/case-flag-summary-list.component.html
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-summary-list/case-flag-summary-list.component.html
@@ -27,7 +27,7 @@
       </a>
     </dd>
   </div>
-  <div class="govuk-summary-list__row" *ngIf="flagDescriptionWelsh?.length > 0">
+  <div class="govuk-summary-list__row" *ngIf="flagDescriptionWelsh?.length > 0 && !externalUserUpdate">
     <dt class="govuk-summary-list__key">
       {{'Other description (Welsh)' | rpxTranslate}}
     </dt>
@@ -55,7 +55,7 @@
       </a>
     </dd>
   </div>
-  <div class="govuk-summary-list__row" *ngIf="flagCommentsWelsh?.length > 0">
+  <div class="govuk-summary-list__row" *ngIf="flagCommentsWelsh?.length > 0 && !externalUserUpdate">
     <dt class="govuk-summary-list__key">
       {{'Comments (Welsh)' | rpxTranslate}}
     </dt>

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-summary-list/case-flag-summary-list.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-flag/components/case-flag-summary-list/case-flag-summary-list.component.spec.ts
@@ -255,6 +255,37 @@ describe('CaseFlagSummaryListComponent', () => {
     expect(summaryListValues[5].textContent).toContain(flag.flagDetail.status);
   });
 
+  it('should not display summary details for Welsh if the flag is being updated by an external user', () => {
+    const flag = {
+      partyName: 'Rose Bank',
+      flagDetail: {
+        name: 'Flag 1',
+        flagComment: 'First flag',
+        flagComment_cy: 'Flag comment for Welsh',
+        dateTimeCreated: new Date(),
+        path: [{ id: '', value: 'Reasonable adjustment' }],
+        hearingRelevant: false,
+        flagCode: 'FL1',
+        otherDescription_cy: 'Other description for Welsh',
+        status: 'Active'
+      } as FlagDetail
+    } as FlagDetailDisplay;
+    // Set a comment for the flag update reason (mandatory if the user is external)
+    flag.flagDetail['flagStatusReasonChange'] = 'Update by external user';
+    component.flagForSummaryDisplay = flag;
+    component.displayContextParameter = CaseFlagDisplayContextParameter.UPDATE_EXTERNAL;
+    fixture.detectChanges();
+    const addUpdateFlagHeaderTextElement = nativeElement.querySelector('dt');
+    expect(addUpdateFlagHeaderTextElement.textContent).toContain(updateSupportHeaderText);
+    const summaryListValues = nativeElement.querySelectorAll('dd.govuk-summary-list__value');
+    expect(summaryListValues.length).toBe(4);
+    expect(summaryListValues[0].textContent).toContain(flag.partyName);
+    expect(summaryListValues[1].textContent).toContain(flag.flagDetail.name);
+    // The flag update comment is displayed in place of the original flag comment, for an external user
+    expect(summaryListValues[2].textContent).toContain('Update by external user');
+    expect(summaryListValues[3].textContent).toContain(flag.flagDetail.status);
+  });
+
   it('should use the stored Welsh values for flag name and sub-type value if the selected language is Welsh', () => {
     mockRpxTranslationService.language = 'cy';
     const flag = {


### PR DESCRIPTION
### JIRA link (if applicable) ###
EUI-9061

### Change description ###
Fix bug where Welsh description (for flags of type "Other") and Welsh comments fields are shown on the Case Flag Summary (CYA) page when a flag is updated by an external user.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
