### PR TITLE
EUI-9165: Yes/no field fix

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,7 @@
 ## RELEASE NOTES
+### Version 7.0.6-welsh-translation-yes-no-field-fix
+**EUI-9165** Fix bug where nothing is shown for the yes/no field if there is no `caseField` label (should fall back on the field value)
+
 ### Version 7.0.6-case-flags-v2-1-release
 **EUI-9048** Re-tag for re-release of Case Flags v2.1, following merge conflict resolution with latest from `master`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "7.0.6-case-flags-v2-1-release",
+  "version": "7.0.6-welsh-translation-yes-no-field-fix",
   "engines": {
     "node": ">=18.17.0"
   },

--- a/projects/ccd-case-ui-toolkit/package.json
+++ b/projects/ccd-case-ui-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "7.0.6-case-flags-v2-1-release",
+  "version": "7.0.6-welsh-translation-yes-no-field-fix",
   "engines": {
     "node": ">=18.17.0"
   },

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/yes-no/write-yes-no-field.html
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/yes-no/write-yes-no-field.html
@@ -11,7 +11,7 @@
     <div [id]="createElementId('radio')">
   	  <div class="multiple-choice" *ngFor="let value of yesNoValues" [ngClass]="{selected: yesNoControl.value === value}">
   	    <input class="form-control" [id]="createElementId(value)" [attr.name]="id()" [name]="id()" type="radio" [formControl]="yesNoControl" [value]="value">
-  	    <label class="form-label" [for]="createElementId(value)">{{caseField.label | rpxTranslate : null : value}}</label>
+        <label class="form-label" [for]="createElementId(value)">{{caseField.label ? (caseField.label | rpxTranslate:null:value) : value}}</label>
   	  </div>
     </div>
 	</fieldset>


### PR DESCRIPTION
### JIRA link (if applicable) ###
EUI-9165

### Change description ###
Fix bug where nothing is shown for the yes/no field if there is no `caseField` label (should fall back on the field value).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
