### PR TITLE
EUI-9164 / EUI-9129 / EUI-9146: Welsh Translation feature - various fixes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,6 @@
 ## RELEASE NOTES
 ### Version 7.0.7-welsh-translation-fixes
+**EUI-9129** Fix conditional display of "Event summary" and "Event description" fields to be dependent solely on the value of `show_event_notes` as set for a given case event via a CCD Definition file
 **EUI-9164** Fix non-translation of "Event summary" label and hint text, and "Event description" label, displayed on the "Check your answers" page
 
 ### Version 7.0.7-welsh-translation-yes-no-field-fix

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,7 @@
 ## RELEASE NOTES
+### Version 7.0.7-welsh-translation-fixes
+**EUI-9164** Fix non-translation of "Event summary" label and hint text, and "Event description" label, displayed on the "Check your answers" page
+
 ### Version 7.0.7-welsh-translation-yes-no-field-fix
 **EUI-9165** Re-tag for re-release of fix, following merge conflict resolution with latest from `master`
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,8 @@
 ## RELEASE NOTES
+
+### Version 7.0.13-welsh-translation-fixes
+**CSFD-23** Fix case history label by adding translation pipe
+
 ### Version 7.0.13
 **EUI-1275** Manual Language Entry in case flags - missing subTypeValue during form submission
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,6 @@
 ## RELEASE NOTES
 ### Version 7.0.7-welsh-translation-fixes
+**EUI-9146** Fix "View case flags" link in banner to work when the Case Flags tab label is translated to Welsh
 **EUI-9129** Fix conditional display of "Event summary" and "Event description" fields to be dependent solely on the value of `show_event_notes` as set for a given case event via a CCD Definition file
 **EUI-9164** Fix non-translation of "Event summary" label and hint text, and "Event description" label, displayed on the "Check your answers" page
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "7.0.10-welsh-translation-fixes",
+  "version": "7.0.13-welsh-translation-fixes",
   "engines": {
     "node": ">=18.17.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "7.0.7-welsh-translation-yes-no-field-fix",
+  "version": "7.0.7-welsh-translation-fixes",
   "engines": {
     "node": ">=18.17.0"
   },
@@ -115,7 +115,7 @@
     "@storybook/manager-webpack4": "^6.5.10",
     "@storybook/preset-scss": "^1.0.3",
     "@storybook/testing-library": "^0.0.13",
-    "@types/jasmine": "~2.8.0",
+    "@types/jasmine": "~5.1.0",
     "@types/jasminewd2": "^2.0.3",
     "@types/node": "^18.17.0",
     "@types/pegjs": "^0.10.0",

--- a/projects/ccd-case-ui-toolkit/package.json
+++ b/projects/ccd-case-ui-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "7.0.10-welsh-translation-fixes",
+  "version": "7.0.13-welsh-translation-fixes",
   "engines": {
     "node": ">=18.17.0"
   },

--- a/projects/ccd-case-ui-toolkit/package.json
+++ b/projects/ccd-case-ui-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "7.0.7-welsh-translation-yes-no-field-fix",
+  "version": "7.0.7-welsh-translation-fixes",
   "engines": {
     "node": ">=18.17.0"
   },

--- a/projects/ccd-case-ui-toolkit/src/lib/components/banners/notification-banner/domain/notification-banner-config.model.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/components/banners/notification-banner/domain/notification-banner-config.model.ts
@@ -1,13 +1,14 @@
+import { Observable } from 'rxjs';
 import { NotificationBannerType } from '../enums/notification-banner-type.enum';
 
 export interface NotificationBannerConfig {
   bannerType: NotificationBannerType;
-  headingText: string;
-  description: string;
+  headingText: Observable<string>;
+  description: Observable<string>;
   showLink: boolean;
-  linkUrl?: string;
-  linkText?: string;
+  linkUrl?: Observable<string>;
+  linkText?: Observable<string>;
   triggerOutputEvent?: boolean;
-  triggerOutputEventText?: string;
+  triggerOutputEventText?: Observable<string>;
   headerClass: string;
 }

--- a/projects/ccd-case-ui-toolkit/src/lib/components/banners/notification-banner/notification-banner.component.html
+++ b/projects/ccd-case-ui-toolkit/src/lib/components/banners/notification-banner/notification-banner.component.html
@@ -7,7 +7,7 @@
 
   <div class="govuk-notification-banner__header">
     <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-      {{notificationBannerConfig.headingText}}
+      {{notificationBannerConfig.headingText | async}}
     </h2>
   </div>
   <div class="govuk-notification-banner__content">
@@ -39,14 +39,16 @@
           </svg>
         </ng-container>
       </ng-container>
-      {{notificationBannerConfig.description}}
+      {{notificationBannerConfig.description | async}}
       <a *ngIf="notificationBannerConfig.showLink && !notificationBannerConfig.triggerOutputEvent"
         class="govuk-notification-banner__link"
-        href="{{notificationBannerConfig.linkUrl}}">{{notificationBannerConfig.linkText}}</a>
-      <a *ngIf="notificationBannerConfig.showLink && notificationBannerConfig.triggerOutputEvent"
-        class="govuk-notification-banner__link"
+        href="{{notificationBannerConfig.linkUrl | async}}">{{notificationBannerConfig.linkText | async}}</a>
+      <ng-container *ngIf="notificationBannerConfig.showLink && notificationBannerConfig.triggerOutputEvent">
+        <input #triggerOutputEventText style="display: none" type="text" value="{{notificationBannerConfig.triggerOutputEventText | async}}">
+        <a class="govuk-notification-banner__link"
         href="javascript:void(0)"
-        (click)="onLinkClick(notificationBannerConfig.triggerOutputEventText)">{{notificationBannerConfig.linkText}}</a>
+        (click)="onLinkClick(triggerOutputEventText.value)">{{notificationBannerConfig.linkText | async}}</a>
+      </ng-container>
     </p>
   </div>
 </div>

--- a/projects/ccd-case-ui-toolkit/src/lib/components/banners/notification-banner/notification-banner.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/components/banners/notification-banner/notification-banner.component.spec.ts
@@ -1,5 +1,6 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { of } from 'rxjs';
 import { NotificationBannerType } from './enums';
 import { NotificationBannerComponent } from './notification-banner.component';
 
@@ -28,11 +29,11 @@ describe('NotificationBannerComponent', () => {
   it('should display information banner', () => {
     component.notificationBannerConfig = {
       bannerType: NotificationBannerType.INFORMATION,
-      headingText: 'Important',
-      description: 'There are 4 active flags on this case.',
+      headingText: of('Important'),
+      description: of('There are 4 active flags on this case.'),
       showLink: true,
-      linkText: 'View case flags',
-      linkUrl: '/case/ddd',
+      linkText: of('View case flags'),
+      linkUrl: of('/case/ddd'),
       headerClass: 'notification-banner-information'
     };
     fixture.detectChanges();
@@ -44,8 +45,8 @@ describe('NotificationBannerComponent', () => {
   it('should display warning banner', () => {
     component.notificationBannerConfig = {
       bannerType: NotificationBannerType.WARNING,
-      headingText: 'Warning',
-      description: 'There are 4 active flags on this case.',
+      headingText: of('Warning'),
+      description: of('There are 4 active flags on this case.'),
       showLink: false,
       headerClass: 'notification-banner-warning'
     };
@@ -58,8 +59,8 @@ describe('NotificationBannerComponent', () => {
   it('should display error banner', () => {
     component.notificationBannerConfig = {
       bannerType: NotificationBannerType.ERROR,
-      headingText: 'Error',
-      description: 'There are 4 active flags on this case.',
+      headingText: of('Error'),
+      description: of('There are 4 active flags on this case.'),
       showLink: false,
       headerClass: 'notification-banner-error'
     };
@@ -72,11 +73,11 @@ describe('NotificationBannerComponent', () => {
   it('should display success banner', () => {
     component.notificationBannerConfig = {
       bannerType: NotificationBannerType.SUCCESS,
-      headingText: 'Success',
-      description: 'There are 4 active flags on this case.',
+      headingText: of('Success'),
+      description: of('There are 4 active flags on this case.'),
       showLink: true,
-      linkText: 'View case flags',
-      linkUrl: '/case/ddd',
+      linkText: of('View case flags'),
+      linkUrl: of('/case/ddd'),
       headerClass: 'notification-banner-success'
     };
     fixture.detectChanges();

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-editor/case-edit-submit/case-edit-submit.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-editor/case-edit-submit/case-edit-submit.component.spec.ts
@@ -512,7 +512,7 @@ describe('CaseEditSubmitComponent', () => {
       expect(eventNotes).not.toBeNull();
     });
 
-    it('should show event notes when not set in event trigger and showEventNotes is called', () => {
+    it('should not show event notes when not set in event trigger and showEventNotes is called', () => {
       fixture.detectChanges();
       comp.eventTrigger.show_event_notes = null;
       fixture.detectChanges();
@@ -524,7 +524,7 @@ describe('CaseEditSubmitComponent', () => {
       expect(eventNotes).toBeNull();
     });
 
-    it('should show event notes when not defined in event trigger and showEventNotes is called', () => {
+    it('should not show event notes when not defined in event trigger and showEventNotes is called', () => {
       fixture.detectChanges();
       comp.eventTrigger.show_event_notes = undefined;
       fixture.detectChanges();
@@ -548,9 +548,9 @@ describe('CaseEditSubmitComponent', () => {
       expect(eventNotes).toBeNull();
     });
 
-    it('should show event notes when set in event trigger and showEventNotes is called', () => {
+    it('should show event notes when set in event trigger and profile is solicitor and showEventNotes is called', () => {
       fixture.detectChanges();
-      comp.profile.user.idam.roles = ['caseworker-divorce'];
+      comp.profile.user.idam.roles = ['divorce-solicitor'];
       comp.eventTrigger.show_event_notes = true;
       fixture.detectChanges();
       const eventNotes = de.query($EVENT_NOTES);
@@ -559,18 +559,7 @@ describe('CaseEditSubmitComponent', () => {
       expect(eventNotes).not.toBeNull();
     });
 
-    it('should hide event notes when set in event trigger and profile is solicitor and showEventNotes is called', () => {
-      fixture.detectChanges();
-      comp.profile.user.idam.roles = ['divorce-solicitor'];
-      comp.eventTrigger.show_event_notes = true;
-      fixture.detectChanges();
-      const eventNotes = de.query($EVENT_NOTES);
-      const result = comp.showEventNotes();
-      expect(result).toEqual(false);
-      expect(eventNotes).toBeNull();
-    });
-
-    it('should hide event notes when set in event trigger and is case flag journey and showEventNotes is called', () => {
+    it('should show event notes when set in event trigger and is case flag journey and showEventNotes is called', () => {
       fixture.detectChanges();
       comp.profile.user.idam.roles = ['caseworker-divorce'];
       comp.caseEdit.isCaseFlagSubmission = true;
@@ -578,28 +567,8 @@ describe('CaseEditSubmitComponent', () => {
       fixture.detectChanges();
       const eventNotes = de.query($EVENT_NOTES);
       const result = comp.showEventNotes();
-      expect(result).toEqual(false);
-      expect(eventNotes).toBeNull();
-    });
-
-    it('should hide event notes when not set in event trigger and showEventNotes is called', () => {
-      fixture.detectChanges();
-      comp.eventTrigger.show_event_notes = null;
-      fixture.detectChanges();
-      const eventNotes = de.query($EVENT_NOTES);
-      const result = comp.showEventNotes();
-      expect(result).toEqual(false);
-      expect(eventNotes).toBeNull();
-    });
-
-    it('should hide event notes when not defined in event trigger and showEventNotes is called', () => {
-      fixture.detectChanges();
-      comp.eventTrigger.show_event_notes = undefined;
-      fixture.detectChanges();
-      const eventNotes = de.query($EVENT_NOTES);
-      const result = comp.showEventNotes();
-      expect(result).toEqual(false);
-      expect(eventNotes).toBeNull();
+      expect(result).toEqual(true);
+      expect(eventNotes).not.toBeNull();
     });
 
     it('should set correct page title', () => {

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-editor/case-edit-submit/case-edit-submit.component.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-editor/case-edit-submit/case-edit-submit.component.ts
@@ -201,15 +201,7 @@ export class CaseEditSubmitComponent implements OnInit, OnDestroy {
   }
 
   public showEventNotes(): boolean {
-    // Display event notes related controls only if the following conditions are met
-    // 1. show_event_notes flag is set to true
-    // 2. profile is not a solicitor
-    // 3. is not a case flags journey, as it uses a custom check your answers component
-    if (this.eventTrigger.show_event_notes) {
-      return !this.profile?.isSolicitor()
-        && !this.caseEdit.isCaseFlagSubmission;
-    }
-    return false;
+    return !!this.eventTrigger.show_event_notes;
   }
 
   private getLastPageShown(): WizardPage {

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-editor/case-edit-submit/case-edit-submit.html
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-editor/case-edit-submit/case-edit-submit.html
@@ -19,7 +19,7 @@
   <form class="check-your-answers" [formGroup]="editForm" (submit)="submit()">
     <ng-container *ngIf="checkYourAnswerFieldsToDisplayExists()">
 
-      <h2 class="heading-h2">{{pageTitle | rpxTranslate }}</h2>
+      <h2 class="heading-h2">{{pageTitle | rpxTranslate}}</h2>
       <span class="text-16" *ngIf="!caseEdit.isCaseFlagSubmission">{{'Check the information below carefully.' | rpxTranslate}}</span>
 
       <table class="form-table" aria-describedby="check your answers table">
@@ -86,13 +86,13 @@
         <legend style="display: none;"></legend>
         <div class="form-group">
           <label for="field-trigger-summary" class="form-label">
-            Event summary (optional)
-            <span class="form-hint">A few words describing the purpose of the event.</span>
+            {{'Event summary (optional)' | rpxTranslate}}
+            <span class="form-hint">{{'A few words describing the purpose of the event.' | rpxTranslate}}</span>
           </label>
           <input type="text" id="field-trigger-summary" class="form-control bottom-30 width-50" formControlName="summary" maxlength="1024">
         </div>
         <div class="form-group">
-          <label for="field-trigger-description" class="form-label">Event description (optional)</label>
+          <label for="field-trigger-description" class="form-label">{{'Event description (optional)' | rpxTranslate}}</label>
           <textarea id="field-trigger-description" class="form-control bottom-30 width-50" formControlName="description"
                     maxlength="65536"></textarea>
         </div>

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-editor/case-edit/case-edit.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-editor/case-edit/case-edit.component.spec.ts
@@ -863,7 +863,7 @@ describe('CaseEditComponent', () => {
 
         it('should check page is not refreshed', () => {
           mockSessionStorageService.getItem.and.returnValue(component.initialUrl = null);
-          mockSessionStorageService.getItem.and.returnValue(component.isPageRefreshed = false);
+          mockSessionStorageService.getItem.and.returnValue((component.isPageRefreshed = false).toString());
 
           fixture.detectChanges();
           expect(component.checkPageRefresh()).toBe(false);
@@ -871,7 +871,7 @@ describe('CaseEditComponent', () => {
 
         it('should check page is refreshed', () => {
           mockSessionStorageService.getItem.and.returnValue(component.initialUrl = 'test');
-          mockSessionStorageService.getItem.and.returnValue(component.isPageRefreshed = true);
+          mockSessionStorageService.getItem.and.returnValue((component.isPageRefreshed = true).toString());
 
           fixture.detectChanges();
           expect(component.checkPageRefresh()).toBe(true);

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-editor/case-event-completion/components/case-event-completion-task-reassigned/case-event-completion-task-reassigned.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-editor/case-event-completion/components/case-event-completion-task-reassigned/case-event-completion-task-reassigned.component.spec.ts
@@ -139,7 +139,7 @@ describe('TaskReassignedComponent', () => {
   });
 
   it('should assign and complete task on continue event', () => {
-    spyOn(mockWorkAllocationService, 'assignAndCompleteTask').and.returnValue({subscribe: () => {}});
+    spyOn(mockWorkAllocationService, 'assignAndCompleteTask').and.returnValue(of({}));
     component.onContinue();
     expect(mockSessionStorageService.getItem).toHaveBeenCalledTimes(1);
   });

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-editor/services/case.notifier.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-editor/services/case.notifier.spec.ts
@@ -1,3 +1,4 @@
+import { of } from 'rxjs';
 import { CaseField, CaseTab, CaseView } from '../../../domain';
 import { CaseNotifier } from './case.notifier';
 import { CasesService } from './cases.service';
@@ -74,7 +75,7 @@ describe('setBasicFields', () => {
 
   xit ('should call getCaseV2 on refresh', () => {
     const csv: jasmine.SpyObj<CasesService> = jasmine.createSpyObj<CasesService>('CasesService', ['getCaseViewV2']);
-    csv.getCaseViewV2.and.returnValue(CASE_VIEW_2);
+    csv.getCaseViewV2.and.returnValue(of(CASE_VIEW_2));
     const cNote = new CaseNotifier(csv);
     cNote.fetchAndRefresh('1');
     expect(csv.getCaseViewV2).toHaveBeenCalled();

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-editor/services/event-completion-state-machine.service.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-editor/services/event-completion-state-machine.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { State, StateMachine } from '@edium/fsm';
 import { throwError } from 'rxjs';
-import { Task, TaskState } from '../../../domain/work-allocation/Task';
+import { TaskState } from '../../../domain/work-allocation/Task';
 import { EventCompletionPortalTypes } from '../domain/event-completion-portal-types.model';
 import { EventCompletionStateMachineContext } from '../domain/event-completion-state-machine-context.model';
 import { EventCompletionStates } from '../domain/event-completion-states.enum.model';

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-editor/services/work-allocation.service.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-editor/services/work-allocation.service.spec.ts
@@ -2,7 +2,7 @@ import { waitForAsync } from '@angular/core/testing';
 import { of, throwError } from 'rxjs';
 import { AbstractAppConfig } from '../../../../app.config';
 import { HttpError, TaskSearchParameter } from '../../../domain';
-import { TaskRespone } from '../../../domain/work-allocation/task-response.model';
+import { TaskResponse } from '../../../domain/work-allocation/task-response.model';
 import { HttpErrorService, HttpService } from '../../../services';
 import { MULTIPLE_TASKS_FOUND, WorkAllocationService } from './work-allocation.service';
 
@@ -64,7 +64,7 @@ function getExampleUserDetails(): UserDetails[] {
   }];
 }
 
-function getExampleTask(): TaskRespone {
+function getExampleTask(): TaskResponse {
   return {
     task: {
       assignee: '1234-1234-1234-1234',

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-editor/services/work-allocation.service.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-editor/services/work-allocation.service.ts
@@ -4,7 +4,7 @@ import { catchError, map } from 'rxjs/operators';
 import { AbstractAppConfig } from '../../../../app.config';
 import { TaskSearchParameter, WAFeatureConfig } from '../../../domain';
 import { UserDetails } from '../../../domain/user/user-details.model';
-import { TaskRespone } from '../../../domain/work-allocation/task-response.model';
+import { TaskResponse } from '../../../domain/work-allocation/task-response.model';
 import { TaskPayload } from '../../../domain/work-allocation/TaskPayload';
 import { AlertService, HttpErrorService, HttpService, SessionStorageService } from '../../../services';
 
@@ -222,7 +222,7 @@ export class WorkAllocationService {
  /**
   * Call the API to get a task
   */
- public getTask(taskId: string): Observable<TaskRespone> {
+ public getTask(taskId: string): Observable<TaskResponse> {
   if (!this.isWAEnabled()) {
     return of({task: null});
   }

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-history/case-history.component.html
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-history/case-history.component.html
@@ -48,7 +48,7 @@
                   <ng-container [ngSwitch]="!(field | ccdIsCompound)">
                     <tr *ngSwitchCase="true">
                       <th id="case-viewer-label-header">
-                        <div class="case-viewer-label">{{field.label}}</div>
+                        <div class="case-viewer-label">{{field.label | rpxTranslate}}</div>
                       </th>
                       <td>
                         <ccd-field-read [caseField]="field" [caseReference]="caseHistory.case_id"></ccd-field-read>

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-viewer/case-challenged-access-request/case-challenged-access-view.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-viewer/case-challenged-access-request/case-challenged-access-view.component.spec.ts
@@ -7,7 +7,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { RpxTranslationService } from 'rpx-xui-translation';
 import { of } from 'rxjs';
 import { AlertModule } from '../../../../components/banners/alert';
-import { CaseView, ChallengedAccessRequest } from '../../../domain';
+import { CaseView, ChallengedAccessRequest, RoleAssignmentResponse } from '../../../domain';
 import { MockRpxTranslatePipe } from '../../../test/mock-rpx-translate.pipe';
 import { CaseNotifier } from '../../case-editor';
 import { CasesService } from '../../case-editor/services/cases.service';
@@ -31,13 +31,17 @@ describe('CaseChallengedAccessRequestComponent', () => {
         cid: caseId
       }
     }
-  };
+  } as unknown as ActivatedRoute;
   let router: Router;
   let location: Location;
   beforeEach(waitForAsync(() => {
+    const roleAssignmentResponse: RoleAssignmentResponse = {
+      roleRequest: null,
+      requestedRoles: []
+    };
     casesService = createSpyObj<CasesService>('casesService', ['createChallengedAccessRequest']);
     casesNotifier = createSpyObj<CaseNotifier>('caseNotifier', ['fetchAndRefresh']);
-    casesService.createChallengedAccessRequest.and.returnValue(of(true));
+    casesService.createChallengedAccessRequest.and.returnValue(of(roleAssignmentResponse));
     casesNotifier.fetchAndRefresh.and.returnValue(of(new CaseView()));
     TestBed.configureTestingModule({
       imports: [

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-viewer/case-full-access-view/case-full-access-view.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-viewer/case-full-access-view/case-full-access-view.component.spec.ts
@@ -627,9 +627,6 @@ describe('CaseFullAccessViewComponent', () => {
     caseNotifier = createSpyObj('caseService', ['announceCase']);
 
     alertService = createSpyObj('alertService', ['setPreserveAlerts', 'success', 'warning', 'clear']);
-    alertService.setPreserveAlerts.and.returnValue(of({}));
-    alertService.success.and.returnValue(of({}));
-    alertService.warning.and.returnValue(of({}));
 
     navigationNotifierService = new NavigationNotifierService();
     spyOn(navigationNotifierService, 'announceNavigation').and.callThrough();
@@ -643,10 +640,10 @@ describe('CaseFullAccessViewComponent', () => {
 
     mockCallbackErrorSubject = createSpyObj<any>('callbackErrorSubject', ['next', 'subscribe', 'unsubscribe']);
 
-    convertHrefToRouterMockService = jasmine.createSpyObj('ConvertHrefToRouterService', ['getHrefMarkdownLinkContent', 'callAngularRouter']);
+    convertHrefToRouterMockService = createSpyObj('ConvertHrefToRouterService', ['getHrefMarkdownLinkContent', 'callAngularRouter']);
     convertHrefToRouterMockService.getHrefMarkdownLinkContent.and.returnValue(of('[Send a new direction](/case/IA/Asylum/1641014744613435/trigger/sendDirection)'));
 
-    sessionStorageMockService = jasmine.createSpyObj('SessionStorageService', ['getItem', 'setItem', 'removeItem']);
+    sessionStorageMockService = createSpyObj('SessionStorageService', ['getItem', 'setItem', 'removeItem']);
 
     TestBed
       .configureTestingModule({
@@ -689,7 +686,7 @@ describe('CaseFullAccessViewComponent', () => {
           DeleteOrCancelDialogComponent,
           { provide: ConvertHrefToRouterService, useValue: convertHrefToRouterMockService },
           { provide: SessionStorageService, useValue: sessionStorageMockService },
-          { provide: RpxTranslationService, useValue: createSpyObj('RpxTranslationService', ['translate']) },
+          { provide: RpxTranslationService, useValue: createSpyObj('RpxTranslationService', ['getTranslation$']) }
         ],
         schemas: [CUSTOM_ELEMENTS_SCHEMA]
       })
@@ -1108,9 +1105,6 @@ xdescribe('CaseFullAccessViewComponent - no tabs available', () => {
     caseNotifier = createSpyObj('caseService', ['announceCase']);
 
     alertService = createSpyObj('alertService', ['setPreserveAlerts', 'success', 'warning', 'clear']);
-    alertService.setPreserveAlerts.and.returnValue(of({}));
-    alertService.success.and.returnValue(of({}));
-    alertService.warning.and.returnValue(of({}));
 
     navigationNotifierService = new NavigationNotifierService();
     spyOn(navigationNotifierService, 'announceNavigation').and.callThrough();
@@ -1164,7 +1158,7 @@ xdescribe('CaseFullAccessViewComponent - no tabs available', () => {
           { provide: MatDialogRef, useValue: matDialogRef },
           { provide: MatDialogConfig, useValue: DIALOG_CONFIG },
           { provide: ActivityPollingService, useValue: activityService },
-          { provide: RpxTranslationService, useValue: createSpyObj('RpxTranslationService', ['translate']) },
+          { provide: RpxTranslationService, useValue: createSpyObj('RpxTranslationService', ['getTranslation$']) },
           DeleteOrCancelDialogComponent
         ]
       })
@@ -1195,9 +1189,6 @@ xdescribe('CaseFullAccessViewComponent - print and event selector disabled', () 
     caseNotifier = createSpyObj('caseNotifier', ['announceCase']);
 
     alertService = createSpyObj('alertService', ['setPreserveAlerts', 'success', 'warning', 'clear']);
-    alertService.setPreserveAlerts.and.returnValue(of({}));
-    alertService.success.and.returnValue(of({}));
-    alertService.warning.and.returnValue(of({}));
 
     navigationNotifierService = new NavigationNotifierService();
     spyOn(navigationNotifierService, 'announceNavigation').and.callThrough();
@@ -1282,7 +1273,7 @@ describe('CaseFullAccessViewComponent - prependedTabs', () => {
   let convertHrefToRouterService: jasmine.SpyObj<ConvertHrefToRouterService>;
 
   beforeEach((() => {
-    convertHrefToRouterService = jasmine.createSpyObj('ConvertHrefToRouterService', ['getHrefMarkdownLinkContent', 'callAngularRouter']);
+    convertHrefToRouterService = createSpyObj('ConvertHrefToRouterService', ['getHrefMarkdownLinkContent', 'callAngularRouter']);
     convertHrefToRouterService.getHrefMarkdownLinkContent.and.returnValue(of('[Send a new direction](/case/IA/Asylum/1641014744613435/trigger/sendDirection)'));
     TestBed
       .configureTestingModule({
@@ -1358,7 +1349,7 @@ describe('CaseFullAccessViewComponent - prependedTabs', () => {
           { provide: MatDialogRef, useValue: matDialogRef },
           { provide: MatDialogConfig, useValue: DIALOG_CONFIG },
           { provide: ConvertHrefToRouterService, useValue: convertHrefToRouterService },
-          { provide: RpxTranslationService, useValue: createSpyObj('RpxTranslationService', ['translate']) },
+          { provide: RpxTranslationService, useValue: createSpyObj('RpxTranslationService', ['getTranslation$']) },
           DeleteOrCancelDialogComponent
         ],
         teardown: { destroyAfterEach: false }
@@ -1408,11 +1399,19 @@ describe('CaseFullAccessViewComponent - appendedTabs', () => {
   let comp: CaseFullAccessViewComponent;
   let f: ComponentFixture<CaseFullAccessViewComponent>;
   let d: DebugElement;
-  let convertHrefToRouterService;
+  let convertHrefToRouterService: jasmine.SpyObj<ConvertHrefToRouterService>;
+  let rpxTranslationService: jasmine.SpyObj<RpxTranslationService>;
 
   beforeEach((() => {
-    convertHrefToRouterService = jasmine.createSpyObj('ConvertHrefToRouterService', ['getHrefMarkdownLinkContent', 'callAngularRouter']);
+    convertHrefToRouterService = createSpyObj('ConvertHrefToRouterService', ['getHrefMarkdownLinkContent', 'callAngularRouter']);
     convertHrefToRouterService.getHrefMarkdownLinkContent.and.returnValue(of('[Send a new direction](/case/IA/Asylum/1641014744613435/trigger/sendDirection)'));
+    rpxTranslationService = createSpyObj('RpxTranslationService', ['getTranslation$', 'getTranslationWithReplacements$']);
+    rpxTranslationService.getTranslationWithReplacements$.and.returnValue(of('Welsh: There are 2 active flags on this case.'));
+    rpxTranslationService.getTranslation$.withArgs('There is 1 active flag on this case.').and.returnValue(of('Welsh: There is 1 active flag on this case.'));
+    rpxTranslationService.getTranslation$.withArgs('Important').and.returnValue(of('Pwysig'));
+    rpxTranslationService.getTranslation$.withArgs('View case flags').and.returnValue(of('Gweld fflagiau\'r achos'));
+    rpxTranslationService.getTranslation$.withArgs('Case flags').and.returnValue(of('Fflagiau\'r achos'));
+    rpxTranslationService.getTranslation$.withArgs('Hearings').and.returnValue(of('Gwrandawiadau'));
     TestBed
       .configureTestingModule({
         imports: [
@@ -1487,7 +1486,7 @@ describe('CaseFullAccessViewComponent - appendedTabs', () => {
           { provide: MatDialogRef, useValue: matDialogRef },
           { provide: MatDialogConfig, useValue: DIALOG_CONFIG },
           { provide: ConvertHrefToRouterService, useValue: convertHrefToRouterService },
-          { provide: RpxTranslationService, useValue: createSpyObj('RpxTranslationService', ['translate']) },
+          { provide: RpxTranslationService, useValue: rpxTranslationService },
           DeleteOrCancelDialogComponent
         ],
         teardown: { destroyAfterEach: false }
@@ -1543,8 +1542,14 @@ describe('CaseFullAccessViewComponent - appendedTabs', () => {
     comp.ngOnInit();
 
     expect(comp.hasActiveCaseFlags).toHaveBeenCalledTimes(1);
+    expect(rpxTranslationService.getTranslation$).toHaveBeenCalledWith('There is 1 active flag on this case.');
+    expect(rpxTranslationService.getTranslation$).toHaveBeenCalledWith('Important');
+    expect(rpxTranslationService.getTranslation$).toHaveBeenCalledWith('View case flags');
+    expect(rpxTranslationService.getTranslation$).toHaveBeenCalledWith('Case flags');
     const bannerElement = d.nativeElement.querySelector('.govuk-notification-banner');
-    expect(bannerElement.textContent).toContain('There is 1 active flag on this case');
+    // Expect the banner to contain the translated text
+    expect(bannerElement.textContent).toContain('Welsh: There is 1 active flag on this case.');
+    expect(bannerElement.textContent).toContain('Gweld fflagiau\'r achos');
     expect(comp.activeCaseFlags).toBe(true);
   });
 
@@ -1578,13 +1583,24 @@ describe('CaseFullAccessViewComponent - appendedTabs', () => {
     f.detectChanges();
 
     expect(comp.hasActiveCaseFlags).toHaveBeenCalledTimes(1);
+    expect(rpxTranslationService.getTranslationWithReplacements$).toHaveBeenCalledWith(
+      `There are %activeCaseFlags% active flags on this case.`, { activeCaseFlags: '2' });
+    expect(rpxTranslationService.getTranslation$).toHaveBeenCalledWith('Important');
+    expect(rpxTranslationService.getTranslation$).toHaveBeenCalledWith('View case flags');
+    expect(rpxTranslationService.getTranslation$).toHaveBeenCalledWith('Case flags');
     const bannerElement = d.nativeElement.querySelector('.govuk-notification-banner');
-    expect(bannerElement.textContent).toContain('There are 2 active flags on this case');
+    // Expect the banner to contain the translated text
+    expect(bannerElement.textContent).toContain('Welsh: There are 2 active flags on this case.');
+    expect(bannerElement.textContent).toContain('Gweld fflagiau\'r achos');
     expect(comp.activeCaseFlags).toBe(true);
   });
 
   it('should select the tab containing Case Flags data when the "View case flags" link in the banner message is clicked', () => {
     const viewCaseFlagsLink = d.nativeElement.querySelector('.govuk-notification-banner__link');
+    // The (normally translated) tab label needs to match the triggerOutputEventText (which is the translated tab label text)
+    // emitted by the NotificationBannerComponent, so this needs to be simulated
+    const caseFlagsMatTab = comp.tabGroup._tabs.toArray().find((tab) => tab.textLabel === 'Case flags');
+    caseFlagsMatTab.textLabel = 'Fflagiau\'r achos';
     // Case Flags tab is expected to be the sixth tab (i.e. index 5)
     const caseFlagsTab = d.nativeElement.querySelector('.mat-tab-labels').children[5] as HTMLElement;
     expect(caseFlagsTab.getAttribute('aria-selected')).toEqual('false');
@@ -1627,10 +1643,10 @@ describe('CaseFullAccessViewComponent - ends with caseID', () => {
   let comp: CaseFullAccessViewComponent;
   let compFixture: ComponentFixture<CaseFullAccessViewComponent>;
   let debugElement: DebugElement;
-  let convertHrefToRouterService;
+  let convertHrefToRouterService: jasmine.SpyObj<ConvertHrefToRouterService>;
 
   beforeEach((() => {
-    convertHrefToRouterService = jasmine.createSpyObj('ConvertHrefToRouterService', ['getHrefMarkdownLinkContent', 'callAngularRouter']);
+    convertHrefToRouterService = createSpyObj('ConvertHrefToRouterService', ['getHrefMarkdownLinkContent', 'callAngularRouter']);
     convertHrefToRouterService.getHrefMarkdownLinkContent.and.returnValue(of('[Send a new direction](/case/IA/Asylum/1641014744613435/trigger/sendDirection)'));
     TestBed
       .configureTestingModule({
@@ -1717,7 +1733,10 @@ describe('CaseFullAccessViewComponent - ends with caseID', () => {
           FieldTypeSanitiser,
           PageValidationService,
           CaseFieldService,
-          { provide: RpxTranslationService, useValue: createSpyObj('RpxTranslationService', ['translate']) },
+          {
+            provide: RpxTranslationService,
+            useValue: createSpyObj('RpxTranslationService', ['getTranslation$', 'getTranslationWithReplacements$'])
+          }
         ],
         teardown: { destroyAfterEach: false }
       })
@@ -1750,7 +1769,8 @@ describe('CaseFullAccessViewComponent - Overview with prepended Tabs', () => {
   let caseViewerComponent: CaseFullAccessViewComponent;
   let componentFixture: ComponentFixture<CaseFullAccessViewComponent>;
   let debugElement: DebugElement;
-  let convertHrefToRouterService;
+  let convertHrefToRouterService: jasmine.SpyObj<ConvertHrefToRouterService>;
+  let rpxTranslationService: jasmine.SpyObj<RpxTranslationService>;
   let router: Router;
   const prependedTabsList = [
     {
@@ -1768,8 +1788,10 @@ describe('CaseFullAccessViewComponent - Overview with prepended Tabs', () => {
   ];
 
   beforeEach(waitForAsync(() => {
-    convertHrefToRouterService = jasmine.createSpyObj('ConvertHrefToRouterService', ['getHrefMarkdownLinkContent', 'callAngularRouter']);
+    convertHrefToRouterService = createSpyObj('ConvertHrefToRouterService', ['getHrefMarkdownLinkContent', 'callAngularRouter']);
     convertHrefToRouterService.getHrefMarkdownLinkContent.and.returnValue(of('/case/IA/Asylum/1641014744613435/trigger/sendDirection'));
+    rpxTranslationService = createSpyObj('RpxTranslationService', ['getTranslation$']);
+    rpxTranslationService.getTranslation$.withArgs('Hearings').and.returnValue(of('Gwrandawiadau'));
     navigationNotifierService = new NavigationNotifierService();
     spyOn(navigationNotifierService, 'announceNavigation').and.callThrough();
     mockLocation = createSpyObj('location', ['path']);
@@ -1846,7 +1868,7 @@ describe('CaseFullAccessViewComponent - Overview with prepended Tabs', () => {
           { provide: MatDialogRef, useValue: matDialogRef },
           { provide: MatDialogConfig, useValue: DIALOG_CONFIG },
           { provide: ConvertHrefToRouterService, useValue: convertHrefToRouterService },
-          { provide: RpxTranslationService, useValue: createSpyObj('RpxTranslationService', ['translate', 'getTranslation$']) },
+          { provide: RpxTranslationService, useValue: rpxTranslationService },
           DeleteOrCancelDialogComponent
         ],
         teardown: { destroyAfterEach: false }
@@ -2051,21 +2073,18 @@ describe('CaseFullAccessViewComponent - get default hrefMarkdownLinkContent', ()
   let caseViewerComponent: CaseFullAccessViewComponent;
   let componentFixture: ComponentFixture<CaseFullAccessViewComponent>;
   let debugElement: DebugElement;
-  let convertHrefToRouterService;
+  let convertHrefToRouterService: jasmine.SpyObj<ConvertHrefToRouterService>;
   let subscribeSpy: jasmine.Spy;
   let subscriptionMock: Subscription = new Subscription();
 
   beforeEach(waitForAsync(() => {
-    convertHrefToRouterService = jasmine.createSpyObj('ConvertHrefToRouterService', ['getHrefMarkdownLinkContent', 'callAngularRouter']);
+    convertHrefToRouterService = createSpyObj('ConvertHrefToRouterService', ['getHrefMarkdownLinkContent', 'callAngularRouter']);
     convertHrefToRouterService.getHrefMarkdownLinkContent.and.returnValue(of('Default'));
     mockLocation = createSpyObj('location', ['path']);
     mockLocation.path.and.returnValue('/cases/case-details/1620409659381330#caseNotes');
     subscribeSpy = spyOn(subscriptionMock, 'unsubscribe');
 
     alertService = createSpyObj('alertService', ['setPreserveAlerts', 'success', 'warning', 'clear']);
-    alertService.setPreserveAlerts.and.returnValue(of({}));
-    alertService.success.and.returnValue(of({}));
-    alertService.warning.and.returnValue(of({}));
 
     TestBed
       .configureTestingModule({
@@ -2138,7 +2157,7 @@ describe('CaseFullAccessViewComponent - get default hrefMarkdownLinkContent', ()
           { provide: MatDialogRef, useValue: matDialogRef },
           { provide: MatDialogConfig, useValue: DIALOG_CONFIG },
           { provide: ConvertHrefToRouterService, useValue: convertHrefToRouterService },
-          { provide: RpxTranslationService, useValue: createSpyObj('RpxTranslationService', ['translate']) },
+          { provide: RpxTranslationService, useValue: createSpyObj('RpxTranslationService', ['getTranslation$']) },
           DeleteOrCancelDialogComponent
         ],
         teardown: { destroyAfterEach: false }
@@ -2170,7 +2189,7 @@ describe('CaseFullAccessViewComponent - get default hrefMarkdownLinkContent', ()
   });
 
   it('should not call callAngularRouter() on initial (default) value', (done) => {
-    convertHrefToRouterService = jasmine.createSpyObj('ConvertHrefToRouterService', ['getHrefMarkdownLinkContent', 'callAngularRouter']);
+    convertHrefToRouterService = createSpyObj('ConvertHrefToRouterService', ['getHrefMarkdownLinkContent', 'callAngularRouter']);
     convertHrefToRouterService.getHrefMarkdownLinkContent.and.returnValue(of('Default'));
     componentFixture.detectChanges();
     convertHrefToRouterService.getHrefMarkdownLinkContent().subscribe((hrefMarkdownLinkContent: string) => {

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-viewer/case-review-specific-access-request/case-review-specific-access-request.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-viewer/case-review-specific-access-request/case-review-specific-access-request.component.spec.ts
@@ -86,7 +86,7 @@ describe('CaseSpecificAccessRequestComponent', () => {
         },
       },
     },
-  };
+  } as unknown as ActivatedRoute;
   const mockActivatedRoute = new MockActivatedRoute();
   const mockAppConfig = createSpyObj('AbstractAppConfig', [
     'getAccessManagementMode',

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-viewer/case-specific-access-request/case-specific-access-request.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/case-viewer/case-specific-access-request/case-specific-access-request.component.spec.ts
@@ -7,6 +7,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { RpxTranslationService } from 'rpx-xui-translation';
 import { of } from 'rxjs';
 import { AlertModule } from '../../../../components/banners/alert';
+import { RoleAssignmentResponse } from '../../../domain';
 import { MockRpxTranslatePipe } from '../../../test/mock-rpx-translate.pipe';
 import { CaseNotifier } from '../../case-editor';
 import { CasesService } from '../../case-editor/services/cases.service';
@@ -36,8 +37,12 @@ describe('CaseSpecificAccessRequestComponent', () => {
   let location: Location;
 
   beforeEach(waitForAsync(() => {
+    const roleAssignmentResponse: RoleAssignmentResponse = {
+      roleRequest: null,
+      requestedRoles: []
+    };
     casesService = createSpyObj<CasesService>('casesService', ['createSpecificAccessRequest']);
-    casesService.createSpecificAccessRequest.and.returnValue(of(true));
+    casesService.createSpecificAccessRequest.and.returnValue(of(roleAssignmentResponse));
     TestBed.configureTestingModule({
       declarations: [CaseSpecificAccessRequestComponent, ErrorMessageComponent, MockRpxTranslatePipe,
         StubComponent],

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-file-view/case-file-view-field.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/case-file-view/case-file-view-field.component.spec.ts
@@ -5,7 +5,7 @@ import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Observable, of, throwError } from 'rxjs';
 import { CaseField } from '../../../domain';
-import { DocumentTreeNode, DocumentTreeNodeType } from '../../../domain/case-file-view';
+import { CategoriesAndDocuments, DocumentTreeNode, DocumentTreeNodeType } from '../../../domain/case-file-view';
 import { CaseFileViewService, DocumentManagementService, LoadingService } from '../../../services';
 import { mockDocumentManagementService } from '../../../services/document-management/document-management.service.mock';
 import { SessionStorageService } from '../../../services/session/session-storage.service';
@@ -181,7 +181,12 @@ describe('CaseFileViewFieldComponent', () => {
       newCategory: 'newCategoryId'
     };
 
-    mockCaseFileViewService.updateDocumentCategory.and.returnValue(of({ response: true }));
+    const categoriesAndDocuments: CategoriesAndDocuments = {
+      case_version: 1,
+      categories: [],
+      uncategorised_documents: []
+    };
+    mockCaseFileViewService.updateDocumentCategory.and.returnValue(of(categoriesAndDocuments));
     component.reloadPage = () => {};
     spyOn(component, 'reloadPage').and.callThrough();
     spyOn(component, 'resetErrorMessages').and.callThrough();

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/linked-cases/components/link-cases/link-cases.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/linked-cases/components/link-cases/link-cases.component.spec.ts
@@ -81,7 +81,7 @@ describe('LinkCasesComponent', () => {
     linkCaseReasons,
     caseFieldValue: [],
     mapLookupIDToValueFromJurisdictions() {},
-    getCaseName() {}
+    getCaseName(): string { return 'Case name'; }
   };
 
   beforeEach(waitForAsync(() => {
@@ -133,7 +133,7 @@ describe('LinkCasesComponent', () => {
       }, state: { name: 'With FTA' }
     };
     casesService.getCaseViewV2.and.returnValue(of(caseInfo));
-    spyOn(linkedCasesService, 'getCaseName').and.returnValue(of('Case name missing'));
+    spyOn(linkedCasesService, 'getCaseName').and.returnValue('Case name missing');
     component.linkCaseForm.get('caseNumber').setValue('1231231231231231');
     const reasonOption = fixture.debugElement.query(By.css('input[value="Progressed as part of this lead case"]')).nativeElement;
     reasonOption.click();

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/linked-cases/components/linked-cases-table/linked-cases-to-table.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/linked-cases/components/linked-cases-table/linked-cases-to-table.component.spec.ts
@@ -44,7 +44,7 @@ describe('LinkCasesToTableComponent', () => {
     caseId: '1682374819203471',
     linkedCases: mocklinkedCases,
     getAllLinkedCaseInformation() { },
-    getCaseName() { },
+    getCaseName(): string { return 'Case Name'; },
     jurisdictionsResponse: [
       {
         id: 'SSCS',

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/linked-cases/write-linked-cases-field.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/linked-cases/write-linked-cases-field.component.spec.ts
@@ -185,7 +185,7 @@ describe('WriteLinkedCasesFieldComponent', () => {
     linkedCases,
     caseFieldValue: linkedCases,
     getAllLinkedCaseInformation() { },
-    getCaseName() { }
+    getCaseName(): string { return 'Case name'; }
   };
 
   const linkCaseReasons: LovRefDataByServiceModel = {
@@ -285,7 +285,7 @@ describe('WriteLinkedCasesFieldComponent', () => {
     fixture = TestBed.createComponent(WriteLinkedCasesFieldComponent);
     casesService.getCaseViewV2.and.returnValue(of(caseInfo));
     component = fixture.componentInstance;
-    spyOn(caseEditPageComponent, 'getCaseId').and.returnValue(of('1111222233334444'));
+    spyOn(caseEditPageComponent, 'getCaseId').and.returnValue('1111222233334444');
     spyOn(caseEditDataService, 'clearFormValidationErrors').and.callThrough();
     component.formGroup = FORM_GROUP;
     fixture.detectChanges();
@@ -298,7 +298,7 @@ describe('WriteLinkedCasesFieldComponent', () => {
   });
 
   it('should initialise get OrgService', () => {
-   spyOn(component, 'getLinkedCaseReasons').and.returnValue(of([]));
+    spyOn(component, 'getLinkedCaseReasons');
     component.getOrgService();
     expect(component.getLinkedCaseReasons).toHaveBeenCalled();
   });
@@ -330,7 +330,7 @@ describe('WriteLinkedCasesFieldComponent', () => {
 
   it('should validate linked cases state emitter when navigate to next page is true', () => {
     spyOn(component, 'proceedToNextPage');
-    spyOn(linkedCasesService, 'isLinkedCasesEventTrigger').and.returnValue(true);
+    linkedCasesService.isLinkedCasesEventTrigger = true;
     component.linkedCasesPage = LinkedCasesPages.BEFORE_YOU_START;
     const linkedCasesState: LinkedCasesState = {
       currentLinkedCasesPage: LinkedCasesPages.BEFORE_YOU_START,
@@ -343,12 +343,12 @@ describe('WriteLinkedCasesFieldComponent', () => {
 
   it('should validate linked cases state emitter when navigate to next page is false', () => {
     spyOn(component, 'proceedToNextPage');
-    spyOn(linkedCasesService, 'isLinkedCasesEventTrigger').and.returnValue(true);
+    linkedCasesService.isLinkedCasesEventTrigger = true;
     spyOn(caseEditDataService, 'addFormValidationError').and.callThrough();
     component.linkedCasesPage = LinkedCasesPages.BEFORE_YOU_START;
     const linkedCasesState: LinkedCasesState = {
       currentLinkedCasesPage: LinkedCasesPages.BEFORE_YOU_START,
-      errorMessages: [{ title: 'Error title', description: 'Error descriptiom' }],
+      errorMessages: [{ title: 'Error title', description: 'Error description' }],
       navigateToNextPage: false
     };
     component.onLinkedCasesStateEmitted(linkedCasesState);

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/query-management/components/query-write/query-write-date-input/query-write-date-input.component.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/query-management/components/query-write/query-write-date-input/query-write-date-input.component.spec.ts
@@ -53,7 +53,7 @@ describe('QueryWriteDateInputComponent', () => {
   describe('updateDate', () => {
     it('should invoke onChange and onTouched when updateDate is called with a valid date input', () => {
       // @ts-expect-error - private method
-      const onChangeSpy = spyOn(component, 'onChange');
+      spyOn(component, 'onChange');
       // @ts-expect-error - private method
       const onTouchedSpy = spyOn(component, 'onTouched');
       component.day = 7;
@@ -62,13 +62,13 @@ describe('QueryWriteDateInputComponent', () => {
 
       component.updateDate();
 
-      expect(onChangeSpy).toHaveBeenCalledWith(new Date(2023, 5, 7));
+      expect(component['onChange']).toHaveBeenCalledWith(new Date(2023, 5, 7));
       expect(onTouchedSpy).toHaveBeenCalled();
     });
 
     it('should invoke onChange with null when updateDate is called with an invalid date input', () => {
       // @ts-expect-error - private method
-      const onChangeSpy = spyOn(component, 'onChange');
+      spyOn(component, 'onChange');
       // @ts-expect-error - private method
       const onTouchedSpy = spyOn(component, 'onTouched');
       component.day = 35;
@@ -77,7 +77,7 @@ describe('QueryWriteDateInputComponent', () => {
 
       component.updateDate();
 
-      expect(onChangeSpy).toHaveBeenCalledWith(null);
+      expect(component['onChange']).toHaveBeenCalledWith(null);
       expect(onTouchedSpy).toHaveBeenCalled();
     });
   });

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/domain/work-allocation/task-response.model.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/domain/work-allocation/task-response.model.ts
@@ -1,5 +1,5 @@
 import { Task } from './Task';
 
-export interface TaskRespone {
+export interface TaskResponse {
   task: Task;
 }

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/services/alert/alert.service.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/services/alert/alert.service.ts
@@ -139,7 +139,7 @@ export class AlertService {
     return message;
   }
 
-  public setPreserveAlerts(preserve: boolean, urlInfo?: string[]) {
+  public setPreserveAlerts(preserve: boolean, urlInfo?: string[]): void {
     // if there is no url setting then just preserve the messages
     if (!urlInfo) {
       this.preserveAlerts = preserve;
@@ -175,7 +175,7 @@ export class AlertService {
   }
 
   // TODO: Remove
-  public push(msgObject) {
+  public push(msgObject): void {
     this.message = msgObject.message;
     this.level = msgObject.level;
 

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/services/http/http.service.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/services/http/http.service.spec.ts
@@ -114,7 +114,7 @@ describe('HttpService', () => {
 
       httpService.get(URL, options);
 
-      const headers = httpMock.get.calls.mostRecent().args[1].headers;
+      const headers = httpMock.get.calls.mostRecent().args[1].headers as HttpHeaders;
       expect(headers.get('Content-Type')).toEqual(CONTENT_TYPE_HEADER_VALUE);
       expect(headers.get('Accept')).toEqual(ACCEPT_HEADER_VALUE);
     }));
@@ -140,7 +140,7 @@ describe('HttpService', () => {
 
       httpService.get(URL, options);
 
-      const headers = httpMock.get.calls.mostRecent().args[1].headers;
+      const headers = httpMock.get.calls.mostRecent().args[1].headers as HttpHeaders;
       expect(headers.get('Content-Type')).toEqual('application/json');
       expect(headers.get('Accept')).toEqual('application/json');
     }));
@@ -220,7 +220,7 @@ describe('HttpService', () => {
 
       httpService.post(URL, BODY, options);
 
-      const headers = httpMock.post.calls.mostRecent().args[2].headers;
+      const headers = httpMock.post.calls.mostRecent().args[2].headers as HttpHeaders;
       expect(headers.get('Content-Type')).toEqual('application/json');
       expect(headers.get('Accept')).toEqual('application/json');
     }));
@@ -284,7 +284,7 @@ describe('HttpService', () => {
 
       httpService.put(URL, BODY, options);
 
-      const headers = httpMock.put.calls.mostRecent().args[2].headers;
+      const headers = httpMock.put.calls.mostRecent().args[2].headers as HttpHeaders;
       expect(headers.get('Content-Type')).toEqual('application/json');
       expect(headers.get('Accept')).toEqual('application/json');
     }));
@@ -348,7 +348,7 @@ describe('HttpService', () => {
 
       httpService.delete(URL, options);
 
-      const headers = httpMock.delete.calls.mostRecent().args[1].headers;
+      const headers = httpMock.delete.calls.mostRecent().args[1].headers as HttpHeaders;
       expect(headers.get('Content-Type')).toEqual('application/json');
       expect(headers.get('Accept')).toEqual('application/json');
     }));

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/services/jurisdiction/jurisdiction.service.spec.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/services/jurisdiction/jurisdiction.service.spec.ts
@@ -7,7 +7,7 @@ describe('JurisdictionService', () => {
   describe('searchJudicialUsers', () => {
     it('should make a http post', () => {
       const mockHttpService = {
-        post: () => { }
+        post: (_endpoint: string, _request: object) => { }
       };
 
       service = new JurisdictionService(mockHttpService as unknown as HttpService);
@@ -21,7 +21,7 @@ describe('JurisdictionService', () => {
   describe('searchJudicialUsersByPersonalCodes', () => {
     it('should make a http post', () => {
       const mockHttpService = {
-        post: () => { }
+        post: (_endpoint: string, _request: object) => { }
       };
       const result = ['example'];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3300,7 +3300,7 @@ __metadata:
     "@storybook/manager-webpack4": ^6.5.10
     "@storybook/preset-scss": ^1.0.3
     "@storybook/testing-library": ^0.0.13
-    "@types/jasmine": ~2.8.0
+    "@types/jasmine": ~5.1.0
     "@types/jasminewd2": ^2.0.3
     "@types/node": ^18.17.0
     "@types/pegjs": ^0.10.0
@@ -6387,17 +6387,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jasmine@npm:*":
+"@types/jasmine@npm:*, @types/jasmine@npm:~5.1.0":
   version: 5.1.4
   resolution: "@types/jasmine@npm:5.1.4"
   checksum: 1b2048d988077aee747a72fab31f4e0820f928c25e886ab91aa5a1ee2d4277655c22f81feed5d7b3b15cc61542878568a24b2381457eb21dfc84250c693f980a
-  languageName: node
-  linkType: hard
-
-"@types/jasmine@npm:~2.8.0":
-  version: 2.8.23
-  resolution: "@types/jasmine@npm:2.8.23"
-  checksum: b9538cfa84dca23df14e6355dda1d0b2e63c6aea5d0f62e5e8d03e4c19d2854d9d65780e7d4fe6d755e95a10dcb22ceae997a343473f7f30559c1075f7cf0d0b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
EUI-9164
EUI-9129
EUI-9164
[CSFD-23](https://tools.hmcts.net/jira/browse/CSFD-23)

### Change description ###
EUI-9164:  Fix non-translation of "Event summary" label and hint text, and "Event description" label, displayed on the "Check your answers" page.
EUI-9129: Fix conditional display of "Event summary" and "Event description" fields to be dependent solely on the value of `show_event_notes` as set for a given case event via a CCD Definition file.
EUI-9146: Fix "View case flags" link in banner to work when the Case Flags tab label is translated to Welsh.
Also, `@types/jasmine` version upgraded to `5.1.0`, _which might break other unit tests due to stricter type-checking_.
CSFD-23: Added the Translation pipe to the case history labels

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
