### PR TITLE
EXUI-3322. Fix issue where post-interpolation strings are sent for translation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "7.2.25",
+  "version": "7.2.25-welsh-interp",
   "engines": {
     "node": ">=18.19.0"
   },

--- a/projects/ccd-case-ui-toolkit/package.json
+++ b/projects/ccd-case-ui-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/ccd-case-ui-toolkit",
-  "version": "7.2.25",
+  "version": "7.2.25-welsh-interp",
   "engines": {
     "node": ">=18.19.0"
   },

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/organisation/read-organisation-field-raw.component.html
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/organisation/read-organisation-field-raw.component.html
@@ -5,15 +5,15 @@
         <th style="display: none;"></th>
         <td>
           <table class="complex-field-table" *ngIf="(selectedOrg$ | async) as selectedOrg"
-                 [attr.aria-describedby]="'complex selected organisation field table' | rpxTranslate">
+                 [attr.aria-describedby]="'selected organisation field table'">
             <tr class="complex-panel-compound-field">
               <th style="display: none;"></th>
-              <td class="label-width-small"><span class="text-16">{{'Name:' | rpxTranslate}}</span></td>
+              <td class="label-width-small"><span class="text-16">{{'Name:'}}</span></td>
               <td><span class="text-16">{{selectedOrg.name}}</span></td>
             </tr>
             <tr class="complex-panel-compound-field">
               <th style="display: none;"></th>
-              <td class="label-width-small"><span class="text-16">{{'Address:' | rpxTranslate}}</span></td>
+              <td class="label-width-small"><span class="text-16">{{'Address:'}}</span></td>
               <td>
                 <ccd-markdown [content]="selectedOrg.address"></ccd-markdown>
               </td>

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/organisation/read-organisation-field-table.component.html
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/organisation/read-organisation-field-table.component.html
@@ -9,15 +9,15 @@
         </th>
         <td>
           <table class="complex-field-table" *ngIf="(selectedOrg$ | async) as selectedOrg"
-                 [attr.aria-describedby]="'complex selected organisation field table' | rpxTranslate">
+                 [attr.aria-describedby]="'selected organisation field table'">
             <tr class="complex-panel-compound-field">
               <th style="display: none;"></th>
-              <td class="label-width-medium"><span class="text-16">{{'Name:' | rpxTranslate}}</span></td>
+              <td class="label-width-medium"><span class="text-16">{{'Name:'}}</span></td>
               <td><span class="text-16">{{selectedOrg.name}}</span></td>
             </tr>
             <tr class="complex-panel-compound-field">
               <th style="display: none;"></th>
-              <td class="label-width-medium"><span class="text-16">{{'Address:' | rpxTranslate}}</span></td>
+              <td class="label-width-medium"><span class="text-16">{{'Address:'}}</span></td>
               <td>
                 <ccd-markdown [content]="selectedOrg.address"></ccd-markdown>
               </td>

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/utils/field-label.pipe.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/utils/field-label.pipe.ts
@@ -10,15 +10,24 @@ export class FieldLabelPipe implements PipeTransform {
 
   constructor(
     private readonly rpxTranslationPipe: RpxTranslatePipe
-  ) {}
-  
-  public transform (field: CaseField): string {
+  ) {
+  }
+
+  public transform(field: CaseField): string {
     if (!field || !field.label) {
       return '';
     } else if (!field.display_context) {
-      return this.rpxTranslationPipe.transform(field.label);
+      this.getTranslatedLabel(field);
     }
-    return this.rpxTranslationPipe.transform(field.label) + (field.display_context.toUpperCase() === 'OPTIONAL' ? 
+    return this.getTranslatedLabel(field) + (field.display_context.toUpperCase() === 'OPTIONAL' ?
       ' (' + this.rpxTranslationPipe.transform('Optional') + ')' : '');
+  }
+
+  private getTranslatedLabel(field: CaseField): string {
+    if (!field.isTranslated) {
+      return this.rpxTranslationPipe.transform(field.label);
+    } else {
+      return field.label;
+    }
   }
 }

--- a/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/utils/field-label.pipe.ts
+++ b/projects/ccd-case-ui-toolkit/src/lib/shared/components/palette/utils/field-label.pipe.ts
@@ -17,7 +17,7 @@ export class FieldLabelPipe implements PipeTransform {
     if (!field || !field.label) {
       return '';
     } else if (!field.display_context) {
-      this.getTranslatedLabel(field);
+      return this.getTranslatedLabel(field);
     }
     return this.getTranslatedLabel(field) + (field.display_context.toUpperCase() === 'OPTIONAL' ?
       ' (' + this.rpxTranslationPipe.transform('Optional') + ')' : '');


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/EXUI-3322

### Change description ###

The Field label pipe does translation of labels. We now only do this if the field is marked as not having already been translated

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
